### PR TITLE
fix(worker): start uptime windows from first probe

### DIFF
--- a/apps/worker/src/public/status.ts
+++ b/apps/worker/src/public/status.ts
@@ -373,19 +373,28 @@ async function readUptimeRatingLevel(db: D1Database): Promise<1 | 2 | 3 | 4 | 5>
 
 async function computeTodayPartialUptimeBatch(
   db: D1Database,
-  monitors: Array<{ id: number; interval_sec: number; created_at: number }>,
+  monitors: Array<{
+    id: number;
+    interval_sec: number;
+    created_at: number;
+    last_checked_at: number | null;
+  }>,
   rangeStart: number,
   now: number,
 ): Promise<Map<number, UptimeWindowTotals>> {
   const out = new Map<number, UptimeWindowTotals>();
 
-  const monitorById = new Map<number, { id: number; interval_sec: number; created_at: number }>();
+  const monitorById = new Map<
+    number,
+    { id: number; interval_sec: number; created_at: number; last_checked_at: number | null }
+  >();
   for (const monitor of monitors) {
     if (!Number.isFinite(monitor.id)) continue;
     monitorById.set(monitor.id, {
       id: monitor.id,
       interval_sec: monitor.interval_sec,
       created_at: monitor.created_at,
+      last_checked_at: monitor.last_checked_at,
     });
   }
   const ids = [...monitorById.keys()];
@@ -462,7 +471,18 @@ async function computeTodayPartialUptimeBatch(
     if (!monitor) continue;
 
     const monitorRangeStart = Math.max(rangeStart, monitor.created_at);
-    if (now <= monitorRangeStart) {
+    const checks = checksById.get(id) ?? [];
+    const checksSinceMonitorStart =
+      monitorRangeStart > rangeStart
+        ? checks.filter((check) => check.checked_at >= monitorRangeStart)
+        : checks;
+    const firstCheckAt = checksSinceMonitorStart.find(
+      (check) => check.checked_at >= monitorRangeStart,
+    )?.checked_at;
+    const effectiveRangeStart =
+      firstCheckAt ?? (monitor.last_checked_at === null ? null : monitorRangeStart);
+
+    if (effectiveRangeStart === null || now <= effectiveRangeStart) {
       out.set(id, {
         total_sec: 0,
         downtime_sec: 0,
@@ -473,25 +493,23 @@ async function computeTodayPartialUptimeBatch(
       continue;
     }
 
-    const total_sec = now - monitorRangeStart;
+    const total_sec = now - effectiveRangeStart;
 
     const downtimeIntervals = mergeIntervals(
       (downtimeById.get(id) ?? [])
         .map((it) => ({
-          start: Math.max(it.start, monitorRangeStart),
+          start: Math.max(it.start, effectiveRangeStart),
           end: Math.min(it.end, now),
         }))
         .filter((it) => it.end > it.start),
     );
     const downtime_sec = sumIntervals(downtimeIntervals);
 
-    const checks = checksById.get(id) ?? [];
-    const checksForUnknown =
-      monitorRangeStart > rangeStart
-        ? checks.filter((check) => check.checked_at >= monitorRangeStart)
-        : checks;
+    const checksForUnknown = checksSinceMonitorStart.filter(
+      (check) => check.checked_at >= effectiveRangeStart,
+    );
     const unknownIntervals = buildUnknownIntervals(
-      monitorRangeStart,
+      effectiveRangeStart,
       now,
       monitor.interval_sec,
       checksForUnknown,
@@ -643,6 +661,7 @@ export async function computePublicStatusPayload(
             id: monitor.id,
             interval_sec: monitor.interval_sec,
             created_at: monitor.created_at,
+            last_checked_at: monitor.last_checked_at,
           })),
           Math.max(todayStartAt, rangeStart),
           rangeEnd,

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -796,19 +796,44 @@ publicRoutes.get('/monitors/:id/latency', async (c) => {
 
 type OutageRow = { started_at: number; ended_at: number | null };
 
+function resolveUptimeRangeStart(
+  rangeStart: number,
+  rangeEnd: number,
+  lastCheckedAt: number | null,
+  checks: Array<{ checked_at: number; status: string }>,
+): number | null {
+  if (rangeEnd <= rangeStart) return null;
+
+  const firstCheckAt = checks.find(
+    (check) => check.checked_at >= rangeStart && check.checked_at < rangeEnd,
+  )?.checked_at;
+  if (firstCheckAt !== undefined) {
+    return firstCheckAt;
+  }
+
+  return lastCheckedAt === null ? null : rangeStart;
+}
+
 publicRoutes.get('/monitors/:id/uptime', async (c) => {
   const id = z.coerce.number().int().positive().parse(c.req.param('id'));
   const range = uptimeRangeSchema.optional().default('24h').parse(c.req.query('range'));
 
   const monitor = await c.env.DB.prepare(
     `
-      SELECT id, name, interval_sec, created_at
-      FROM monitors
-      WHERE id = ?1 AND is_active = 1
+      SELECT m.id, m.name, m.interval_sec, m.created_at, s.last_checked_at
+      FROM monitors m
+      LEFT JOIN monitor_state s ON s.monitor_id = m.id
+      WHERE m.id = ?1 AND m.is_active = 1
     `,
   )
     .bind(id)
-    .first<{ id: number; name: string; interval_sec: number; created_at: number }>();
+    .first<{
+      id: number;
+      name: string;
+      interval_sec: number;
+      created_at: number;
+      last_checked_at: number | null;
+    }>();
 
   if (!monitor) {
     throw new AppError(404, 'NOT_FOUND', 'Monitor not found');
@@ -818,32 +843,6 @@ publicRoutes.get('/monitors/:id/uptime', async (c) => {
   const rangeEnd = Math.floor(now / 60) * 60;
   const requestedRangeStart = rangeEnd - rangeToSeconds(range);
   const rangeStart = Math.max(requestedRangeStart, monitor.created_at);
-
-  const total_sec = Math.max(0, rangeEnd - rangeStart);
-
-  const { results: outageRows } = await c.env.DB.prepare(
-    `
-      SELECT started_at, ended_at
-      FROM outages
-      WHERE monitor_id = ?1
-        AND started_at < ?2
-        AND (ended_at IS NULL OR ended_at > ?3)
-      ORDER BY started_at
-    `,
-  )
-    .bind(id, rangeEnd, rangeStart)
-    .all<OutageRow>();
-
-  const downtimeIntervals = mergeIntervals(
-    (outageRows ?? [])
-      .map((r) => {
-        const start = Math.max(r.started_at, rangeStart);
-        const end = Math.min(r.ended_at ?? rangeEnd, rangeEnd);
-        return { start, end };
-      })
-      .filter((it) => it.end > it.start),
-  );
-  const downtime_sec = sumIntervals(downtimeIntervals);
 
   const checksStart = rangeStart - monitor.interval_sec * 2;
   const { results: checkRows } = await c.env.DB.prepare(
@@ -859,11 +858,58 @@ publicRoutes.get('/monitors/:id/uptime', async (c) => {
     .bind(id, checksStart, rangeEnd)
     .all<{ checked_at: number; status: string }>();
 
-  const unknownIntervals = buildUnknownIntervals(
+  const checks = (checkRows ?? []).map((r) => ({ checked_at: r.checked_at, status: toCheckStatus(r.status) }));
+  const effectiveRangeStart = resolveUptimeRangeStart(
     rangeStart,
     rangeEnd,
+    monitor.last_checked_at,
+    checks,
+  );
+  const rangeStartAt = effectiveRangeStart ?? rangeStart;
+  if (effectiveRangeStart === null || rangeEnd <= effectiveRangeStart) {
+    return c.json({
+      monitor: { id: monitor.id, name: monitor.name },
+      range,
+      range_start_at: rangeStartAt,
+      range_end_at: rangeEnd,
+      total_sec: 0,
+      downtime_sec: 0,
+      unknown_sec: 0,
+      uptime_sec: 0,
+      uptime_pct: 0,
+    });
+  }
+
+  const total_sec = rangeEnd - effectiveRangeStart;
+  const { results: outageRows } = await c.env.DB.prepare(
+    `
+      SELECT started_at, ended_at
+      FROM outages
+      WHERE monitor_id = ?1
+        AND started_at < ?2
+        AND (ended_at IS NULL OR ended_at > ?3)
+      ORDER BY started_at
+    `,
+  )
+    .bind(id, rangeEnd, effectiveRangeStart)
+    .all<OutageRow>();
+
+  const downtimeIntervals = mergeIntervals(
+    (outageRows ?? [])
+      .map((r) => {
+        const start = Math.max(r.started_at, effectiveRangeStart);
+        const end = Math.min(r.ended_at ?? rangeEnd, rangeEnd);
+        return { start, end };
+      })
+      .filter((it) => it.end > it.start),
+  );
+  const downtime_sec = sumIntervals(downtimeIntervals);
+
+  const unknownIntervals = buildUnknownIntervals(
+    effectiveRangeStart,
+    rangeEnd,
     monitor.interval_sec,
-    (checkRows ?? []).map((r) => ({ checked_at: r.checked_at, status: toCheckStatus(r.status) })),
+    checks.filter((check) => check.checked_at >= effectiveRangeStart),
   );
 
   // Unknown time is treated as "unavailable" per Application.md; exclude overlap with downtime to avoid double counting.
@@ -879,7 +925,7 @@ publicRoutes.get('/monitors/:id/uptime', async (c) => {
   return c.json({
     monitor: { id: monitor.id, name: monitor.name },
     range,
-    range_start_at: rangeStart,
+    range_start_at: rangeStartAt,
     range_end_at: rangeEnd,
     total_sec,
     downtime_sec,
@@ -893,37 +939,13 @@ async function computePartialUptimeTotals(
   db: D1Database,
   monitorId: number,
   intervalSec: number,
+  lastCheckedAt: number | null,
   rangeStart: number,
   rangeEnd: number,
 ): Promise<{ total_sec: number; downtime_sec: number; unknown_sec: number; uptime_sec: number }> {
-  const total_sec = Math.max(0, rangeEnd - rangeStart);
-  if (total_sec === 0) {
+  if (rangeEnd <= rangeStart) {
     return { total_sec: 0, downtime_sec: 0, unknown_sec: 0, uptime_sec: 0 };
   }
-
-  const { results: outageRows } = await db
-    .prepare(
-      `
-      SELECT started_at, ended_at
-      FROM outages
-      WHERE monitor_id = ?1
-        AND started_at < ?2
-        AND (ended_at IS NULL OR ended_at > ?3)
-      ORDER BY started_at
-    `,
-    )
-    .bind(monitorId, rangeEnd, rangeStart)
-    .all<{ started_at: number; ended_at: number | null }>();
-
-  const downtimeIntervals = mergeIntervals(
-    (outageRows ?? [])
-      .map((r) => ({
-        start: Math.max(r.started_at, rangeStart),
-        end: Math.min(r.ended_at ?? rangeEnd, rangeEnd),
-      }))
-      .filter((it) => it.end > it.start),
-  );
-  const downtime_sec = sumIntervals(downtimeIntervals);
 
   const checksStart = rangeStart - intervalSec * 2;
   const { results: checkRows } = await db
@@ -940,11 +962,42 @@ async function computePartialUptimeTotals(
     .bind(monitorId, checksStart, rangeEnd)
     .all<{ checked_at: number; status: string }>();
 
+  const checks = (checkRows ?? []).map((r) => ({ checked_at: r.checked_at, status: toCheckStatus(r.status) }));
+  const effectiveRangeStart = resolveUptimeRangeStart(rangeStart, rangeEnd, lastCheckedAt, checks);
+  if (effectiveRangeStart === null || rangeEnd <= effectiveRangeStart) {
+    return { total_sec: 0, downtime_sec: 0, unknown_sec: 0, uptime_sec: 0 };
+  }
+
+  const total_sec = rangeEnd - effectiveRangeStart;
+  const { results: outageRows } = await db
+    .prepare(
+      `
+      SELECT started_at, ended_at
+      FROM outages
+      WHERE monitor_id = ?1
+        AND started_at < ?2
+        AND (ended_at IS NULL OR ended_at > ?3)
+      ORDER BY started_at
+    `,
+    )
+    .bind(monitorId, rangeEnd, effectiveRangeStart)
+    .all<{ started_at: number; ended_at: number | null }>();
+
+  const downtimeIntervals = mergeIntervals(
+    (outageRows ?? [])
+      .map((r) => ({
+        start: Math.max(r.started_at, effectiveRangeStart),
+        end: Math.min(r.ended_at ?? rangeEnd, rangeEnd),
+      }))
+      .filter((it) => it.end > it.start),
+  );
+  const downtime_sec = sumIntervals(downtimeIntervals);
+
   const unknownIntervals = buildUnknownIntervals(
-    rangeStart,
+    effectiveRangeStart,
     rangeEnd,
     intervalSec,
-    (checkRows ?? []).map((r) => ({ checked_at: r.checked_at, status: toCheckStatus(r.status) })),
+    checks.filter((check) => check.checked_at >= effectiveRangeStart),
   );
   const unknown_sec = Math.max(
     0,
@@ -968,12 +1021,20 @@ publicRoutes.get('/analytics/uptime', async (c) => {
 
   const { results: monitorRows } = await c.env.DB.prepare(
     `
-      SELECT id, name, type, interval_sec
-      FROM monitors
-      WHERE is_active = 1
-      ORDER BY id
+      SELECT m.id, m.name, m.type, m.interval_sec, m.created_at, s.last_checked_at
+      FROM monitors m
+      LEFT JOIN monitor_state s ON s.monitor_id = m.id
+      WHERE m.is_active = 1
+      ORDER BY m.id
     `,
-  ).all<{ id: number; name: string; type: string; interval_sec: number }>();
+  ).all<{
+    id: number;
+    name: string;
+    type: string;
+    interval_sec: number;
+    created_at: number;
+    last_checked_at: number | null;
+  }>();
 
   const monitors = monitorRows ?? [];
 
@@ -1035,6 +1096,7 @@ publicRoutes.get('/analytics/uptime', async (c) => {
               c.env.DB,
               m.id,
               m.interval_sec,
+              m.last_checked_at,
               partialStart,
               partialEnd,
             )

--- a/apps/worker/test/public-status.test.ts
+++ b/apps/worker/test/public-status.test.ts
@@ -197,7 +197,7 @@ describe('public/status payload regression', () => {
     ]);
   });
 
-  it('clamps synthetic today uptime to monitor creation time for newly created monitors', async () => {
+  it('starts synthetic today uptime at the first probe for newly created monitors', async () => {
     const dayStart = 1_728_000_000;
     const now = dayStart + 36_600; // 10h 10m into current UTC day
     const newMonitorCreatedAt = now - 600; // created 10m ago
@@ -286,12 +286,106 @@ describe('public/status payload regression', () => {
     expect(today).toBeDefined();
     expect(today).toMatchObject({
       day_start_at: dayStart,
-      total_sec: 600,
+      total_sec: 120,
       downtime_sec: 0,
-      unknown_sec: 480,
+      unknown_sec: 0,
       uptime_sec: 120,
     });
-    expect(today?.uptime_pct).toBeCloseTo(20, 6);
+    expect(today?.uptime_pct).toBeCloseTo(100, 6);
+  });
+
+  it('does not count unknown time before the first probe when monitor has never been checked', async () => {
+    const dayStart = 1_728_000_000;
+    const now = dayStart + 36_600; // 10h 10m into current UTC day
+    const newMonitorCreatedAt = now - 600; // created 10m ago
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: 'from monitors m',
+        all: () => [
+          {
+            id: 11,
+            name: 'Legacy Monitor',
+            type: 'http',
+            group_name: null,
+            group_sort_order: 0,
+            sort_order: 0,
+            interval_sec: 60,
+            created_at: dayStart - 5 * 86_400,
+            state_status: 'up',
+            last_checked_at: now - 30,
+            last_latency_ms: 50,
+          },
+          {
+            id: 12,
+            name: 'New Monitor',
+            type: 'http',
+            group_name: null,
+            group_sort_order: 0,
+            sort_order: 1,
+            interval_sec: 60,
+            created_at: newMonitorCreatedAt,
+            state_status: 'unknown',
+            last_checked_at: null,
+            last_latency_ms: null,
+          },
+        ],
+      },
+      {
+        match: 'select distinct mwm.monitor_id',
+        all: () => [],
+      },
+      {
+        match: 'select value from settings where key = ?1',
+        first: (args) => (args[0] === 'uptime_rating_level' ? { value: '3' } : null),
+      },
+      {
+        match: 'row_number() over',
+        all: () => [{ monitor_id: 11, checked_at: now - 60, status: 'up', latency_ms: 50 }],
+      },
+      {
+        match: 'from monitor_daily_rollups',
+        all: () => [],
+      },
+      {
+        match: 'select monitor_id, started_at, ended_at',
+        all: () => [],
+      },
+      {
+        match: 'select monitor_id, checked_at, status from check_results',
+        all: () => [],
+      },
+      {
+        match: 'from incidents',
+        all: () => [],
+      },
+      {
+        match: 'from maintenance_windows where starts_at <= ?1 and ends_at > ?1',
+        all: () => [],
+      },
+      {
+        match: 'from maintenance_windows where starts_at > ?1',
+        all: () => [],
+      },
+      {
+        match: 'select key, value from settings',
+        all: () => [{ key: 'site_timezone', value: 'UTC' }],
+      },
+    ];
+
+    const payload = await computePublicStatusPayload(createFakeD1Database(handlers), now);
+    const monitor = payload.monitors.find((m) => m.id === 12);
+    const today = monitor?.uptime_days.at(-1);
+
+    expect(today).toBeDefined();
+    expect(today).toMatchObject({
+      day_start_at: dayStart,
+      total_sec: 0,
+      downtime_sec: 0,
+      unknown_sec: 0,
+      uptime_sec: 0,
+    });
+    expect(today?.uptime_pct).toBeNull();
   });
 
   it('does not seed synthetic today uptime from checks before monitor creation', async () => {
@@ -493,11 +587,11 @@ describe('public/status payload regression', () => {
     expect(today).toBeDefined();
     expect(today).toMatchObject({
       day_start_at: dayStart,
-      total_sec: 300,
-      downtime_sec: 60,
-      unknown_sec: 30,
+      total_sec: 210,
+      downtime_sec: 0,
+      unknown_sec: 0,
       uptime_sec: 210,
     });
-    expect(today?.uptime_pct).toBeCloseTo(70, 6);
+    expect(today?.uptime_pct).toBeCloseTo(100, 6);
   });
 });

--- a/apps/worker/test/public-uptime-routes.test.ts
+++ b/apps/worker/test/public-uptime-routes.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Env } from '../src/env';
+import { publicRoutes } from '../src/routes/public';
+import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
+
+type CacheStore = Map<string, Response>;
+
+function installCacheMock(store: CacheStore) {
+  const open = vi.fn(async () => ({
+    async match(request: Request) {
+      const cached = store.get(request.url);
+      return cached ? cached.clone() : undefined;
+    },
+    async put(request: Request, response: Response) {
+      store.set(request.url, response.clone());
+    },
+  }));
+
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: { open },
+  });
+
+  return open;
+}
+
+async function requestPublic(path: string, handlers: FakeD1QueryHandler[]) {
+  const env = { DB: createFakeD1Database(handlers) } as unknown as Env;
+  const res = await publicRoutes.fetch(
+    new Request(`https://status.example.com${path}`),
+    env,
+    { waitUntil: vi.fn() } as unknown as ExecutionContext,
+  );
+  const body = (await res.json()) as Record<string, unknown>;
+  return { res, body };
+}
+
+describe('public routes uptime regression', () => {
+  const originalCaches = (globalThis as { caches?: unknown }).caches;
+
+  beforeEach(() => {
+    installCacheMock(new Map());
+  });
+
+  afterEach(() => {
+    if (originalCaches === undefined) {
+      delete (globalThis as { caches?: unknown }).caches;
+    } else {
+      Object.defineProperty(globalThis, 'caches', {
+        configurable: true,
+        value: originalCaches,
+      });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('keeps monitor uptime window start for existing monitors instead of snapping to first in-range probe', async () => {
+    const rangeEnd = 1_728_000_000;
+    const rangeStart = rangeEnd - 86_400;
+    const firstInRangeCheckAt = rangeStart + 80_000;
+
+    vi.spyOn(Date, 'now').mockReturnValue(rangeEnd * 1000 + 15_000);
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: 'from monitors m',
+        first: () => ({
+          id: 12,
+          name: 'Legacy Monitor',
+          interval_sec: 60,
+          created_at: rangeStart - 5 * 86_400,
+          last_checked_at: rangeEnd - 30,
+        }),
+      },
+      {
+        match: 'from check_results',
+        all: () => [
+          { checked_at: rangeStart - 60, status: 'up' },
+          { checked_at: firstInRangeCheckAt, status: 'up' },
+        ],
+      },
+      {
+        match: 'from outages',
+        all: () => [
+          {
+            started_at: rangeStart + 600,
+            ended_at: rangeStart + 900,
+          },
+        ],
+      },
+    ];
+
+    const { res, body } = await requestPublic('/monitors/12/uptime?range=24h', handlers);
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      range_start_at: rangeStart,
+      range_end_at: rangeEnd,
+      total_sec: 86_400,
+      downtime_sec: 300,
+    });
+  });
+
+  it('keeps partial-day totals for existing monitors in public uptime overview', async () => {
+    const dayStart = 1_728_000_000;
+    const rangeEnd = dayStart + 3_600;
+    const firstInRangeCheckAt = dayStart + 1_800;
+
+    vi.spyOn(Date, 'now').mockReturnValue(rangeEnd * 1000 + 10_000);
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: 'from monitors m',
+        all: () => [
+          {
+            id: 21,
+            name: 'Core API',
+            type: 'http',
+            interval_sec: 60,
+            created_at: dayStart - 10 * 86_400,
+            last_checked_at: rangeEnd - 30,
+          },
+        ],
+      },
+      {
+        match: 'from monitor_daily_rollups',
+        all: () => [],
+      },
+      {
+        match: 'from check_results',
+        all: () => [
+          { checked_at: dayStart - 60, status: 'up' },
+          { checked_at: firstInRangeCheckAt, status: 'up' },
+        ],
+      },
+      {
+        match: 'from outages',
+        all: () => [
+          {
+            started_at: dayStart + 300,
+            ended_at: dayStart + 600,
+          },
+        ],
+      },
+    ];
+
+    const { res, body } = await requestPublic('/analytics/uptime?range=30d', handlers);
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      range_end_at: rangeEnd,
+      overall: {
+        total_sec: 3_600,
+        downtime_sec: 300,
+      },
+      monitors: [
+        {
+          id: 21,
+          total_sec: 3_600,
+          downtime_sec: 300,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes incorrect UNKNOWN accounting for newly created monitors before their first probe.
The uptime window now starts at the first observed check within range, so pre-probe time is no longer treated as UNKNOWN/unavailable.

## Changes

- Updated synthetic "today" uptime computation in `apps/worker/src/public/status.ts` to use an effective range start based on first probe time.
- Added `last_checked_at` context into uptime window resolution to distinguish "never checked" monitors.
- Unified public uptime endpoint behavior in `apps/worker/src/routes/public.ts`:
  - `/api/v1/public/monitors/:id/uptime`
  - `/api/v1/public/analytics/uptime` (partial-day path)
- Added/updated regression coverage in `apps/worker/test/public-status.test.ts`:
  - First-probe start behavior
  - Never-checked monitor behavior
  - Pre-creation downtime not counted

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] Manually tested