### PR TITLE
feat: improve local test bootstrap and worker coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,10 @@ Typical settings:
 
 ## Local development
 
-See `LOCAL-TESTING.md`.
+One-command local bootstrap + start:
+
+```bash
+pnpm dev
+```
+
+See `LOCAL-TESTING.md` for full workflow.

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,7 +7,12 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "lint": "pnpm -w exec eslint --config eslint.config.mjs apps/worker",
-    "typecheck": "pnpm -w exec tsc -p apps/worker/tsconfig.json --noEmit"
+    "typecheck": "pnpm -w exec tsc -p apps/worker/tsconfig.json --noEmit",
+    "test": "vitest run --config vitest.config.ts --coverage",
+    "test:watch": "vitest --config vitest.config.ts",
+    "migrate:local": "CI=1 wrangler d1 migrations apply uptimer --local",
+    "init:local": "pnpm migrate:local && pnpm seed:local",
+    "seed:local": "wrangler d1 execute uptimer --local --file ./scripts/seed-local.sql"
   },
   "dependencies": {
     "@uptimer/db": "workspace:*",
@@ -17,6 +22,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",
+    "@vitest/coverage-v8": "^2.1.8",
+    "vitest": "^2.1.8",
     "wrangler": "^4.0.0"
   }
 }

