### PR TITLE
feat: add smart outlier filtering for latency charts

### DIFF
--- a/apps/web/src/components/DailyLatencyChart.tsx
+++ b/apps/web/src/components/DailyLatencyChart.tsx
@@ -3,6 +3,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'rec
 import type { MonitorAnalyticsDayPoint } from '../api/types';
 import { useI18n } from '../app/I18nContext';
 import { useTheme } from '../app/ThemeContext';
+import { suggestLatencyAxisCeiling } from '../utils/latencyScale';
 
 interface DailyLatencyChartProps {
   points: MonitorAnalyticsDayPoint[];
@@ -25,6 +26,13 @@ export function DailyLatencyChart({ points, height = 220 }: DailyLatencyChartPro
       p95_latency_ms: p.p95_latency_ms,
       p50_latency_ms: p.p50_latency_ms,
     }));
+  const axisCeiling = suggestLatencyAxisCeiling(
+    data.flatMap((point) => [point.p95_latency_ms, point.p50_latency_ms]).filter(
+      (value): value is number => typeof value === 'number',
+    ),
+  );
+  const yAxisDomainProps =
+    axisCeiling === null ? {} : { domain: [0, axisCeiling] as [number, number] };
 
   if (data.length === 0) {
     return (
@@ -50,6 +58,7 @@ export function DailyLatencyChart({ points, height = 220 }: DailyLatencyChartPro
         <YAxis
           tick={{ fontSize: 12, fill: axisColor }}
           stroke={axisColor}
+          {...yAxisDomainProps}
           tickFormatter={(v) => `${v}ms`}
         />
         <Tooltip

--- a/apps/web/src/components/LatencyChart.tsx
+++ b/apps/web/src/components/LatencyChart.tsx
@@ -2,6 +2,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'rec
 import type { LatencyPoint } from '../api/types';
 import { useI18n } from '../app/I18nContext';
 import { useTheme } from '../app/ThemeContext';
+import { suggestLatencyAxisCeiling } from '../utils/latencyScale';
 
 interface LatencyChartProps {
   points: LatencyPoint[];
@@ -21,8 +22,11 @@ export function LatencyChart({ points, height = 200 }: LatencyChartProps) {
     .filter((p) => p.status === 'up' && p.latency_ms !== null)
     .map((p) => ({
       time: p.checked_at,
-      latency: p.latency_ms,
+      latency: p.latency_ms as number,
     }));
+  const axisCeiling = suggestLatencyAxisCeiling(data.map((point) => point.latency));
+  const yAxisDomainProps =
+    axisCeiling === null ? {} : { domain: [0, axisCeiling] as [number, number] };
 
   if (data.length === 0) {
     return (
@@ -47,6 +51,7 @@ export function LatencyChart({ points, height = 200 }: LatencyChartProps) {
         <YAxis
           tick={{ fontSize: 12, fill: axisColor }}
           stroke={axisColor}
+          {...yAxisDomainProps}
           tickFormatter={(v) => `${v}ms`}
         />
         <Tooltip

--- a/apps/web/src/utils/latencyScale.ts
+++ b/apps/web/src/utils/latencyScale.ts
@@ -1,0 +1,68 @@
+const MIN_SAMPLE_SIZE_FOR_FILTER = 6;
+const IQR_MULTIPLIER = 1.5;
+const MEDIAN_SPIKE_MULTIPLIER = 2.5;
+const MEDIAN_SPIKE_PADDING_MS = 200;
+const AXIS_HEADROOM_RATIO = 0.12;
+
+function percentileFromSorted(values: number[], p: number): number | null {
+  if (values.length === 0) return null;
+  if (p <= 0) return values[0] ?? null;
+  if (p >= 1) return values[values.length - 1] ?? null;
+
+  const rank = (values.length - 1) * p;
+  const lowerIndex = Math.floor(rank);
+  const upperIndex = Math.ceil(rank);
+
+  const lower = values[lowerIndex];
+  const upper = values[upperIndex];
+  if (typeof lower !== 'number' || typeof upper !== 'number') return null;
+
+  if (lowerIndex === upperIndex) return lower;
+  return lower + (upper - lower) * (rank - lowerIndex);
+}
+
+function roundUpByMagnitude(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 1;
+
+  const exponent = Math.floor(Math.log10(value));
+  const stepExponent = Math.max(0, exponent - 1);
+  const step = 10 ** stepExponent;
+  return Math.ceil(value / step) * step;
+}
+
+export function suggestLatencyAxisCeiling(latencies: number[]): number | null {
+  const values = latencies
+    .filter((value): value is number => Number.isFinite(value) && value >= 0)
+    .sort((a, b) => a - b);
+
+  if (values.length < MIN_SAMPLE_SIZE_FOR_FILTER) return null;
+
+  const median = percentileFromSorted(values, 0.5);
+  const q1 = percentileFromSorted(values, 0.25);
+  const q3 = percentileFromSorted(values, 0.75);
+  if (median === null || q1 === null || q3 === null) return null;
+
+  const iqr = q3 - q1;
+  const upperFenceByIqr = iqr > 0 ? q3 + iqr * IQR_MULTIPLIER : Number.NEGATIVE_INFINITY;
+  const upperFenceByMedian = Math.max(
+    median * MEDIAN_SPIKE_MULTIPLIER,
+    median + MEDIAN_SPIKE_PADDING_MS,
+  );
+  const outlierFence = Math.max(upperFenceByIqr, upperFenceByMedian);
+  const max = values[values.length - 1];
+  if (typeof max !== 'number' || max <= outlierFence) return null;
+
+  const inlierMax = values.filter((value) => value <= outlierFence).at(-1);
+  if (typeof inlierMax !== 'number') return null;
+
+  const paddedCeiling = inlierMax * (1 + AXIS_HEADROOM_RATIO);
+  const ceiling = roundUpByMagnitude(paddedCeiling);
+
+  if (ceiling <= 0 || ceiling >= max * 0.98) return null;
+  return ceiling;
+}
+
+export function clampLatencyToCeiling(value: number, ceiling: number | null): number {
+  if (ceiling === null) return value;
+  return Math.min(value, ceiling);
+}


### PR DESCRIPTION
## What\n- add a reusable latency outlier scaler utility for chart axes\n- apply smart Y-axis ceiling to LatencyChart and DailyLatencyChart\n- apply the same ceiling logic to HeartbeatBar height scaling\n\n## Why\n- prevent single extreme latency spikes (e.g. 6000ms) from flattening the whole chart\n- keep original latency values intact while improving chart readability\n\n## Validation\n- pnpm -r lint\n- pnpm -r typecheck\n- pnpm -r --if-present test\n- pnpm --filter @uptimer/web build