### PR TITLE
fix(web): stop loading tab title

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -26,7 +26,7 @@
         }
       })();
     </script>
-    <title>Loading...</title>
+    <title>Uptimer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/pages/AdminAnalytics.tsx
+++ b/apps/web/src/pages/AdminAnalytics.tsx
@@ -121,7 +121,12 @@ export function AdminAnalytics() {
   );
 
   const settings = settingsQuery.data?.settings;
+  const siteTitle = settings?.site_title?.trim() || 'Uptimer';
   const timeZone = settings?.site_timezone || 'UTC';
+
+  useEffect(() => {
+    document.title = `${siteTitle} · Analytics`;
+  }, [siteTitle]);
 
   useEffect(() => {
     if (!settings) return;

--- a/apps/web/src/pages/AdminDashboard.tsx
+++ b/apps/web/src/pages/AdminDashboard.tsx
@@ -179,6 +179,11 @@ export function AdminDashboard() {
   });
 
   const settings = settingsQuery.data?.settings;
+  const siteTitle = settings?.site_title?.trim() || 'Uptimer';
+
+  useEffect(() => {
+    document.title = `${siteTitle} · Admin`;
+  }, [siteTitle]);
 
   const [settingsDraft, setSettingsDraft] = useState<AdminSettings | null>(null);
   const [focusedSetting, setFocusedSetting] = useState<keyof AdminSettings | null>(null);

--- a/apps/web/src/pages/AdminLogin.tsx
+++ b/apps/web/src/pages/AdminLogin.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../app/AuthContext';
@@ -16,6 +16,10 @@ export function AdminLogin() {
   const from =
     (location.state as { from?: { pathname: string } })?.from?.pathname ||
     ADMIN_PATH;
+
+  useEffect(() => {
+    document.title = 'Uptimer · Admin Login';
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## What
- replace default document title in `index.html` from `Loading...` to `Uptimer`
- set explicit page titles for Admin Dashboard, Admin Analytics, and Admin Login
- keep admin titles aligned with `site_title` when settings are available

## Why
- browser tabs could stay on a loading placeholder title during route/data loading
- explicit titles prevent the recurring `Loading` label in tabs

## Verification
- pnpm -r lint
- pnpm -r typecheck
- pnpm -r test