--- a/apps/worker/scripts/seed-local.sql
+++ b/apps/worker/scripts/seed-local.sql
@@ -1,0 +1,529 @@
+-- Local demo data seed for Uptimer.
+-- Reserved id range:
+--   monitors / monitor_state: 900001-900099
+--   incidents / maintenance windows: 900001-900099
+--   notification channels: 900001-900099
+
+-- 1) Clean previously seeded data (id-range scoped, avoids touching user-created rows).
+DELETE FROM check_results WHERE monitor_id BETWEEN 900001 AND 900099;
+DELETE FROM monitor_daily_rollups WHERE monitor_id BETWEEN 900001 AND 900099;
+DELETE FROM outages WHERE monitor_id BETWEEN 900001 AND 900099;
+DELETE FROM monitor_state WHERE monitor_id BETWEEN 900001 AND 900099;
+DELETE FROM monitors WHERE id BETWEEN 900001 AND 900099;
+
+DELETE FROM incident_updates WHERE incident_id BETWEEN 900001 AND 900099;
+DELETE FROM incident_monitors WHERE incident_id BETWEEN 900001 AND 900099;
+DELETE FROM incident_monitors WHERE monitor_id BETWEEN 900001 AND 900099;
+DELETE FROM incidents WHERE id BETWEEN 900001 AND 900099;
+
+DELETE FROM maintenance_window_monitors WHERE maintenance_window_id BETWEEN 900001 AND 900099;
+DELETE FROM maintenance_window_monitors WHERE monitor_id BETWEEN 900001 AND 900099;
+DELETE FROM maintenance_windows WHERE id BETWEEN 900001 AND 900099;
+
+DELETE FROM notification_deliveries WHERE channel_id BETWEEN 900001 AND 900099;
+DELETE FROM notification_channels WHERE id BETWEEN 900001 AND 900099;
+
+-- 2) Core monitor configs.
+INSERT INTO monitors (
+  id,
+  name,
+  type,
+  target,
+  interval_sec,
+  timeout_ms,
+  http_method,
+  expected_status_json,
+  is_active,
+  created_at,
+  updated_at
+)
+VALUES
+  (
+    900001,
+    'Homepage',
+    'http',
+    'https://example.com/healthz',
+    60,
+    5000,
+    'GET',
+    '[200]',
+    1,
+    CAST(strftime('%s','now') AS INTEGER) - 86400,
+    CAST(strftime('%s','now') AS INTEGER)
+  ),
+  (
+    900002,
+    'Public API',
+    'http',
+    'https://api.example.com/healthz',
+    60,
+    5000,
+    'GET',
+    '[200,204]',
+    1,
+    CAST(strftime('%s','now') AS INTEGER) - 86400,
+    CAST(strftime('%s','now') AS INTEGER)
+  ),
+  (
+    900003,
+    'Billing Service',
+    'http',
+    'https://billing.example.com/status',
+    60,
+    8000,
+    'GET',
+    '[200]',
+    1,
+    CAST(strftime('%s','now') AS INTEGER) - 86400,
+    CAST(strftime('%s','now') AS INTEGER)
+  ),
+  (
+    900004,
+    'Database TCP',
+    'tcp',
+    'db.example.com:5432',
+    60,
+    5000,
+    NULL,
+    NULL,
+    1,
+    CAST(strftime('%s','now') AS INTEGER) - 86400,
+    CAST(strftime('%s','now') AS INTEGER)
+  ),
+  (
+    900005,
+    'Legacy API',
+    'http',
+    'https://legacy.example.com/healthz',
+    120,
+    10000,
+    'GET',
+    '[200]',
+    1,
+    CAST(strftime('%s','now') AS INTEGER) - 86400,
+    CAST(strftime('%s','now') AS INTEGER)
+  ),
+  (
+    900006,
+    'Worker TCP',
+    'tcp',
+    'edge.example.com:443',
+    60,
+    4000,
+    NULL,
+    NULL,
+    1,
+    CAST(strftime('%s','now') AS INTEGER) - 86400,
+    CAST(strftime('%s','now') AS INTEGER)
+  );
+
+-- 3) Current state snapshot (covers up/down/maintenance/paused/unknown).
+INSERT INTO monitor_state (
+  monitor_id,
+  status,
+  last_checked_at,
+  last_changed_at,
+  last_latency_ms,
+  last_error,
+  consecutive_failures,
+  consecutive_successes
+)
+VALUES
+  (
+    900001,
+    'up',
+    CAST(strftime('%s','now') AS INTEGER) - 30,
+    CAST(strftime('%s','now') AS INTEGER) - 7200,
+    93,
+    NULL,
+    0,
+    35
+  ),
+  (
+    900002,
+    'down',
+    CAST(strftime('%s','now') AS INTEGER) - 20,
+    CAST(strftime('%s','now') AS INTEGER) - 2700,
+    NULL,
+    'HTTP 503',
+    46,
+    0
+  ),
+  (
+    900003,
+    'maintenance',
+    CAST(strftime('%s','now') AS INTEGER) - 40,
+    CAST(strftime('%s','now') AS INTEGER) - 900,
+    NULL,
+    NULL,
+    0,
+    0
+  ),
+  (
+    900004,
+    'paused',
+    CAST(strftime('%s','now') AS INTEGER) - 3600,
+    CAST(strftime('%s','now') AS INTEGER) - 3600,
+    NULL,
+    'Paused by admin',
+    0,
+    0
+  ),
+  (
+    900005,
+    'unknown',
+    CAST(strftime('%s','now') AS INTEGER) - 7200,
+    CAST(strftime('%s','now') AS INTEGER) - 3600,
+    NULL,
+    'No recent checks',
+    0,
+    0
+  ),
+  (
+    900006,
+    'up',
+    CAST(strftime('%s','now') AS INTEGER) - 25,
+    CAST(strftime('%s','now') AS INTEGER) - 300,
+    140,
+    NULL,
+    0,
+    3
+  );
+
+-- 4) Heartbeat / latency history (last ~60 samples).
+WITH RECURSIVE seq(i) AS (
+  SELECT 0
+  UNION ALL
+  SELECT i + 1 FROM seq WHERE i < 59
+)
+INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, http_status, error, location, attempt)
+SELECT
+  900001,
+  CAST(strftime('%s','now') AS INTEGER) - i * 60,
+  'up',
+  80 + (i % 6) * 5,
+  200,
+  NULL,
+  'LAX',
+  1
+FROM seq;
+
+WITH RECURSIVE seq(i) AS (
+  SELECT 0
+  UNION ALL
+  SELECT i + 1 FROM seq WHERE i < 59
+)
+INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, http_status, error, location, attempt)
+SELECT
+  900002,
+  CAST(strftime('%s','now') AS INTEGER) - i * 60,
+  CASE WHEN i <= 45 THEN 'down' ELSE 'up' END,
+  CASE WHEN i <= 45 THEN NULL ELSE 140 + (i % 4) * 10 END,
+  CASE WHEN i <= 45 THEN 503 ELSE 200 END,
+  CASE WHEN i <= 45 THEN 'HTTP 503' ELSE NULL END,
+  'LAX',
+  1
+FROM seq;
+
+WITH RECURSIVE seq(i) AS (
+  SELECT 0
+  UNION ALL
+  SELECT i + 1 FROM seq WHERE i < 59
+)
+INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, http_status, error, location, attempt)
+SELECT
+  900003,
+  CAST(strftime('%s','now') AS INTEGER) - i * 60,
+  'maintenance',
+  NULL,
+  NULL,
+  NULL,
+  'LAX',
+  1
+FROM seq;
+
+WITH RECURSIVE seq(i) AS (
+  SELECT 0
+  UNION ALL
+  SELECT i + 1 FROM seq WHERE i < 11
+)
+INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, http_status, error, location, attempt)
+SELECT
+  900005,
+  CAST(strftime('%s','now') AS INTEGER) - (i + 2) * 600,
+  CASE WHEN i < 6 THEN 'unknown' ELSE 'up' END,
+  CASE WHEN i < 6 THEN NULL ELSE 600 + (i % 3) * 100 END,
+  CASE WHEN i < 6 THEN NULL ELSE 200 END,
+  CASE WHEN i < 6 THEN 'Upstream timeout' ELSE NULL END,
+  'LAX',
+  1
+FROM seq;
+
+WITH RECURSIVE seq(i) AS (
+  SELECT 0
+  UNION ALL
+  SELECT i + 1 FROM seq WHERE i < 59
+)
+INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, http_status, error, location, attempt)
+SELECT
+  900006,
+  CAST(strftime('%s','now') AS INTEGER) - i * 60,
+  CASE WHEN (i % 10) < 3 THEN 'down' ELSE 'up' END,
+  CASE WHEN (i % 10) < 3 THEN NULL ELSE 110 + (i % 8) * 10 END,
+  NULL,
+  CASE WHEN (i % 10) < 3 THEN 'TCP connect timeout' ELSE NULL END,
+  'LAX',
+  1
+FROM seq;
+
+-- 5) Outages + incidents + maintenance windows.
+INSERT INTO outages (monitor_id, started_at, ended_at, initial_error, last_error)
+VALUES
+  (
+    900002,
+    CAST(strftime('%s','now') AS INTEGER) - 2700,
+    NULL,
+    'HTTP 503',
+    'HTTP 503'
+  ),
+  (
+    900006,
+    CAST(strftime('%s','now') AS INTEGER) - 10800,
+    CAST(strftime('%s','now') AS INTEGER) - 10200,
+    'TCP connect timeout',
+    'TCP connect timeout'
+  ),
+  (
+    900006,
+    CAST(strftime('%s','now') AS INTEGER) - 7200,
+    CAST(strftime('%s','now') AS INTEGER) - 6840,
+    'TCP connect timeout',
+    'TCP connect timeout'
+  );
+
+INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
+VALUES
+  (
+    900001,
+    'Public API instability',
+    'identified',
+    'major',
+    'Investigating elevated 5xx responses.',
+    CAST(strftime('%s','now') AS INTEGER) - 2600,
+    NULL
+  ),
+  (
+    900002,
+    'Worker TCP packet loss',
+    'resolved',
+    'minor',
+    'Intermittent TCP failures observed and resolved.',
+    CAST(strftime('%s','now') AS INTEGER) - 93600,
+    CAST(strftime('%s','now') AS INTEGER) - 90000
+  );
+
+INSERT INTO incident_updates (incident_id, status, message, created_at)
+VALUES
+  (
+    900001,
+    'investigating',
+    'Initial triage started.',
+    CAST(strftime('%s','now') AS INTEGER) - 2500
+  ),
+  (
+    900001,
+    'identified',
+    'Root cause isolated to upstream dependency.',
+    CAST(strftime('%s','now') AS INTEGER) - 1400
+  ),
+  (
+    900002,
+    'monitoring',
+    'Mitigation deployed, watching error rate.',
+    CAST(strftime('%s','now') AS INTEGER) - 91200
+  ),
+  (
+    900002,
+    'resolved',
+    'Recovered after network route update.',
+    CAST(strftime('%s','now') AS INTEGER) - 90000
+  );
+
+INSERT INTO incident_monitors (incident_id, monitor_id, created_at)
+VALUES
+  (900001, 900002, CAST(strftime('%s','now') AS INTEGER) - 2500),
+  (900002, 900006, CAST(strftime('%s','now') AS INTEGER) - 91200);
+
+INSERT INTO maintenance_windows (id, title, message, starts_at, ends_at, created_at)
+VALUES
+  (
+    900001,
+    'Billing DB maintenance',
+    'Scheduled failover in progress.',
+    CAST(strftime('%s','now') AS INTEGER) - 900,
+    CAST(strftime('%s','now') AS INTEGER) + 1800,
+    CAST(strftime('%s','now') AS INTEGER) - 1000
+  ),
+  (
+    900002,
+    'Homepage deploy window',
+    'Blue-green rollout planned.',
+    CAST(strftime('%s','now') AS INTEGER) + 3600,
+    CAST(strftime('%s','now') AS INTEGER) + 7200,
+    CAST(strftime('%s','now') AS INTEGER) - 100
+  );
+
+INSERT INTO maintenance_window_monitors (maintenance_window_id, monitor_id, created_at)
+VALUES
+  (900001, 900003, CAST(strftime('%s','now') AS INTEGER) - 900),
+  (900002, 900001, CAST(strftime('%s','now') AS INTEGER) - 100);
+
+-- 6) Notification channels + delivery history.
+INSERT INTO notification_channels (id, name, type, config_json, is_active, created_at)
+VALUES
+  (
+    900001,
+    'Local webhook (JSON)',
+    'webhook',
+    '{"url":"https://example.com/webhook","method":"POST","timeout_ms":5000,"payload_type":"json","enabled_events":["monitor.down","monitor.up","incident.created","incident.updated","incident.resolved"]}',
+    1,
+    CAST(strftime('%s','now') AS INTEGER) - 86400
+  ),
+  (
+    900002,
+    'Backup webhook (param)',
+    'webhook',
+    '{"url":"https://example.com/query","method":"GET","payload_type":"param","enabled_events":["monitor.down"]}',
+    0,
+    CAST(strftime('%s','now') AS INTEGER) - 86400
+  );
+
+INSERT INTO notification_deliveries (event_key, channel_id, status, http_status, error, created_at)
+VALUES
+  (
+    'monitor:900002:down:' || (CAST(strftime('%s','now') AS INTEGER) - 2600),
+    900001,
+    'success',
+    200,
+    NULL,
+    CAST(strftime('%s','now') AS INTEGER) - 2500
+  ),
+  (
+    'incident:900001:created:' || (CAST(strftime('%s','now') AS INTEGER) - 2600),
+    900001,
+    'failed',
+    500,
+    'Upstream webhook timeout',
+    CAST(strftime('%s','now') AS INTEGER) - 2400
+  );
+
+-- 7) Settings + 30-day rollup samples (status page/admin analytics warm start).
+INSERT OR REPLACE INTO settings (key, value) VALUES ('site_title', 'Uptimer Local Demo');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('site_description', 'Seeded data for local verification');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('site_timezone', 'UTC');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('retention_check_results_days', '14');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('state_failures_to_down_from_up', '2');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('state_successes_to_up_from_down', '2');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('admin_default_overview_range', '7d');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('admin_default_monitor_range', '30d');
+INSERT OR REPLACE INTO settings (key, value) VALUES ('uptime_rating_level', '4');
+
+WITH RECURSIVE day_seq(i, day_start) AS (
+  SELECT
+    0,
+    CAST(strftime('%s', date('now', 'start of day')) AS INTEGER)
+  UNION ALL
+  SELECT
+    i + 1,
+    day_start - 86400
+  FROM day_seq
+  WHERE i < 29
+)
+INSERT INTO monitor_daily_rollups (
+  monitor_id,
+  day_start_at,
+  total_sec,
+  downtime_sec,
+  unknown_sec,
+  uptime_sec,
+  checks_total,
+  checks_up,
+  checks_down,
+  checks_unknown,
+  checks_maintenance,
+  avg_latency_ms,
+  p50_latency_ms,
+  p95_latency_ms,
+  latency_histogram_json,
+  created_at,
+  updated_at
+)
+SELECT
+  900001,
+  day_start,
+  86400,
+  CASE WHEN (i % 9) = 0 THEN 120 ELSE 0 END,
+  0,
+  86400 - CASE WHEN (i % 9) = 0 THEN 120 ELSE 0 END,
+  1440,
+  1438 - CASE WHEN (i % 9) = 0 THEN 2 ELSE 0 END,
+  CASE WHEN (i % 9) = 0 THEN 2 ELSE 0 END,
+  0,
+  0,
+  90 + (i % 6),
+  88 + (i % 4),
+  140 + (i % 10),
+  '[0,0,20,80,160,320,480,240,120,20,0,0,0,0,0,0,0,0,0,0,0,0]',
+  CAST(strftime('%s','now') AS INTEGER),
+  CAST(strftime('%s','now') AS INTEGER)
+FROM day_seq;
+
+WITH RECURSIVE day_seq(i, day_start) AS (
+  SELECT
+    0,
+    CAST(strftime('%s', date('now', 'start of day')) AS INTEGER)
+  UNION ALL
+  SELECT
+    i + 1,
+    day_start - 86400
+  FROM day_seq
+  WHERE i < 29
+)
+INSERT INTO monitor_daily_rollups (
+  monitor_id,
+  day_start_at,
+  total_sec,
+  downtime_sec,
+  unknown_sec,
+  uptime_sec,
+  checks_total,
+  checks_up,
+  checks_down,
+  checks_unknown,
+  checks_maintenance,
+  avg_latency_ms,
+  p50_latency_ms,
+  p95_latency_ms,
+  latency_histogram_json,
+  created_at,
+  updated_at
+)
+SELECT
+  900002,
+  day_start,
+  86400,
+  1200 + (i % 5) * 300,
+  (i % 3) * 60,
+  86400 - (1200 + (i % 5) * 300) - (i % 3) * 60,
+  1440,
+  1400 - (i % 5) * 4,
+  40 + (i % 5) * 4,
+  (i % 3),
+  0,
+  180 + (i % 8) * 8,
+  170 + (i % 8) * 8,
+  600 + (i % 10) * 20,
+  '[0,0,0,10,30,80,120,180,240,220,180,120,70,40,25,15,5,3,1,1,0,0]',
+  CAST(strftime('%s','now') AS INTEGER),
+  CAST(strftime('%s','now') AS INTEGER)
+FROM day_seq;

