### PR TITLE
feat(web): improve page density and readability

### DIFF
--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -25,7 +25,7 @@ export const MODAL_PANEL_CLASS = 'ui-modal-panel animate-slide-up';
 
 export const INPUT_CLASS = cn(
   'ui-input',
-  'text-sm',
+  'text-base',
   'bg-white/90 dark:bg-slate-700/80',
   'border-slate-200 dark:border-slate-600',
   'placeholder:text-slate-400 dark:placeholder:text-slate-500',
@@ -33,14 +33,14 @@ export const INPUT_CLASS = cn(
 
 export const SELECT_CLASS = cn(
   'ui-select',
-  'text-sm',
+  'text-base',
   'bg-white/90 dark:bg-slate-700/80',
   'border-slate-200 dark:border-slate-600',
 );
 
 export const TEXTAREA_CLASS = cn(
   'ui-textarea',
-  'text-sm',
+  'text-base',
   'bg-white/90 dark:bg-slate-700/80',
   'border-slate-200 dark:border-slate-600',
   'placeholder:text-slate-400 dark:placeholder:text-slate-500',
@@ -71,7 +71,7 @@ const badgeStyles = {
 };
 
 export function Badge({ variant, children, size = 'sm' }: BadgeProps) {
-  const sizeClass = size === 'sm' ? 'px-2 py-0.5 text-[11px]' : 'px-2.5 py-1 text-xs';
+  const sizeClass = size === 'sm' ? 'px-2.5 py-0.5 text-xs' : 'px-3 py-1 text-sm';
   return (
     <span
       className={cn(
@@ -182,9 +182,9 @@ const buttonVariants = {
 };
 
 const buttonSizes = {
-  sm: 'h-8 px-3 text-sm',
-  md: 'h-9 px-4 text-sm',
-  lg: 'h-10 px-5 text-base',
+  sm: 'h-9 px-3.5 text-sm',
+  md: 'h-10 px-4 text-base',
+  lg: 'h-11 px-5 text-base',
 };
 
 export function Button({
@@ -276,7 +276,7 @@ export function ThemeToggle() {
     <button
       onClick={cycleTheme}
       className={cn(
-        'flex h-9 w-9 items-center justify-center rounded-lg',
+        'flex h-10 w-10 items-center justify-center rounded-lg',
         'text-slate-500 hover:bg-slate-100 hover:text-slate-900',
         'dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100',
         'transition-colors',

--- a/apps/web/src/pages/AdminAnalytics.tsx
+++ b/apps/web/src/pages/AdminAnalytics.tsx
@@ -55,7 +55,7 @@ function RangeTabs<T extends string>({
           key={value}
           onClick={() => onChange(value)}
           className={cn(
-            'rounded-md px-2.5 py-1 text-xs font-medium transition-colors sm:px-3',
+            'rounded-md px-2.5 py-1.5 text-sm font-medium transition-colors sm:px-3',
             current === value
               ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
               : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
@@ -79,12 +79,12 @@ function StatTile({
 }) {
   return (
     <div className="rounded-xl border border-slate-200/80 bg-white/80 p-4 dark:border-slate-700/80 dark:bg-slate-800/50">
-      <div className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <div className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
         {label}
       </div>
       <div
         className={cn(
-          'mt-2 text-xl font-semibold tabular-nums',
+          'mt-2 text-2xl font-semibold tabular-nums',
           tone === 'danger'
             ? 'text-red-600 dark:text-red-400'
             : 'text-slate-900 dark:text-slate-100',
@@ -179,8 +179,8 @@ export function AdminAnalytics() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
       <header className="bg-white dark:bg-slate-800 shadow-sm dark:shadow-none dark:border-b dark:border-slate-700">
-        <div className="max-w-6xl mx-auto px-4 py-3 sm:py-4 flex justify-between items-center">
-          <h1 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-slate-100">
+        <div className="mx-auto max-w-[92rem] px-4 py-3 sm:px-6 sm:py-4 lg:px-8 flex justify-between items-center">
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-slate-100">
             {settings?.site_title ? `${settings.site_title} · Analytics` : 'Analytics'}
           </h1>
 
@@ -188,7 +188,7 @@ export function AdminAnalytics() {
             <ThemeToggle />
             <Link
               to={ADMIN_PATH}
-              className="flex items-center justify-center h-9 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors px-3 rounded-lg"
+              className="flex items-center justify-center h-10 text-base text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors px-3 rounded-lg"
             >
               <svg className="w-5 h-5 sm:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path
@@ -202,7 +202,7 @@ export function AdminAnalytics() {
             </Link>
             <Link
               to="/"
-              className="flex items-center justify-center h-9 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors px-3 rounded-lg"
+              className="flex items-center justify-center h-10 text-base text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors px-3 rounded-lg"
             >
               <svg className="w-5 h-5 sm:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path
@@ -216,7 +216,7 @@ export function AdminAnalytics() {
             </Link>
             <button
               onClick={logout}
-              className="flex items-center justify-center h-9 text-sm text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors px-3 rounded-lg"
+              className="flex items-center justify-center h-10 text-base text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors px-3 rounded-lg"
             >
               <svg className="w-5 h-5 sm:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path
@@ -232,11 +232,11 @@ export function AdminAnalytics() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-6xl space-y-6 px-4 py-6 sm:px-6 sm:py-8">
+      <main className="mx-auto max-w-[92rem] space-y-6 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
         <Card className="p-5 sm:p-6">
           <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100 sm:text-lg">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 sm:text-xl">
                 Overview
               </h2>
               <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
@@ -298,7 +298,7 @@ export function AdminAnalytics() {
           <div className="mb-5 flex flex-col gap-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100 sm:text-lg">
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 sm:text-xl">
                   Monitor Analytics
                 </h2>
                 <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">

--- a/apps/web/src/pages/AdminDashboard.tsx
+++ b/apps/web/src/pages/AdminDashboard.tsx
@@ -97,7 +97,7 @@ type ChannelTestErrorState = {
 };
 
 const navActionClass =
-  'flex items-center justify-center h-9 rounded-lg px-3 text-sm transition-colors';
+  'flex items-center justify-center h-10 rounded-lg px-3 text-base transition-colors';
 
 const tabContainerClass =
   'flex gap-1 rounded-xl border border-slate-200/70 bg-white/80 p-1 shadow-sm dark:border-slate-700 dark:bg-slate-800/80';
@@ -451,8 +451,8 @@ export function AdminDashboard() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
       <header className="bg-white dark:bg-slate-800 border-b border-slate-100 dark:border-slate-700">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex justify-between items-center">
-          <h1 className="text-lg sm:text-xl font-bold text-slate-900 dark:text-slate-100">Admin Dashboard</h1>
+        <div className="mx-auto max-w-[92rem] px-4 py-3 sm:px-6 sm:py-4 lg:px-8 flex justify-between items-center">
+          <h1 className="text-xl sm:text-2xl font-bold text-slate-900 dark:text-slate-100">Admin Dashboard</h1>
           <div className="flex items-center gap-1">
             <ThemeToggle />
             <Link
@@ -501,7 +501,7 @@ export function AdminDashboard() {
         </div>
       </header>
 
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 sm:pt-6">
+      <div className="mx-auto max-w-[92rem] px-4 pt-4 sm:px-6 sm:pt-6 lg:px-8">
         <div className={`${tabContainerClass} overflow-x-auto scrollbar-hide`}>
           {tabs.map((t) => (
             <button
@@ -510,7 +510,7 @@ export function AdminDashboard() {
               aria-label={t.label}
               title={t.label}
               className={cn(
-                'flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-all sm:gap-2 sm:px-4 whitespace-nowrap',
+                'flex items-center gap-1.5 rounded-lg px-3 py-2 text-base font-medium transition-all sm:gap-2 sm:px-4 whitespace-nowrap',
                 tab === t.key
                   ? 'bg-slate-900 text-white shadow-sm dark:bg-slate-100 dark:text-slate-900'
                   : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200',
@@ -525,11 +525,11 @@ export function AdminDashboard() {
         </div>
       </div>
 
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-6">
+      <main className="mx-auto max-w-[92rem] px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
         {tab === 'monitors' && (
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Monitors</h2>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Monitors</h2>
               <Button onClick={() => setModal({ type: 'create-monitor' })}>Add Monitor</Button>
             </div>
             {testingMonitorId !== null && (
@@ -722,7 +722,7 @@ export function AdminDashboard() {
         {tab === 'notifications' && (
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Notification Channels</h2>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Notification Channels</h2>
               <Button onClick={() => setModal({ type: 'create-channel' })}>Add Channel</Button>
             </div>
             {testingChannelId !== null && (
@@ -855,7 +855,7 @@ export function AdminDashboard() {
         {tab === 'settings' && (
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Settings</h2>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Settings</h2>
             </div>
 
             <Card className="p-4 sm:p-5">
@@ -1158,7 +1158,7 @@ export function AdminDashboard() {
         {tab === 'incidents' && (
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Incidents</h2>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Incidents</h2>
               <Button onClick={() => setModal({ type: 'create-incident' })}>Create Incident</Button>
             </div>
             {incidentsQuery.isLoading ? (
@@ -1230,7 +1230,7 @@ export function AdminDashboard() {
         {tab === 'maintenance' && (
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Maintenance Windows</h2>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Maintenance Windows</h2>
               <Button onClick={() => setModal({ type: 'create-maintenance' })}>Create Window</Button>
             </div>
             {maintenanceQuery.isLoading ? (
@@ -1295,7 +1295,7 @@ export function AdminDashboard() {
       {modal.type !== 'none' && (
         <div className={MODAL_OVERLAY_CLASS}>
           <div className={`${MODAL_PANEL_CLASS} sm:max-w-md p-5 sm:p-6`}>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-5">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-5">
               {modal.type === 'create-monitor' && 'Create Monitor'}
               {modal.type === 'edit-monitor' && 'Edit Monitor'}
               {modal.type === 'create-channel' && 'Create Channel'}

--- a/apps/web/src/pages/IncidentHistoryPage.tsx
+++ b/apps/web/src/pages/IncidentHistoryPage.tsx
@@ -184,7 +184,7 @@ export function IncidentHistoryPage() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
       <header className="bg-white dark:bg-slate-800 border-b border-slate-100 dark:border-slate-700">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex justify-between items-center">
+        <div className="mx-auto max-w-[88rem] px-4 py-3 sm:px-6 sm:py-4 lg:px-8 flex justify-between items-center">
           <div className="flex items-center gap-3">
             <Link
               to="/"
@@ -195,13 +195,13 @@ export function IncidentHistoryPage() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
             </Link>
-            <h1 className="text-lg sm:text-xl font-bold text-slate-900 dark:text-slate-100">Incident History</h1>
+            <h1 className="text-xl sm:text-2xl font-bold text-slate-900 dark:text-slate-100">Incident History</h1>
           </div>
           <ThemeToggle />
         </div>
       </header>
 
-      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+      <main className="mx-auto max-w-[88rem] px-4 py-6 sm:px-6 sm:py-10 lg:px-8">
         {isInitialLoading ? (
           <div className="space-y-3">
             {Array.from({ length: 3 }).map((_, idx) => (

--- a/apps/web/src/pages/MaintenanceHistoryPage.tsx
+++ b/apps/web/src/pages/MaintenanceHistoryPage.tsx
@@ -55,7 +55,7 @@ export function MaintenanceHistoryPage() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
       <header className="bg-white dark:bg-slate-800 border-b border-slate-100 dark:border-slate-700">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex justify-between items-center">
+        <div className="mx-auto max-w-[88rem] px-4 py-3 sm:px-6 sm:py-4 lg:px-8 flex justify-between items-center">
           <div className="flex items-center gap-3">
             <Link
               to="/"
@@ -66,13 +66,13 @@ export function MaintenanceHistoryPage() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
             </Link>
-            <h1 className="text-lg sm:text-xl font-bold text-slate-900 dark:text-slate-100">Maintenance History</h1>
+            <h1 className="text-xl sm:text-2xl font-bold text-slate-900 dark:text-slate-100">Maintenance History</h1>
           </div>
           <ThemeToggle />
         </div>
       </header>
 
-      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+      <main className="mx-auto max-w-[88rem] px-4 py-6 sm:px-6 sm:py-10 lg:px-8">
         {isInitialLoading ? (
           <div className="space-y-3">
             {Array.from({ length: 3 }).map((_, idx) => (

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -154,15 +154,15 @@ function MonitorCard({ monitor, onSelect, onDayClick, timeZone }: { monitor: Pub
     : 'Never checked';
 
   return (
-    <Card hover onClick={onSelect} className="p-3.5 sm:p-4">
+    <Card hover onClick={onSelect} className="p-4 sm:p-5">
       <div className="mb-2.5 flex items-start justify-between gap-2">
         <div className="min-w-0 flex items-center gap-2.5">
           <StatusDot status={monitor.status} pulse={monitor.status === 'down'} size="sm" />
           <div className="min-w-0">
-            <h3 className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100 sm:text-[15px]">
+            <h3 className="truncate text-base font-semibold text-slate-900 dark:text-slate-100 sm:text-lg">
               {monitor.name}
             </h3>
-            <span className="text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               {monitor.type}
             </span>
           </div>
@@ -170,11 +170,11 @@ function MonitorCard({ monitor, onSelect, onDayClick, timeZone }: { monitor: Pub
         <Badge variant={getStatusBadgeVariant(monitor.status)}>{monitor.status}</Badge>
       </div>
 
-      <div className="mb-1.5 flex items-center justify-between gap-2 text-[11px] text-slate-500 dark:text-slate-400">
+      <div className="mb-1.5 flex items-center justify-between gap-2 text-xs text-slate-500 dark:text-slate-400">
         <span className="uppercase tracking-wide">Availability (30d)</span>
         {uptime30d ? (
           <span
-            className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-medium tabular-nums ${getAvailabilityPillClasses(uptime30d.uptime_pct, monitor.uptime_rating_level)}`}
+            className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium tabular-nums ${getAvailabilityPillClasses(uptime30d.uptime_pct, monitor.uptime_rating_level)}`}
             title="Average availability over the last 30 days"
           >
             <span
@@ -197,7 +197,7 @@ function MonitorCard({ monitor, onSelect, onDayClick, timeZone }: { monitor: Pub
       />
 
       <div className="mt-2.5">
-        <div className="mb-1.5 flex items-center justify-between text-[11px] text-slate-500 dark:text-slate-400">
+        <div className="mb-1.5 flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
           <span className="uppercase tracking-wide">Heartbeat</span>
           <span>Last {HEARTBEAT_BARS} checks</span>
         </div>
@@ -208,7 +208,7 @@ function MonitorCard({ monitor, onSelect, onDayClick, timeZone }: { monitor: Pub
         />
       </div>
 
-      <div className="mt-2.5 flex items-center justify-between gap-2 text-[11px] text-slate-500 dark:text-slate-400">
+      <div className="mt-2.5 flex items-center justify-between gap-2 text-xs text-slate-500 dark:text-slate-400">
         <span className="tabular-nums">{monitor.last_latency_ms !== null ? `${monitor.last_latency_ms}ms` : '-'}</span>
         <span className="truncate text-slate-400 dark:text-slate-500">{checkedAt}</span>
       </div>
@@ -432,20 +432,20 @@ function StatusPageSkeleton() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
       <header className="sticky top-0 z-20 border-b border-slate-200/70 bg-white/95 backdrop-blur dark:border-slate-700/80 dark:bg-slate-800/95">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex justify-between items-center">
+        <div className="mx-auto max-w-[88rem] px-4 py-3 sm:px-6 sm:py-4 lg:px-8 flex justify-between items-center">
           <div className="ui-skeleton h-6 w-28 rounded" />
           <div className="ui-skeleton h-8 w-20 rounded-full" />
         </div>
       </header>
 
-      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
+      <main className="mx-auto max-w-[88rem] px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
         <div className="ui-skeleton h-20 sm:h-24 rounded-2xl mb-8" />
 
         <section>
           <div className="h-6 w-24 bg-slate-200 dark:bg-slate-700 rounded mb-4" />
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {Array.from({ length: 6 }).map((_, idx) => (
-              <Card key={idx} className="p-3.5 sm:p-4">
+              <Card key={idx} className="p-4 sm:p-5">
                 <div className="mb-2.5 flex items-start justify-between">
                   <div className="flex min-w-0 items-center gap-2.5">
                     <div className="h-3 w-3 rounded-full bg-slate-200 dark:bg-slate-700" />
@@ -565,11 +565,11 @@ export function StatusPage() {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
       {/* Header */}
       <header className="sticky top-0 z-20 border-b border-slate-200/70 bg-white/95 backdrop-blur dark:border-slate-700/80 dark:bg-slate-800/95">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex justify-between items-center">
+        <div className="mx-auto max-w-[88rem] px-4 py-3 sm:px-6 sm:py-4 lg:px-8 flex justify-between items-center">
           <Link to="/" className="flex flex-col justify-center min-w-0 min-h-9">
-            <span className="text-lg sm:text-xl font-bold leading-tight text-slate-900 dark:text-slate-100 truncate">{siteTitle}</span>
+            <span className="text-xl sm:text-2xl font-bold leading-tight text-slate-900 dark:text-slate-100 truncate">{siteTitle}</span>
             {data.site_description ? (
-              <span className="mt-0.5 text-xs sm:text-sm leading-tight text-slate-500 dark:text-slate-400 truncate">{data.site_description}</span>
+              <span className="mt-0.5 text-sm leading-tight text-slate-500 dark:text-slate-400 truncate">{data.site_description}</span>
             ) : null}
           </Link>
           <div className="flex items-center gap-1">
@@ -580,28 +580,28 @@ export function StatusPage() {
 
       {/* Status Banner */}
       <div className={`bg-gradient-to-r ${bannerConfig.bg} text-white`}>
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12 text-center">
-          <div className="inline-flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-white/20 text-xl sm:text-2xl mb-3 sm:mb-4">
+        <div className="mx-auto max-w-[88rem] px-4 py-10 sm:px-6 sm:py-14 lg:px-8 text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 rounded-full bg-white/20 text-2xl sm:text-3xl mb-3 sm:mb-4">
             {bannerConfig.icon}
           </div>
-          <h2 className="text-xl sm:text-2xl font-bold mb-2">{bannerConfig.text}</h2>
+          <h2 className="text-2xl sm:text-3xl font-bold mb-2">{bannerConfig.text}</h2>
           {data.banner.source === 'incident' && data.banner.incident && (
-            <p className="text-white/80 text-sm px-4">Incident: {data.banner.incident.title}</p>
+            <p className="text-white/80 text-base px-4">Incident: {data.banner.incident.title}</p>
           )}
           {data.banner.source === 'maintenance' && data.banner.maintenance_window && (
-            <p className="text-white/80 text-sm px-4">Maintenance: {data.banner.maintenance_window.title}</p>
+            <p className="text-white/80 text-base px-4">Maintenance: {data.banner.maintenance_window.title}</p>
           )}
-          <p className="text-white/60 text-xs mt-3">
+          <p className="text-white/60 text-sm mt-3">
             Last updated: {formatDateTime(data.generated_at, timeZone)}
           </p>
         </div>
       </div>
 
-      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+      <main className="mx-auto max-w-[88rem] px-4 py-6 sm:px-6 sm:py-10 lg:px-8">
         {/* Maintenance Windows */}
         {(data.maintenance_windows.active.length > 0 || data.maintenance_windows.upcoming.length > 0) && (
           <section className="mb-10">
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-2">
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-2">
               <svg
                 className="w-5 h-5 text-blue-500 dark:text-blue-400"
                 fill="none"
@@ -675,7 +675,7 @@ export function StatusPage() {
         {/* Active Incidents */}
         {activeIncidents.length > 0 && (
           <section className="mb-10">
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-2">
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4 flex items-center gap-2">
               <svg
                 className="w-5 h-5 text-amber-500 dark:text-amber-400"
                 fill="none"
@@ -701,8 +701,8 @@ export function StatusPage() {
 
         {/* Monitors */}
         <section>
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">Services</h3>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4">Services</h3>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {data.monitors.map((monitor) => (
               <MonitorCard
                 key={monitor.id}
@@ -723,10 +723,10 @@ export function StatusPage() {
         <section className="mt-12 pt-8 border-t border-slate-100 dark:border-slate-800 space-y-10">
           <div>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Incident History</h3>
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Incident History</h3>
               <Link
                 to="/history/incidents"
-                className="text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200"
+                className="text-base text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200"
               >
                 View more
               </Link>
@@ -753,10 +753,10 @@ export function StatusPage() {
 
           <div>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Maintenance History</h3>
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Maintenance History</h3>
               <Link
                 to="/history/maintenance"
-                className="text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200"
+                className="text-base text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200"
               >
                 View more
               </Link>
@@ -793,7 +793,7 @@ export function StatusPage() {
 
       {/* Footer */}
       <footer className="border-t border-slate-100 dark:border-slate-800 bg-white dark:bg-slate-800">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-4 sm:py-6 text-center text-sm text-slate-400 dark:text-slate-500">
+        <div className="mx-auto max-w-[88rem] px-4 py-4 text-center text-base text-slate-400 dark:text-slate-500 sm:px-6 sm:py-6 lg:px-8">
           Powered by {siteTitle}
         </div>
       </footer>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -70,6 +70,16 @@
   --overlay-bg: rgba(2, 6, 23, 0.76);
 }
 
+html {
+  font-size: 16px;
+}
+
+@media (min-width: 1024px) {
+  html {
+    font-size: 17px;
+  }
+}
+
 html,
 body,
 #root {
@@ -214,8 +224,8 @@ a {
   border: 1px solid var(--color-input-border);
   background: var(--color-input-bg);
   color: var(--color-text-primary);
-  padding: 0.625rem 0.75rem;
-  font-size: 0.875rem;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.9375rem;
   transition: border-color 0.16s ease, box-shadow 0.16s ease, background-color 0.16s ease;
 }
 
@@ -241,20 +251,20 @@ a {
 .ui-label {
   display: block;
   margin-bottom: 0.375rem;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--color-text-secondary);
 }
 
 .ui-help {
   margin-top: 0.375rem;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   color: var(--color-text-muted);
 }
 
 .ui-error {
   margin-top: 0.375rem;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   color: #dc2626;
 }
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
 
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd


### PR DESCRIPTION
## What\n- increase content width across status/admin/history pages to reduce excessive whitespace\n- scale up key typography and controls (headers, tabs, buttons, badges, form inputs)\n- tighten monitor card density while preserving mobile responsiveness\n\n## Why\n- current UI feels sparse on larger screens and text appears undersized\n- improve information density and readability without changing behavior\n\n## Validation\n- pnpm -r lint\n- pnpm -r typecheck\n- pnpm -r test