### PR TITLE
ci: unify API base/origin resolution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,8 @@ jobs:
       # - UPTIMER_PREFIX: Base name for Worker/Pages/D1. Defaults to repo name slug.
       # - UPTIMER_WORKER_NAME / UPTIMER_PAGES_PROJECT / UPTIMER_D1_NAME: Override individual names.
       # - UPTIMER_D1_BINDING: D1 binding name in Worker (default: DB).
-      # - UPTIMER_API_BASE: Web build-time API base (defaults to derived workers.dev URL + /api/v1).
+      # - UPTIMER_API_BASE / UPTIMER_API_ORIGIN: Either one can be set; workflow derives the other.
+      #   (API_BASE drives Vite build requests; API_ORIGIN drives Pages HTML preload worker.)
       #
       # Required secret:
       # - UPTIMER_ADMIN_TOKEN: Admin dashboard access key; written to Worker secret ADMIN_TOKEN.
@@ -321,23 +322,72 @@ jobs:
           set -euo pipefail
           printf '%s' "$UPTIMER_ADMIN_TOKEN" | pnpm exec wrangler secret put ADMIN_TOKEN --name "$WORKER_NAME" --config "$WRANGLER_CI_CONFIG"
 
-      - name: Compute web API base (for Vite build)
+      - name: Resolve API base + origin (for Vite build + Pages preload)
         shell: bash
         run: |
           set -euo pipefail
 
+          trim_trailing_slashes() {
+            local value="$1"
+            while [[ "$value" == */ ]]; do
+              value="${value%/}"
+            done
+            printf '%s' "$value"
+          }
+
+          derive_api_base_from_origin() {
+            local origin="$1"
+            local trimmed
+            trimmed="$(trim_trailing_slashes "$origin")"
+            if [[ "$trimmed" == */api/v1 ]]; then
+              printf '%s' "$trimmed"
+            else
+              printf '%s/api/v1' "$trimmed"
+            fi
+          }
+
           if [[ -n "${UPTIMER_API_BASE:-}" ]]; then
             api_base="$UPTIMER_API_BASE"
+          elif [[ -n "${UPTIMER_API_ORIGIN:-}" ]]; then
+            api_base="$(derive_api_base_from_origin "$UPTIMER_API_ORIGIN")"
           elif [[ -n "${WORKER_URL:-}" ]]; then
             api_base="${WORKER_URL}/api/v1"
           else
             api_base="/api/v1"
           fi
 