--- a/apps/worker/test/analytics-latency.test.ts
+++ b/apps/worker/test/analytics-latency.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LATENCY_BUCKETS_MS,
+  avg,
+  buildLatencyHistogram,
+  mergeLatencyHistograms,
+  percentileFromHistogram,
+  percentileFromValues,
+} from '../src/analytics/latency';
+import { buildLatencySeries } from './helpers/data-builders';
+
+describe('analytics/latency', () => {
+  it('computes average from finite non-negative values only', () => {
+    expect(avg([10, 20, Number.NaN, -5, Number.POSITIVE_INFINITY])).toBe(15);
+    expect(avg([-1, Number.NaN])).toBeNull();
+  });
+
+  it('calculates nearest-rank percentiles', () => {
+    const values = buildLatencySeries({ points: 5, base: 100, step: 20 });
+    expect(percentileFromValues(values, 0.5)).toBe(140);
+    expect(percentileFromValues(values, 0.95)).toBe(180);
+    expect(percentileFromValues([], 0.95)).toBeNull();
+    expect(percentileFromValues([Number.NaN], 0.95)).toBeNull();
+    expect(percentileFromValues(values, 0)).toBeNull();
+    expect(percentileFromValues(values, 1.1)).toBeNull();
+  });
+
+  it('builds and merges latency histograms', () => {
+    const a = buildLatencyHistogram([10, 25, 26, 75, 60001, -5]);
+    const b = buildLatencyHistogram([50, 50, 1000, 15000, 60000]);
+    const merged = mergeLatencyHistograms([a, b]);
+
+    expect(a).toHaveLength(LATENCY_BUCKETS_MS.length + 1);
+    expect(merged).toHaveLength(LATENCY_BUCKETS_MS.length + 1);
+    expect(merged.reduce((sum, v) => sum + v, 0)).toBe(11);
+  });
+
+  it('derives percentile approximations from histogram buckets', () => {
+    const hist = buildLatencyHistogram([20, 21, 25, 26, 400, 450, 460, 8_000, 70_000]);
+
+    expect(percentileFromHistogram(hist, 0.5)).toBe(400);
+    expect(percentileFromHistogram(hist, 0.95)).toBe(60000);
+    expect(percentileFromHistogram(hist, 0)).toBeNull();
+    expect(percentileFromHistogram([], 0.9)).toBeNull();
+
+    // Defensive path: NaN buckets do not contribute to total and can force fallback.
+    expect(percentileFromHistogram([Number.NaN, 1], 0.5)).toBe(60000);
+  });
+});

