### PR TITLE
docs: align Cloudflare token permissions in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Click the **Fork** button at the top-right of this repository to create your own
 3. Add the following permissions:
    - `Account / Cloudflare Pages / Edit`
    - `Account / D1 / Edit`
+   - `Account / Account Settings / Read`
 4. Copy the generated token
 
 ### Step 3 — Add GitHub Secrets

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -111,6 +111,7 @@ Admin ─────────►│  Workers (Hono API)                     
 3. 添加以下权限：
    - `Account / Cloudflare Pages / Edit`
    - `Account / D1 / Edit`
+   - `Account / Account Settings / Read`
 4. 复制生成的 Token
 
 ### 第 3 步 — 添加 GitHub Secrets


### PR DESCRIPTION
## What
- add `Account / Account Settings / Read` to the Cloudflare API token permissions list in both READMEs
- keep the permission list formatting consistent with the other items (no extra emphasis text)

## Why
- align quick-deploy docs with the deployment workflow behavior that resolves Cloudflare Account ID

## Where
- `README.md`
- `README.zh-CN.md`

## How to verify
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
