### PR TITLE
fix: prevent mobile clipping in 30d availability bars

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -375,12 +375,17 @@ a {
     min-width: 44px;
   }
 
-  /* Smaller buttons in tables and bar charts */
+  /* Smaller buttons in tables */
   table button,
-  table a,
-  [data-bar-chart] button {
+  table a {
     min-height: 36px;
     min-width: auto;
+  }
+
+  /* Bar-chart cells use dense visual slots; avoid forcing tall tap targets that clip bars. */
+  [data-bar-chart] button {
+    min-height: 0;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## What\n- fix mobile clipping for data bars in 30d availability chart\n- keep larger tap targets globally while exempting dense bar-chart cells\n\n## Why\n- coarse-pointer CSS was forcing chart buttons to min-height 36px, which overflowed the compact chart container and got top-cropped\n\n## Validation\n- pnpm -r lint\n- pnpm -r typecheck\n- pnpm -r test