--- a/apps/worker/test/analytics-uptime.test.ts
+++ b/apps/worker/test/analytics-uptime.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildUnknownIntervals,
+  mergeIntervals,
+  overlapSeconds,
+  rangeToSeconds,
+  sumIntervals,
+  utcDayStart,
+} from '../src/analytics/uptime';
+import { buildCheckSeries } from './helpers/data-builders';
+
+describe('analytics/uptime', () => {
+  it('maps configured ranges to seconds', () => {
+    expect(rangeToSeconds('24h')).toBe(86_400);
+    expect(rangeToSeconds('7d')).toBe(604_800);
+    expect(rangeToSeconds('30d')).toBe(2_592_000);
+    expect(rangeToSeconds('90d')).toBe(7_776_000);
+    expect(rangeToSeconds('invalid' as unknown as '24h')).toBe('invalid');
+  });
+
+  it('normalizes timestamps to UTC day starts', () => {
+    expect(utcDayStart(0)).toBe(0);
+    expect(utcDayStart(86_399)).toBe(0);
+    expect(utcDayStart(86_400)).toBe(86_400);
+    expect(utcDayStart(1700000123)).toBe(Math.floor(1700000123 / 86_400) * 86_400);
+  });
+
+  it('merges overlapping intervals and sums total seconds', () => {
+    expect(mergeIntervals([])).toEqual([]);
+
+    const merged = mergeIntervals([
+      { start: 100, end: 120 },
+      { start: 80, end: 110 },
+      { start: 120, end: 140 },
+      { start: 200, end: 220 },
+    ]);
+
+    expect(merged).toEqual([
+      { start: 80, end: 140 },
+      { start: 200, end: 220 },
+    ]);
+    expect(sumIntervals(merged)).toBe(80);
+    expect(sumIntervals([{ start: 10, end: 5 }])).toBe(0);
+  });
+
+  it('computes overlap duration across sorted interval lists', () => {
+    const a = [
+      { start: 0, end: 100 },
+      { start: 200, end: 400 },
+    ];
+    const b = [
+      { start: 50, end: 120 },
+      { start: 250, end: 260 },
+      { start: 300, end: 450 },
+    ];
+
+    expect(overlapSeconds(a, b)).toBe(50 + 10 + 100);
+
+    const sparse = [{ start: 0, end: 10 }, undefined] as unknown as Array<{ start: number; end: number }>;
+    expect(overlapSeconds(sparse, [{ start: 0, end: 10 }])).toBe(10);
+  });
+
+  it('returns empty unknown windows for invalid ranges', () => {
+    const checks = buildCheckSeries({
+      rangeStart: 0,
+      intervalSec: 60,
+      points: 3,
+      statusAt: () => 'up',
+    });
+    expect(buildUnknownIntervals(100, 100, 60, checks)).toEqual([]);
+  });
+
+  it('marks the full range unknown when interval is invalid or no checks exist', () => {
+    expect(buildUnknownIntervals(0, 300, 0, [])).toEqual([{ start: 0, end: 300 }]);
+    expect(buildUnknownIntervals(0, 300, 60, [])).toEqual([{ start: 0, end: 300 }]);
+  });
+
+  it('marks stale gaps as unknown beyond 2x interval jitter', () => {
+    const checks = [
+      { checked_at: 0, status: 'up' },
+      { checked_at: 300, status: 'up' },
+    ];
+
+    const unknown = buildUnknownIntervals(0, 600, 60, checks);
+    expect(unknown).toEqual([
+      { start: 120, end: 300 },
+      { start: 420, end: 600 },
+    ]);
+  });
+
+  it('uses checks before/after range boundaries when building unknown intervals', () => {
+    const checks = [
+      { checked_at: -60, status: 'up' },
+      { checked_at: 60, status: 'unknown' },
+      { checked_at: 120, status: 'up' },
+      { checked_at: 300, status: 'up' },
+    ];
+
+    expect(buildUnknownIntervals(0, 180, 60, checks)).toEqual([{ start: 60, end: 120 }]);
+  });
+
+  it('marks partial stale tails when last check only covers part of a segment', () => {
+    const checks = [
+      { checked_at: 0, status: 'up' },
+      { checked_at: 100, status: 'up' },
+    ];
+
+    expect(buildUnknownIntervals(0, 300, 60, checks)).toEqual([{ start: 220, end: 300 }]);
+  });
+
+  it('marks windows unknown while the latest known status is unknown', () => {
+    const checks = buildCheckSeries({
+      rangeStart: 0,
+      intervalSec: 60,
+      points: 5,
+      statusAt: (idx) => (idx < 2 ? 'unknown' : 'up'),
+    });
+
+    const unknown = buildUnknownIntervals(0, 300, 60, checks);
+    expect(unknown).toEqual([{ start: 0, end: 120 }]);
+  });
+});

