### PR TITLE
fix(web): public pages use browser timezone

### DIFF
--- a/apps/web/src/pages/IncidentHistoryPage.tsx
+++ b/apps/web/src/pages/IncidentHistoryPage.tsx
@@ -16,7 +16,7 @@ import {
   ThemeToggle,
 } from '../components/ui';
 import { incidentImpactLabel, incidentStatusLabel } from '../i18n/labels';
-import { formatDateTime } from '../utils/datetime';
+import { formatDateTime, getBrowserTimeZone } from '../utils/datetime';
 
 function formatError(err: unknown): string | undefined {
   if (!err) return undefined;
@@ -175,7 +175,7 @@ export function IncidentHistoryPage() {
   const [selectedIncident, setSelectedIncident] = useState<Incident | null>(null);
 
   const statusQuery = useQuery({ queryKey: ['status'], queryFn: fetchStatus });
-  const timeZone = statusQuery.data?.site_timezone ?? 'UTC';
+  const timeZone = getBrowserTimeZone() ?? statusQuery.data?.site_timezone ?? 'UTC';
   useApplyServerLocaleSetting(statusQuery.data?.site_locale);
 
   const query = useQuery({

--- a/apps/web/src/pages/MaintenanceHistoryPage.tsx
+++ b/apps/web/src/pages/MaintenanceHistoryPage.tsx
@@ -8,7 +8,7 @@ import { ApiError, fetchPublicMaintenanceWindows, fetchStatus } from '../api/cli
 import type { MaintenanceWindow } from '../api/types';
 import { Markdown } from '../components/Markdown';
 import { Button, Card, ThemeToggle } from '../components/ui';
-import { formatDateTime } from '../utils/datetime';
+import { formatDateTime, getBrowserTimeZone } from '../utils/datetime';
 
 function formatError(err: unknown): string | undefined {
   if (!err) return undefined;
@@ -24,7 +24,7 @@ export function MaintenanceHistoryPage() {
   const [nextCursor, setNextCursor] = useState<number | null>(null);
 
   const statusQuery = useQuery({ queryKey: ['status'], queryFn: fetchStatus });
-  const timeZone = statusQuery.data?.site_timezone ?? 'UTC';
+  const timeZone = getBrowserTimeZone() ?? statusQuery.data?.site_timezone ?? 'UTC';
   useApplyServerLocaleSetting(statusQuery.data?.site_locale);
   const monitorNames = useMemo(
     () => new Map((statusQuery.data?.monitors ?? []).map((m) => [m.id, m.name] as const)),

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -17,7 +17,7 @@ import { DayDowntimeModal } from '../components/DayDowntimeModal';
 import { Markdown } from '../components/Markdown';
 import { MonitorCard } from '../components/MonitorCard';
 import { incidentImpactLabel, incidentStatusLabel } from '../i18n/labels';
-import { formatDateTime } from '../utils/datetime';
+import { formatDateTime, getBrowserTimeZone } from '../utils/datetime';
 import { Badge, Card, MODAL_OVERLAY_CLASS, MODAL_PANEL_CLASS, ThemeToggle } from '../components/ui';
 
 type MaintenanceHistoryPreview = Pick<
@@ -348,7 +348,7 @@ export function StatusPage() {
   });
 
   const derivedTitle = statusQuery.data?.site_title || 'Uptimer';
-  const derivedTimeZone = statusQuery.data?.site_timezone || 'UTC';
+  const derivedTimeZone = getBrowserTimeZone() || statusQuery.data?.site_timezone || 'UTC';
 
   useApplyServerLocaleSetting(statusQuery.data?.site_locale);
 

--- a/apps/web/src/utils/datetime.ts
+++ b/apps/web/src/utils/datetime.ts
@@ -1,6 +1,15 @@
 export type TimeZone = string;
 export type Locale = string;
 
+export function getBrowserTimeZone(): TimeZone | undefined {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone?.trim();
+    return tz ? tz : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveLocale(locale?: Locale): Locale | undefined {
   if (locale && locale.trim().length > 0) return locale;
   if (typeof document === 'undefined') return undefined;


### PR DESCRIPTION
## What
- Use browser timezone for public-page timestamp display (status / incident history / maintenance history)
- Add `getBrowserTimeZone()` helper with safe fallback

## Why
- Fixes issue #32 where displayed time should follow the visitor browser timezone

## How
- Prefer `Intl.DateTimeFormat().resolvedOptions().timeZone`
- Fallback to `site_timezone`, then `UTC` if unavailable

## Verify
- `pnpm --filter @uptimer/web typecheck`
- `pnpm --filter @uptimer/web lint`
- Override browser timezone in DevTools and confirm timestamps change

Closes #32