+          api_origin=""
+          if [[ -n "${UPTIMER_API_ORIGIN:-}" ]]; then
+            api_origin="$UPTIMER_API_ORIGIN"
+          elif [[ -n "${UPTIMER_API_BASE:-}" ]]; then
+            if [[ "$UPTIMER_API_BASE" =~ ^https?://[^/]+ ]]; then
+              api_origin="${BASH_REMATCH[0]}"
+            fi
+            if [[ -z "$api_origin" && -n "${WORKER_URL:-}" ]]; then
+              api_origin="$WORKER_URL"
+            fi
+          elif [[ -n "${WORKER_URL:-}" ]]; then
+            api_origin="$WORKER_URL"
+          fi
+
+          if [[ -n "${UPTIMER_API_BASE:-}" && -n "${UPTIMER_API_ORIGIN:-}" ]]; then
+            implied_base="$(derive_api_base_from_origin "$UPTIMER_API_ORIGIN")"
+            if [[ "$UPTIMER_API_BASE" != "$implied_base" ]]; then
+              echo "::warning::UPTIMER_API_BASE and UPTIMER_API_ORIGIN resolve to different API bases. UPTIMER_API_BASE wins for web build."
+            fi
+          fi
+
           echo "Using VITE_API_BASE=$api_base"
           echo "VITE_API_BASE=$api_base" >> "$GITHUB_ENV"
+          echo "UPTIMER_RESOLVED_API_BASE=$api_base" >> "$GITHUB_ENV"
+
+          if [[ -n "$api_origin" ]]; then
+            echo "Using UPTIMER_API_ORIGIN=$api_origin"
+            echo "UPTIMER_RESOLVED_API_ORIGIN=$api_origin" >> "$GITHUB_ENV"
+          fi
         env:
           UPTIMER_API_BASE: ${{ vars.UPTIMER_API_BASE }}
+          UPTIMER_API_ORIGIN: ${{ vars.UPTIMER_API_ORIGIN }}
           WORKER_URL: ${{ steps.deploy_worker.outputs.worker_url }}
 
       - name: Build Pages (Vite)
@@ -378,16 +428,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          api_origin="${UPTIMER_API_ORIGIN:-${WORKER_URL:-}}"
+          api_origin="${UPTIMER_RESOLVED_API_ORIGIN:-}"
           if [[ -z "$api_origin" ]]; then
-            echo "Skipping Pages secret: no UPTIMER_API_ORIGIN / WORKER_URL"
+            echo "Skipping Pages secret: no UPTIMER_API_ORIGIN / absolute UPTIMER_API_BASE / WORKER_URL"
             exit 0
           fi
 
           printf %s "$api_origin" | pnpm -C apps/worker exec wrangler --cwd ../.. pages secret put UPTIMER_API_ORIGIN --project-name "$PAGES_PROJECT"
-        env:
-          UPTIMER_API_ORIGIN: ${{ vars.UPTIMER_API_ORIGIN }}
-          WORKER_URL: ${{ steps.deploy_worker.outputs.worker_url }}
 
       - name: Deploy Pages (idempotent)
         shell: bash

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -26,10 +26,12 @@ Source: `.github/workflows/deploy.yml`
 | `UPTIMER_PAGES_PROJECT` | `${UPTIMER_PREFIX}`       | Pages project name                                 |
 | `UPTIMER_D1_NAME`       | `${UPTIMER_PREFIX}`       | D1 database name                                   |
 | `UPTIMER_D1_BINDING`    | `DB`                      | D1 binding name in Worker                          |
-| `UPTIMER_API_BASE`      | Auto-derived or `/api/v1` | API base URL for web build                         |
-| `UPTIMER_API_ORIGIN`    | —                         | Pages Secret `UPTIMER_API_ORIGIN` value            |
+| `UPTIMER_API_BASE`      | Auto-derived or `/api/v1` | API address (e.g. `https://my-worker.example.com/api/v1` or `/api/v1`) |
+| `UPTIMER_API_ORIGIN`    | Auto-derived              | API origin (e.g. `https://my-worker.example.com`); `/api/v1` appended automatically |
 | `VITE_ADMIN_PATH`       | —                         | Admin dashboard path (overridden by Secret if set) |
 | `UPTIMER_ADMIN_PATH`    | —                         | Fallback variable for `VITE_ADMIN_PATH`            |
+
+> **API address**: Usually no configuration needed — the workflow detects the Worker URL automatically. Set `UPTIMER_API_BASE` or `UPTIMER_API_ORIGIN` only if the API is on a custom domain. Both accept the same information in different formats; setting one is enough.
 
 ## 2. Worker Runtime
 
@@ -57,7 +59,7 @@ Source: `apps/web/.env.example`
 | `VITE_ADMIN_PATH` | `/admin`  | Admin dashboard route prefix       |
 | `VITE_API_BASE`   | `/api/v1` | API base URL for frontend requests |
 
-> `VITE_API_BASE` is computed and injected by the deploy workflow (using `UPTIMER_API_BASE` if set).
+> `VITE_API_BASE` is injected by the deploy workflow from `UPTIMER_API_BASE`, `UPTIMER_API_ORIGIN`, or the Worker URL. Falls back to `/api/v1` if none are available.
 
 ## 4. Runtime Settings (D1)
 

--- a/docs/configuration-reference.zh-CN.md
+++ b/docs/configuration-reference.zh-CN.md
@@ -26,10 +26,12 @@ Uptimer 所有可配置参数，按部署时、运行时、本地开发分类。
 | `UPTIMER_PAGES_PROJECT` | `${UPTIMER_PREFIX}`  | Pages 项目名                                |
 | `UPTIMER_D1_NAME`       | `${UPTIMER_PREFIX}`  | D1 数据库名                                 |
 | `UPTIMER_D1_BINDING`    | `DB`                 | Worker 中 D1 binding 名称                   |
-| `UPTIMER_API_BASE`      | 自动推导或 `/api/v1` | Web 构建时 API 基础路径                     |
-| `UPTIMER_API_ORIGIN`    | —                    | Pages Secret `UPTIMER_API_ORIGIN` 的值      |
+| `UPTIMER_API_BASE`      | 自动推导或 `/api/v1` | API 地址（如 `https://my-worker.example.com/api/v1` 或 `/api/v1`） |
+| `UPTIMER_API_ORIGIN`    | 自动推导             | API 源地址（如 `https://my-worker.example.com`）；自动拼接 `/api/v1` |
 | `VITE_ADMIN_PATH`       | —                    | 管理后台路径（可被 Secret 覆盖）            |
 | `UPTIMER_ADMIN_PATH`    | —                    | 兼容变量名（`VITE_ADMIN_PATH` 的 fallback） |
+
+> **API 地址**：通常无需配置——工作流会自动从 Worker URL 推导。仅当 API 使用自定义域名时，设置 `UPTIMER_API_BASE` 或 `UPTIMER_API_ORIGIN` 其中一个即可，两者只是格式不同。
 
 ## 2. Worker 运行时
 
@@ -57,7 +59,7 @@ Uptimer 所有可配置参数，按部署时、运行时、本地开发分类。
 | `VITE_ADMIN_PATH` | `/admin`  | 管理后台路由前缀        |
 | `VITE_API_BASE`   | `/api/v1` | 前端访问 API 的基础 URL |
 
-> `VITE_API_BASE` 在 CI 中由部署工作流计算并注入（优先使用 `UPTIMER_API_BASE`）。
+> `VITE_API_BASE` 由部署工作流自动注入，来源依次为 `UPTIMER_API_BASE`、`UPTIMER_API_ORIGIN`、Worker URL，均不可用时回退为 `/api/v1`。
 
 ## 4. 运行时设置（D1）
 

--- a/docs/deploy-github-actions.md
+++ b/docs/deploy-github-actions.md
@@ -55,11 +55,13 @@ Override default naming and routing:
 | `UPTIMER_PAGES_PROJECT`                  | `${UPTIMER_PREFIX}`       | Pages project name           |
 | `UPTIMER_D1_NAME`                        | `${UPTIMER_PREFIX}`       | D1 database name             |
 | `UPTIMER_D1_BINDING`                     | `DB`                      | D1 binding name in Worker    |
-| `UPTIMER_API_BASE`                       | Auto-derived or `/api/v1` | API base URL for web build   |
-| `UPTIMER_API_ORIGIN`                     | —                         | Pages Secret value           |
+| `UPTIMER_API_BASE`                       | Auto-derived or `/api/v1` | API address (e.g. `https://my-worker.example.com/api/v1` or `/api/v1`) |
+| `UPTIMER_API_ORIGIN`                     | Auto-derived              | API origin (e.g. `https://my-worker.example.com`); `/api/v1` appended automatically |
 | `VITE_ADMIN_PATH` / `UPTIMER_ADMIN_PATH` | —                         | Custom admin dashboard path  |
 
 > If no naming variables are set, the workflow uses the repository name slug as the default prefix. This keeps names stable across forks.
+>
+> **API address**: Usually no configuration needed — the workflow detects the Worker URL automatically. Set `UPTIMER_API_BASE` or `UPTIMER_API_ORIGIN` only if the API is on a custom domain. Both accept the same information in different formats; setting one is enough.
 
 ## Cloudflare Token Permissions
 
@@ -120,9 +122,9 @@ monitors, monitor_state, check_results, outages, settings
 
 ### Pages builds but API returns 404 or HTML
 
-- Check `UPTIMER_API_BASE` is correct
-- If not set, the workflow derives it from the Worker URL + `/api/v1`
-- "API returned HTML instead of JSON" usually means the API base or route is misaligned
+- Verify that `UPTIMER_API_BASE` or `UPTIMER_API_ORIGIN` points to your Worker, not to the Pages site
+- "API returned HTML instead of JSON" usually means the URL is hitting Pages (which returns HTML) instead of the Worker
+- If neither variable is set, the workflow uses the Worker URL automatically — check that it resolved correctly in the deploy logs
 
 ### Admin returns 401
 

--- a/docs/deploy-github-actions.zh-CN.md
+++ b/docs/deploy-github-actions.zh-CN.md
@@ -55,11 +55,13 @@
 | `UPTIMER_PAGES_PROJECT`                  | `${UPTIMER_PREFIX}`  | Pages 项目名              |
 | `UPTIMER_D1_NAME`                        | `${UPTIMER_PREFIX}`  | D1 数据库名               |
 | `UPTIMER_D1_BINDING`                     | `DB`                 | Worker 中 D1 binding 名称 |
-| `UPTIMER_API_BASE`                       | 自动推导或 `/api/v1` | Web 构建时的 API 基础路径 |
-| `UPTIMER_API_ORIGIN`                     | —                    | Pages Secret 值           |
+| `UPTIMER_API_BASE`                       | 自动推导或 `/api/v1` | API 地址（如 `https://my-worker.example.com/api/v1` 或 `/api/v1`） |
+| `UPTIMER_API_ORIGIN`                     | 自动推导             | API 源地址（如 `https://my-worker.example.com`）；自动拼接 `/api/v1` |
 | `VITE_ADMIN_PATH` / `UPTIMER_ADMIN_PATH` | —                    | 自定义管理后台路径        |
 
 > 若不配置命名变量，工作流会使用仓库名 slug 作为默认前缀。这在 fork 场景下能保持命名稳定。
+>
+> **API 地址**：通常无需配置——工作流会自动从 Worker URL 推导。仅当 API 使用自定义域名时，设置 `UPTIMER_API_BASE` 或 `UPTIMER_API_ORIGIN` 其中一个即可，两者只是格式不同。
 
 ## Cloudflare Token 权限
 
@@ -120,9 +122,9 @@ monitors, monitor_state, check_results, outages, settings
 
 ### Pages 构建成功但 API 返回 404 或 HTML
 
-- 检查 `UPTIMER_API_BASE` 是否正确
-- 若未设置，工作流会从 Worker URL + `/api/v1` 推导
-- "API returned HTML instead of JSON" 通常意味着 API Base 或路由未对齐
+- 确认 `UPTIMER_API_BASE` 或 `UPTIMER_API_ORIGIN` 指向的是 Worker 地址，而非 Pages 地址
+- "API returned HTML instead of JSON" 通常意味着请求打到了 Pages（返回 HTML）而非 Worker
+- 都未设置时，工作流会自动使用 Worker URL — 检查部署日志中该值是否正确解析
 
 ### 管理端返回 401
 


### PR DESCRIPTION
## What
- unify `UPTIMER_API_BASE` and `UPTIMER_API_ORIGIN` resolution in deploy workflow
- derive the missing value automatically so setting either env is enough in most deployments
- refine EN/ZH docs to clarify equivalence, fallback behavior, and troubleshooting

## Why
- fixes confusion reported in issue #20 where `UPTIMER_API_ORIGIN` alone did not affect web API base
- keeps backward compatibility while reducing setup mistakes

## Where
- `.github/workflows/deploy.yml`
- `docs/deploy-github-actions.md`
- `docs/deploy-github-actions.zh-CN.md`
- `docs/configuration-reference.md`
- `docs/configuration-reference.zh-CN.md`

## How to verify
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #20