--- a/apps/worker/test/helpers/data-builders.ts
+++ b/apps/worker/test/helpers/data-builders.ts
@@ -1,0 +1,39 @@
+export type CheckStatus = 'up' | 'down' | 'unknown' | 'maintenance';
+
+export type CheckPoint = {
+  checked_at: number;
+  status: CheckStatus;
+};
+
+type CheckSeriesOptions = {
+  rangeStart: number;
+  intervalSec: number;
+  points: number;
+  statusAt: (index: number) => CheckStatus;
+};
+
+type LatencySeriesOptions = {
+  points: number;
+  base: number;
+  step: number;
+  spikeEvery?: number;
+  spikeValue?: number;
+};
+
+export function buildCheckSeries(options: CheckSeriesOptions): CheckPoint[] {
+  const { rangeStart, intervalSec, points, statusAt } = options;
+  return Array.from({ length: points }, (_unused, index) => ({
+    checked_at: rangeStart + index * intervalSec,
+    status: statusAt(index),
+  }));
+}
+
+export function buildLatencySeries(options: LatencySeriesOptions): number[] {
+  const { points, base, step, spikeEvery, spikeValue = base } = options;
+  return Array.from({ length: points }, (_unused, index) => {
+    if (spikeEvery && spikeEvery > 0 && index > 0 && index % spikeEvery === 0) {
+      return spikeValue;
+    }
+    return base + index * step;
+  });
+}

--- a/apps/worker/test/monitor-state-machine.test.ts
+++ b/apps/worker/test/monitor-state-machine.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MonitorStateSnapshot } from '../src/monitor/state-machine';
+import { computeNextState } from '../src/monitor/state-machine';
+
+const CHECKED_AT = 1_735_000_000;
+
+function snapshot(partial: Partial<MonitorStateSnapshot>): MonitorStateSnapshot {
+  return {
+    status: partial.status ?? 'unknown',
+    lastChangedAt: partial.lastChangedAt ?? CHECKED_AT - 120,
+    consecutiveFailures: partial.consecutiveFailures ?? 0,
+    consecutiveSuccesses: partial.consecutiveSuccesses ?? 0,
+  };
+}
+
+describe('computeNextState', () => {
+  it('promotes unknown to up on first successful check', () => {
+    const { next, outageAction } = computeNextState(
+      null,
+      { status: 'up', latencyMs: 25, error: null, httpStatus: 200, attempts: 1 },
+      CHECKED_AT,
+    );
+
+    expect(next).toEqual({
+      status: 'up',
+      lastChangedAt: CHECKED_AT,
+      consecutiveFailures: 0,
+      consecutiveSuccesses: 1,
+      changed: true,
+    });
+    expect(outageAction).toBe('none');
+  });
+
+  it('keeps up until failure threshold is reached', () => {
+    const prev = snapshot({ status: 'up', consecutiveFailures: 0, consecutiveSuccesses: 4 });
+    const first = computeNextState(
+      prev,
+      { status: 'down', latencyMs: null, error: 'timeout', httpStatus: null, attempts: 1 },
+      CHECKED_AT,
+    );
+
+    expect(first.next.status).toBe('up');
+    expect(first.next.changed).toBe(false);
+    expect(first.next.consecutiveFailures).toBe(1);
+    expect(first.outageAction).toBe('none');
+
+    const second = computeNextState(
+      snapshot({ status: 'up', consecutiveFailures: 1, consecutiveSuccesses: 0 }),
+      { status: 'down', latencyMs: null, error: 'timeout', httpStatus: null, attempts: 1 },
+      CHECKED_AT + 60,
+    );
+
+    expect(second.next.status).toBe('down');
+    expect(second.next.changed).toBe(true);
+    expect(second.outageAction).toBe('open');
+  });
+
+  it('keeps down until success threshold is reached', () => {
+    const first = computeNextState(
+      snapshot({ status: 'down', consecutiveFailures: 3, consecutiveSuccesses: 0 }),
+      { status: 'up', latencyMs: 45, error: null, httpStatus: 200, attempts: 1 },
+      CHECKED_AT,
+    );
+
+    expect(first.next.status).toBe('down');
+    expect(first.next.changed).toBe(false);
+    expect(first.next.consecutiveSuccesses).toBe(1);
+    expect(first.outageAction).toBe('update');
+
+    const second = computeNextState(
+      snapshot({ status: 'down', consecutiveFailures: 0, consecutiveSuccesses: 1 }),
+      { status: 'up', latencyMs: 40, error: null, httpStatus: 200, attempts: 1 },
+      CHECKED_AT + 60,
+    );
+
+    expect(second.next.status).toBe('up');
+    expect(second.next.changed).toBe(true);
+    expect(second.outageAction).toBe('close');
+  });
+
+  it('does not auto-transition paused and maintenance states', () => {
+    const paused = computeNextState(
+      snapshot({ status: 'paused', consecutiveFailures: 5, consecutiveSuccesses: 5 }),
+      { status: 'down', latencyMs: null, error: 'timeout', httpStatus: null, attempts: 1 },
+      CHECKED_AT,
+    );
+    expect(paused.next.status).toBe('paused');
+    expect(paused.next.changed).toBe(false);
+    expect(paused.next.consecutiveFailures).toBe(0);
+    expect(paused.next.consecutiveSuccesses).toBe(0);
+    expect(paused.outageAction).toBe('none');
+
+    const maintenance = computeNextState(
+      snapshot({ status: 'maintenance' }),
+      { status: 'up', latencyMs: 30, error: null, httpStatus: 200, attempts: 1 },
+      CHECKED_AT,
+    );
+    expect(maintenance.next.status).toBe('maintenance');
+    expect(maintenance.outageAction).toBe('none');
+  });
+
+  it('retains current state on unknown checks and clears streaks', () => {
+    const { next, outageAction } = computeNextState(
+      snapshot({ status: 'up', consecutiveFailures: 1, consecutiveSuccesses: 2 }),
+      { status: 'unknown', latencyMs: null, error: 'network jitter', httpStatus: null, attempts: 1 },
+      CHECKED_AT,
+    );
+
+    expect(next.status).toBe('up');
+    expect(next.changed).toBe(false);
+    expect(next.consecutiveFailures).toBe(0);
+    expect(next.consecutiveSuccesses).toBe(0);
+    expect(outageAction).toBe('none');
+  });
+
+  it('handles steady-state up/down transitions without flapping', () => {
+    const steadyUp = computeNextState(
+      snapshot({ status: 'up', consecutiveSuccesses: 3 }),
+      { status: 'up', latencyMs: 32, error: null, httpStatus: 200, attempts: 1 },
+      CHECKED_AT,
+    );
+    expect(steadyUp.next.status).toBe('up');
+    expect(steadyUp.next.changed).toBe(false);
+    expect(steadyUp.outageAction).toBe('none');
+
+    const unknownToDown = computeNextState(
+      snapshot({ status: 'unknown', lastChangedAt: null }),
+      { status: 'down', latencyMs: null, error: 'dns error', httpStatus: null, attempts: 1 },
+      CHECKED_AT + 60,
+    );
+    expect(unknownToDown.next.status).toBe('down');
+    expect(unknownToDown.next.changed).toBe(true);
+    expect(unknownToDown.outageAction).toBe('open');
+
+    const steadyDown = computeNextState(
+      snapshot({ status: 'down', consecutiveFailures: 4 }),
+      { status: 'down', latencyMs: null, error: 'timeout', httpStatus: null, attempts: 1 },
+      CHECKED_AT + 120,
+    );
+    expect(steadyDown.next.status).toBe('down');
+    expect(steadyDown.next.changed).toBe(false);
+    expect(steadyDown.outageAction).toBe('update');
+  });
+
+  it('normalizes invalid thresholds and supports custom thresholds', () => {
+    const withInvalidThreshold = computeNextState(
+      snapshot({ status: 'up', consecutiveFailures: 1 }),
+      { status: 'down', latencyMs: null, error: 'timeout', httpStatus: null, attempts: 1 },
+      CHECKED_AT,
+      { failuresToDownFromUp: 0, successesToUpFromDown: Number.NaN },
+    );
+    expect(withInvalidThreshold.next.status).toBe('down');
+    expect(withInvalidThreshold.outageAction).toBe('open');
+
+    const withCustomThreshold = computeNextState(
+      snapshot({ status: 'down', consecutiveSuccesses: 0 }),
+      { status: 'up', latencyMs: 20, error: null, httpStatus: 200, attempts: 1 },
+      CHECKED_AT,
+      { successesToUpFromDown: 1 },
+    );
+    expect(withCustomThreshold.next.status).toBe('up');
+    expect(withCustomThreshold.outageAction).toBe('close');
+  });
+
+  it('caps streak counters at max range', () => {
+    const { next } = computeNextState(
+      snapshot({ status: 'down', consecutiveSuccesses: 1000 }),
+      { status: 'up', latencyMs: 55, error: null, httpStatus: 200, attempts: 1 },
+      CHECKED_AT,
+      { successesToUpFromDown: 2000 },
+    );
+
+    expect(next.status).toBe('down');
+    expect(next.consecutiveSuccesses).toBe(1000);
+  });
+});

--- a/apps/worker/test/monitor-targets.test.ts
+++ b/apps/worker/test/monitor-targets.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseTcpTarget, validateHttpTarget, validateTcpTarget } from '../src/monitor/targets';
+
+describe('validateHttpTarget', () => {
+  it('accepts valid public http/https targets', () => {
+    expect(validateHttpTarget('https://example.com/health')).toBeNull();
+    expect(validateHttpTarget('http://status.example.com:8080/ping')).toBeNull();
+  });
+
+  it('rejects invalid URL and unsupported protocols', () => {
+    expect(validateHttpTarget('not-a-url')).toBe('target must be a valid URL');
+    expect(validateHttpTarget('ftp://example.com')).toBe('target protocol must be http or https');
+  });
+
+  it('rejects blocked hosts and reserved addresses', () => {
+    expect(validateHttpTarget('https://localhost/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://10.0.1.2/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://127.0.0.1/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://[::1]/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://[fc00::1]/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://192.0.2.10/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://198.18.0.10/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://224.1.1.1/health')).toBe('target hostname is not allowed');
+    expect(validateHttpTarget('https://240.0.0.1/health')).toBe('target hostname is not allowed');
+  });
+
+  it('rejects invalid ports', () => {
+    expect(validateHttpTarget('https://example.com:0/health')).toBe('target port is invalid');
+  });
+});
+
+describe('parseTcpTarget', () => {
+  it('parses host:port and bracketed IPv6 targets', () => {
+    expect(parseTcpTarget('db.example.com:5432')).toEqual({ host: 'db.example.com', port: 5432 });
+    expect(parseTcpTarget('[2606:4700:4700::1111]:443')).toEqual({
+      host: '2606:4700:4700::1111',
+      port: 443,
+    });
+  });
+
+  it('returns null for malformed targets', () => {
+    expect(parseTcpTarget('')).toBeNull();
+    expect(parseTcpTarget('missing-port')).toBeNull();
+    expect(parseTcpTarget('[::1]')).toBeNull();
+    expect(parseTcpTarget('[::1')).toBeNull();
+    expect(parseTcpTarget('[::1]443')).toBeNull();
+    expect(parseTcpTarget('[::1]:0')).toBeNull();
+    expect(parseTcpTarget('example.com:not-a-port')).toBeNull();
+  });
+});
+
+describe('validateTcpTarget', () => {
+  it('accepts reachable public targets', () => {
+    expect(validateTcpTarget('example.com:443')).toBeNull();
+    expect(validateTcpTarget('[2606:4700:4700::1111]:53')).toBeNull();
+  });
+
+  it('rejects blocked hosts and reserved IP ranges', () => {
+    expect(validateTcpTarget('localhost:5432')).toBe('target host is not allowed');
+    expect(validateTcpTarget('192.168.1.2:5432')).toBe('target host is not allowed');
+    expect(validateTcpTarget('127.0.0.1:80')).toBe('target host is not allowed');
+    expect(validateTcpTarget('[::1]:443')).toBe('target host is not allowed');
+  });
+
+  it('rejects malformed payloads and out-of-range ports', () => {
+    expect(validateTcpTarget('bad-target')).toBe('target must be in host:port format (IPv6: [addr]:port)');
+    expect(validateTcpTarget('example.com:65536')).toBe('target must be in host:port format (IPv6: [addr]:port)');
+    expect(validateTcpTarget('[]:443')).toBe('target host is required');
+  });
+});

--- a/apps/worker/test/notify-template.test.ts
+++ b/apps/worker/test/notify-template.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultMessageForEvent,
+  renderJsonTemplate,
+  renderStringTemplate,
+} from '../src/notify/template';
+
+describe('notify/template', () => {
+  const vars = {
+    event: 'monitor.down',
+    message: 'API timeout',
+    monitor: { id: 9, name: 'API', target: 'https://api.example.com/health' },
+    state: { status: 'down', error: 'Timeout 10000ms', latency_ms: 10000 },
+    incident: { title: 'API outage', impact: 'major' },
+    update: { message: 'Mitigation applied' },
+    maintenance: { title: 'DB maintenance' },
+    arr: [{ value: 'first' }, { value: 'second' }],
+  } satisfies Record<string, unknown>;
+
+  it('renders string templates with nested paths and array indexes', () => {
+    const output = renderStringTemplate(
+      '[{{event}}] {{monitor.name}} {{state.status}} {{arr[1].value}} {{missing.field}}',
+      vars,
+    );
+    expect(output).toBe('[monitor.down] API down second ');
+  });
+
+  it('supports leading-dot paths and empty message fallback', () => {
+    expect(renderStringTemplate('{{ .monitor.name }}', vars)).toBe('API');
+    expect(renderStringTemplate('Alert: $MSG', { monitor: vars.monitor })).toBe('Alert: $MSG');
+  });
+
+  it('supports UptimeFlare-compatible $MSG replacement', () => {
+    expect(renderStringTemplate('$MSG', vars)).toBe('API timeout');
+    expect(renderStringTemplate('Alert: $MSG', vars)).toBe('Alert: API timeout');
+    expect(renderStringTemplate('Alert: {{message}}', vars)).toBe('Alert: API timeout');
+  });
+
+  it('blocks prototype-pollution style path expressions', () => {
+    expect(renderStringTemplate('{{__proto__.polluted}}', vars)).toBe('');
+    expect(renderStringTemplate('{{constructor.prototype}}', vars)).toBe('');
+    expect(renderStringTemplate('{{arr[foo]}}', vars)).toBe('');
+    expect(renderStringTemplate('{{arr[0}}', vars)).toBe('');
+    expect(renderStringTemplate('{{monitor.name[0]}}', vars)).toBe('');
+  });
+
+  it('renders JSON templates recursively and respects maxDepth', () => {
+    const payload = {
+      text: '{{message}}',
+      monitor: {
+        id: '{{monitor.id}}',
+        target: '{{monitor.target}}',
+      },
+      rows: ['{{arr[0].value}}', '{{arr[1].value}}'],
+    };
+
+    expect(renderJsonTemplate(payload, vars)).toEqual({
+      text: 'API timeout',
+      monitor: {
+        id: '9',
+        target: 'https://api.example.com/health',
+      },
+      rows: ['first', 'second'],
+    });
+
+    expect(renderJsonTemplate({ deep: { deeper: { value: 'x' } } }, vars, { maxDepth: 1 })).toEqual({
+      deep: {
+        deeper: null,
+      },
+    });
+
+    expect(renderJsonTemplate(123, vars)).toBe(123);
+  });
+
+  it('builds default message templates for built-in event types', () => {
+    expect(defaultMessageForEvent('monitor.down', vars)).toContain('Monitor DOWN: API');
+    expect(defaultMessageForEvent('monitor.up', vars)).toBe('Monitor UP: API (https://api.example.com/health)');
+    expect(defaultMessageForEvent('incident.created', vars)).toBe('Incident created: API outage (impact: major)');
+    expect(defaultMessageForEvent('incident.updated', vars)).toContain('Mitigation applied');
+    expect(defaultMessageForEvent('incident.resolved', vars)).toBe('Incident resolved: API outage');
+    expect(defaultMessageForEvent('maintenance.started', vars)).toBe('Maintenance started: DB maintenance');
+    expect(defaultMessageForEvent('maintenance.ended', vars)).toBe('Maintenance ended: DB maintenance');
+    expect(defaultMessageForEvent('test.ping', vars)).toBe('Uptimer test notification');
+    expect(defaultMessageForEvent('custom.event', vars)).toBe('Uptimer event: monitor.down');
+    expect(defaultMessageForEvent('custom.event', {})).toBe('Uptimer notification');
+  });
+
+  it('falls back when value stringification throws', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(renderStringTemplate('{{circular}}', { circular })).toBe('[object Object]');
+    expect(defaultMessageForEvent('custom.event', { event: circular })).toBe('Uptimer event: [object Object]');
+  });
+});

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: [
+        'src/analytics/latency.ts',
+        'src/analytics/uptime.ts',
+        'src/monitor/state-machine.ts',
+        'src/monitor/targets.ts',
+        'src/notify/template.ts',
+      ],
+      thresholds: {
+        lines: 90,
+        functions: 90,
+        statements: 90,
+        // Branch threshold is slightly lower because several defensive/nullish branches are runtime-hard to trigger.
+        branches: 85,
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -7,8 +7,13 @@
     "node": ">=22.14.0"
   },
   "scripts": {
+    "dev": "pnpm dev:init && pnpm dev:start",
+    "dev:init": "pnpm --filter @uptimer/worker init:local",
+    "dev:start": "pnpm -r --parallel --filter @uptimer/worker --filter @uptimer/web dev",
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
+    "test": "pnpm -r --if-present test",
+    "test:coverage": "pnpm --filter @uptimer/worker test",
     "format": "prettier -w .",
     "format:check": "prettier -c ."
   },
@@ -25,4 +30,3 @@
     "typescript-eslint": "^8.0.0"
   }
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.0.0
         version: 4.20260128.0
+      '@vitest/coverage-v8':
+        specifier: ^2.1.8
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.7))
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.7)
       wrangler:
         specifier: ^4.0.0
         version: 4.61.0(@cloudflare/workers-types@4.20260128.0)
@@ -124,6 +130,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -212,6 +222,9 @@ packages:
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
@@ -265,6 +278,12 @@ packages:
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -277,6 +296,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -287,6 +312,12 @@ packages:
     resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -301,6 +332,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -313,6 +350,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -323,6 +366,12 @@ packages:
     resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -337,6 +386,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -347,6 +402,12 @@ packages:
     resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -361,6 +422,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -371,6 +438,12 @@ packages:
     resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -385,6 +458,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -395,6 +474,12 @@ packages:
     resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -409,6 +494,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -419,6 +510,12 @@ packages:
     resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -433,6 +530,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -445,6 +548,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -455,6 +564,12 @@ packages:
     resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -481,6 +596,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -503,6 +624,12 @@ packages:
     resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -529,6 +656,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -540,6 +673,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -553,6 +692,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -563,6 +708,12 @@ packages:
     resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -768,6 +919,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -798,6 +957,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -1103,6 +1266,44 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1116,9 +1317,21 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1160,6 +1373,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1208,6 +1425,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1234,6 +1455,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1249,6 +1474,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1364,6 +1593,10 @@ packages:
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1496,8 +1729,17 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.279:
     resolution: {integrity: sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -1518,6 +1760,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1533,6 +1778,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1611,12 +1861,19 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1673,6 +1930,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -1718,6 +1979,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1771,6 +2037,9 @@ packages:
   hono@4.11.7:
     resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -1855,6 +2124,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -1928,9 +2201,28 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -2001,8 +2293,24 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2115,6 +2423,10 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2188,6 +2500,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2206,11 +2521,22 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2474,6 +2800,13 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2481,9 +2814,23 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -2506,6 +2853,14 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2539,6 +2894,10 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -2549,9 +2908,27 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2660,6 +3037,42 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -2700,6 +3113,31 @@ packages:
       yaml:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2721,6 +3159,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -2739,6 +3182,14 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
@@ -2778,6 +3229,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -2893,6 +3349,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@0.2.3': {}
+
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
   '@cloudflare/unenv-preset@2.11.0(unenv@2.0.0-rc.24)(workerd@1.20260124.0)':
@@ -2927,10 +3385,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -2939,10 +3403,16 @@ snapshots:
   '@esbuild/android-arm64@0.27.0':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.0':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -2951,10 +3421,16 @@ snapshots:
   '@esbuild/android-x64@0.27.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -2963,10 +3439,16 @@ snapshots:
   '@esbuild/darwin-x64@0.27.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -2975,10 +3457,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -2987,10 +3475,16 @@ snapshots:
   '@esbuild/linux-arm@0.27.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -2999,10 +3493,16 @@ snapshots:
   '@esbuild/linux-loong64@0.27.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -3011,16 +3511,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.0':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -3035,6 +3544,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -3045,6 +3557,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -3059,10 +3574,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -3071,10 +3592,16 @@ snapshots:
   '@esbuild/win32-arm64@0.27.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -3236,6 +3763,17 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3271,6 +3809,9 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -3565,6 +4106,64 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.7))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.1
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@22.19.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.7))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.7)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3578,9 +4177,15 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -3650,6 +4255,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   async-function@1.0.0: {}
 
   autoprefixer@10.4.23(postcss@8.5.6):
@@ -3696,6 +4303,8 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -3721,6 +4330,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3733,6 +4350,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -3840,6 +4459,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -3885,7 +4506,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.279: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -3969,6 +4596,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -3989,6 +4618,32 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -4150,9 +4805,15 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@4.0.7: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -4203,6 +4864,11 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   fraction.js@5.3.4: {}
 
@@ -4257,6 +4923,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   globals@14.0.0: {}
 
@@ -4316,6 +4991,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   hono@4.11.7: {}
+
+  html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -4399,6 +5076,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -4469,6 +5148,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -4477,6 +5177,12 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
 
@@ -4532,9 +5238,27 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
 
   math-intrinsics@1.1.0: {}
 
@@ -4787,6 +5511,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minipass@7.1.2: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -4868,6 +5594,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4888,9 +5616,18 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
   path-to-regexp@6.3.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -5247,14 +5984,34 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
 
   string.prototype.matchall@4.0.12:
     dependencies:
@@ -5304,6 +6061,14 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@3.1.1: {}
 
@@ -5361,6 +6126,12 @@ snapshots:
       - tsx
       - yaml
 
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 9.0.5
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -5371,10 +6142,20 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -5530,6 +6311,33 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@2.1.9(@types/node@22.19.7):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.7)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.7):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.57.0
+    optionalDependencies:
+      '@types/node': 22.19.7
+      fsevents: 2.3.3
+
   vite@6.4.1(@types/node@22.19.7)(jiti@1.21.7):
     dependencies:
       esbuild: 0.25.12
@@ -5542,6 +6350,41 @@ snapshots:
       '@types/node': 22.19.7
       fsevents: 2.3.3
       jiti: 1.21.7
+
+  vitest@2.1.9(@types/node@22.19.7):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.7))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.7)
+      vite-node: 2.1.9(@types/node@22.19.7)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.7
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -5588,6 +6431,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   workerd@1.20260124.0:
@@ -5614,6 +6462,18 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
 
   ws@8.18.0: {}
 


### PR DESCRIPTION
## What
- add a Worker-side vitest harness with focused tests for state machine, target validation, latency/uptime analytics, and notification templates
- add local D1 seed script and wiring so `pnpm dev` now runs migration + seed before starting worker/web
- update local testing docs + README and fix IPv6 literal host normalization in monitor target blocking

## Why
- make local verification reproducible and faster
- increase confidence on high-risk monitor logic and validation paths
- reduce setup errors by collapsing bootstrap/start into one command

## Validation
- pnpm -r lint
- pnpm -r typecheck
- pnpm -r test
- pnpm dev (verified migration + seed + worker/web startup)
