### PR TITLE
Add hidden monitors for public status

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -108,6 +108,24 @@ function getAuthHeaders(): HeadersInit {
   return { Authorization: `Bearer ${token}` };
 }
 
+function getOptionalPublicAuth(): {
+  fetchInit: RequestInit;
+  shouldBypassCache: boolean;
+} {
+  const token = localStorage.getItem('admin_token')?.trim();
+  if (!token) {
+    return { fetchInit: {}, shouldBypassCache: false };
+  }
+
+  return {
+    fetchInit: {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    },
+    shouldBypassCache: true,
+  };
+}
+
 function safeJsonParse(text: string): unknown | null {
   const trimmed = text.trim();
   if (!trimmed) return null;
@@ -150,21 +168,24 @@ async function handleResponse<T>(res: Response): Promise<T> {
 // Public API
 export async function fetchStatus(): Promise<StatusResponse> {
   const url = `${API_BASE}/public/status`;
-  const cached = getCachedPublic<StatusResponse>(url);
+  const auth = getOptionalPublicAuth();
+  const cached = auth.shouldBypassCache ? null : getCachedPublic<StatusResponse>(url);
   if (cached) return cached;
 
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, auth.fetchInit);
     const data = await handleResponse<StatusResponse>(res);
-    setCachedPublic(url, data);
-    writePersistedStatusCache(data);
+    if (!auth.shouldBypassCache) {
+      setCachedPublic(url, data);
+      writePersistedStatusCache(data);
+    }
     return data;
   } catch (err) {
     // Prefer returning a cached snapshot over a hard error on weak networks.
-    const persisted = readPersistedStatusCache(10 * 60_000);
+    const persisted = auth.shouldBypassCache ? null : readPersistedStatusCache(10 * 60_000);
     if (persisted) return persisted;
 
-    const stale = getCachedPublic<StatusResponse>(url);
+    const stale = auth.shouldBypassCache ? null : getCachedPublic<StatusResponse>(url);
     if (stale) return stale;
 
     throw err;
@@ -176,15 +197,16 @@ export async function fetchLatency(
   range: '24h' = '24h',
 ): Promise<LatencyResponse> {
   const url = `${API_BASE}/public/monitors/${monitorId}/latency?range=${range}`;
-  const cached = getCachedPublic<LatencyResponse>(url);
+  const auth = getOptionalPublicAuth();
+  const cached = auth.shouldBypassCache ? null : getCachedPublic<LatencyResponse>(url);
   if (cached) return cached;
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, auth.fetchInit);
     const data = await handleResponse<LatencyResponse>(res);
-    setCachedPublic(url, data);
+    if (!auth.shouldBypassCache) setCachedPublic(url, data);
     return data;
   } catch (err) {
-    const stale = getCachedPublic<LatencyResponse>(url);
+    const stale = auth.shouldBypassCache ? null : getCachedPublic<LatencyResponse>(url);
     if (stale) return stale;
     throw err;
   }
@@ -195,15 +217,16 @@ export async function fetchUptime(
   range: '24h' | '7d' | '30d' = '24h',
 ): Promise<UptimeResponse> {
   const url = `${API_BASE}/public/monitors/${monitorId}/uptime?range=${range}`;
-  const cached = getCachedPublic<UptimeResponse>(url);
+  const auth = getOptionalPublicAuth();
+  const cached = auth.shouldBypassCache ? null : getCachedPublic<UptimeResponse>(url);
   if (cached) return cached;
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, auth.fetchInit);
     const data = await handleResponse<UptimeResponse>(res);
-    setCachedPublic(url, data);
+    if (!auth.shouldBypassCache) setCachedPublic(url, data);
     return data;
   } catch (err) {
-    const stale = getCachedPublic<UptimeResponse>(url);
+    const stale = auth.shouldBypassCache ? null : getCachedPublic<UptimeResponse>(url);
     if (stale) return stale;
     throw err;
   }
@@ -213,15 +236,18 @@ export async function fetchPublicUptimeOverview(
   range: '30d' | '90d' = '30d',
 ): Promise<PublicUptimeOverviewResponse> {
   const url = `${API_BASE}/public/analytics/uptime?range=${range}`;
-  const cached = getCachedPublic<PublicUptimeOverviewResponse>(url);
+  const auth = getOptionalPublicAuth();
+  const cached = auth.shouldBypassCache ? null : getCachedPublic<PublicUptimeOverviewResponse>(url);
   if (cached) return cached;
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, auth.fetchInit);
     const data = await handleResponse<PublicUptimeOverviewResponse>(res);
-    setCachedPublic(url, data);
+    if (!auth.shouldBypassCache) setCachedPublic(url, data);
     return data;
   } catch (err) {
-    const stale = getCachedPublic<PublicUptimeOverviewResponse>(url);
+    const stale = auth.shouldBypassCache
+      ? null
+      : getCachedPublic<PublicUptimeOverviewResponse>(url);
     if (stale) return stale;
     throw err;
   }
@@ -231,13 +257,14 @@ export async function fetchPublicMonitorOutages(
   monitorId: number,
   opts: { range?: '30d'; limit?: number; cursor?: number } = {},
 ): Promise<MonitorOutagesResponse> {
+  const auth = getOptionalPublicAuth();
   const qs = new URLSearchParams();
   qs.set('range', opts.range ?? '30d');
   qs.set('limit', String(opts.limit ?? 200));
   if (opts.cursor !== undefined) qs.set('cursor', String(opts.cursor));
 
   const url = `${API_BASE}/public/monitors/${monitorId}/outages?${qs.toString()}`;
-  const res = await fetch(url);
+  const res = await fetch(url, auth.fetchInit);
   return handleResponse<MonitorOutagesResponse>(res);
 }
 
@@ -389,10 +416,11 @@ export async function fetchPublicIncidents(
   cursor?: number,
   opts: { resolvedOnly?: boolean } = {},
 ): Promise<PublicIncidentsResponse> {
+  const auth = getOptionalPublicAuth();
   const qs = new URLSearchParams({ limit: String(limit) });
   if (opts.resolvedOnly) qs.set('resolved_only', '1');
   if (cursor) qs.set('cursor', String(cursor));
-  const res = await fetch(`${API_BASE}/public/incidents?${qs.toString()}`);
+  const res = await fetch(`${API_BASE}/public/incidents?${qs.toString()}`, auth.fetchInit);
   return handleResponse<PublicIncidentsResponse>(res);
 }
 
@@ -401,9 +429,13 @@ export async function fetchPublicMaintenanceWindows(
   limit = 20,
   cursor?: number,
 ): Promise<PublicMaintenanceWindowsResponse> {
+  const auth = getOptionalPublicAuth();
   const qs = new URLSearchParams({ limit: String(limit) });
   if (cursor) qs.set('cursor', String(cursor));
-  const res = await fetch(`${API_BASE}/public/maintenance-windows?${qs.toString()}`);
+  const res = await fetch(
+    `${API_BASE}/public/maintenance-windows?${qs.toString()}`,
+    auth.fetchInit,
+  );
   return handleResponse<PublicMaintenanceWindowsResponse>(res);
 }
 
@@ -412,8 +444,12 @@ export async function fetchPublicDayContext(
   monitorId: number,
   dayStartAt: number,
 ): Promise<PublicDayContextResponse> {
+  const auth = getOptionalPublicAuth();
   const qs = new URLSearchParams({ day_start_at: String(dayStartAt) });
-  const res = await fetch(`${API_BASE}/public/monitors/${monitorId}/day-context?${qs.toString()}`);
+  const res = await fetch(
+    `${API_BASE}/public/monitors/${monitorId}/day-context?${qs.toString()}`,
+    auth.fetchInit,
+  );
   return handleResponse<PublicDayContextResponse>(res);
 }
 

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -266,6 +266,7 @@ export interface AdminMonitor {
   group_name: string | null;
   group_sort_order: number;
   sort_order: number;
+  show_on_status_page: boolean;
   interval_sec: number;
   timeout_ms: number;
   http_method: string | null;
@@ -292,6 +293,7 @@ export interface CreateMonitorInput {
   group_name?: string;
   group_sort_order?: number;
   sort_order?: number;
+  show_on_status_page?: boolean;
   interval_sec?: number;
   timeout_ms?: number;
   http_method?: string;
@@ -309,6 +311,7 @@ export interface PatchMonitorInput {
   group_name?: string | null;
   group_sort_order?: number;
   sort_order?: number;
+  show_on_status_page?: boolean;
   interval_sec?: number;
   timeout_ms?: number;
   http_method?: string;

--- a/apps/web/src/app/AuthContext.tsx
+++ b/apps/web/src/app/AuthContext.tsx
@@ -3,14 +3,30 @@ import {
   useContext,
   useState,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   type ReactNode,
 } from 'react';
 
 import { verifyAdminToken } from '../api/client';
+import { queryClient } from './queryClient';
 
 const LS_ADMIN_TOKEN_KEY = 'admin_token';
+const AUTH_SENSITIVE_PUBLIC_QUERY_KEYS = [
+  ['status'],
+  ['latency'],
+  ['public-incidents'],
+  ['public-maintenance-windows'],
+  ['public-day-context'],
+  ['public-monitor-outages'],
+] as const;
+
+function resetAuthSensitivePublicQueries() {
+  for (const key of AUTH_SENSITIVE_PUBLIC_QUERY_KEYS) {
+    queryClient.resetQueries({ queryKey: key });
+  }
+}
 
 type AuthStatus = 'unauthenticated' | 'checking' | 'authenticated';
 
@@ -33,6 +49,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<AuthStatus>(() => (token ? 'checking' : 'unauthenticated'));
 
   const verifyInFlight = useRef<Promise<boolean> | null>(null);
+  const didInitTokenSync = useRef(false);
+
+  useEffect(() => {
+    if (!didInitTokenSync.current) {
+      didInitTokenSync.current = true;
+      if (!token) return;
+    }
+
+    resetAuthSensitivePublicQueries();
+  }, [token]);
 
   const logout = useCallback(() => {
     localStorage.removeItem(LS_ADMIN_TOKEN_KEY);

--- a/apps/web/src/components/MonitorForm.tsx
+++ b/apps/web/src/components/MonitorForm.tsx
@@ -179,6 +179,7 @@ export function MonitorForm(props: CreateProps | EditProps) {
   const [groupName, setGroupName] = useState(monitor?.group_name ?? '');
   const [groupSortOrder, setGroupSortOrder] = useState(monitor?.group_sort_order ?? 0);
   const [sortOrder, setSortOrder] = useState(monitor?.sort_order ?? 0);
+  const [showOnStatusPage, setShowOnStatusPage] = useState(monitor?.show_on_status_page ?? true);
   const [type, setType] = useState<MonitorType>(monitor?.type ?? 'http');
   const [target, setTarget] = useState(monitor?.target ?? '');
   const [intervalSec, setIntervalSec] = useState(monitor?.interval_sec ?? 60);
@@ -236,6 +237,7 @@ export function MonitorForm(props: CreateProps | EditProps) {
       target: target.trim(),
       group_sort_order: groupSortOrder,
       sort_order: sortOrder,
+      show_on_status_page: showOnStatusPage,
       interval_sec: intervalSec,
       timeout_ms: timeoutMs,
     };
@@ -383,6 +385,25 @@ export function MonitorForm(props: CreateProps | EditProps) {
           />
           <div className={FIELD_HELP_CLASS}>{t('monitor_form.sort_order_help')}</div>
         </div>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-slate-50/70 p-4 dark:border-slate-700 dark:bg-slate-800/40">
+        <label className="flex items-start gap-3 text-sm text-slate-700 dark:text-slate-300">
+          <input
+            type="checkbox"
+            checked={showOnStatusPage}
+            onChange={(e) => setShowOnStatusPage(e.target.checked)}
+            className="mt-1"
+          />
+          <span>
+            <span className="font-medium text-slate-900 dark:text-slate-100">
+              {t('monitor_form.show_on_status_page')}
+            </span>
+            <span className={`mt-1 block ${FIELD_HELP_CLASS}`}>
+              {t('monitor_form.show_on_status_page_help')}
+            </span>
+          </span>
+        </label>
       </div>
 
       <div>

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -215,6 +215,7 @@ const en = {
   'admin_dashboard.resolve_incident': 'Resolve Incident',
   'admin_dashboard.create_maintenance': 'Create Maintenance',
   'admin_dashboard.edit_maintenance': 'Edit Maintenance',
+  'admin_dashboard.monitor_visibility_hidden': 'Hidden',
   'admin_dashboard.monitor_test_running': 'Running test for {name}...',
   'admin_dashboard.monitor_test_last': 'Last test: {name}',
   'admin_dashboard.monitor_test_failed': 'Monitor test failed: {name}',
@@ -308,6 +309,9 @@ const en = {
   'monitor_form.group_order_help': 'Lower groups appear first.',
   'monitor_form.sort_order': 'Sort Order',
   'monitor_form.sort_order_help': 'Lower values appear first.',
+  'monitor_form.show_on_status_page': 'Show on status page',
+  'monitor_form.show_on_status_page_help':
+    'Turn this off to hide the monitor from anonymous visitors while keeping checks and notifications active.',
   'monitor_form.type': 'Type',
   'monitor_form.type_http': 'HTTP',
   'monitor_form.type_tcp': 'TCP',
@@ -616,6 +620,7 @@ const zhCn: LocaleMessages = {
   'admin_dashboard.resolve_incident': '解决事件',
   'admin_dashboard.create_maintenance': '新建维护',
   'admin_dashboard.edit_maintenance': '编辑维护',
+  'admin_dashboard.monitor_visibility_hidden': '已隐藏',
   'admin_dashboard.monitor_test_running': '正在对 {name} 执行测试...',
   'admin_dashboard.monitor_test_last': '最近一次测试：{name}',
   'admin_dashboard.monitor_test_failed': '监控测试失败：{name}',
@@ -709,6 +714,9 @@ const zhCn: LocaleMessages = {
   'monitor_form.group_order_help': '数值越小分组越靠前。',
   'monitor_form.sort_order': '监控排序',
   'monitor_form.sort_order_help': '数值越小越靠前。',
+  'monitor_form.show_on_status_page': '在状态页显示',
+  'monitor_form.show_on_status_page_help':
+    '关闭后，匿名访客不会在状态页看到该监控，但探测和通知仍会继续。',
   'monitor_form.type': '类型',
   'monitor_form.type_http': 'HTTP',
   'monitor_form.type_tcp': 'TCP',
@@ -953,6 +961,7 @@ const zhTw: LocaleMessages = {
   'admin_dashboard.resolve_incident': '解決事件',
   'admin_dashboard.create_maintenance': '新增維護',
   'admin_dashboard.edit_maintenance': '編輯維護',
+  'admin_dashboard.monitor_visibility_hidden': '已隱藏',
 
   'admin_analytics.analytics_title': '分析',
   'admin_analytics.overview_title': '總覽',
@@ -1127,6 +1136,7 @@ const ja: LocaleMessages = {
   'admin_dashboard.resolve_incident': 'インシデントを解決',
   'admin_dashboard.create_maintenance': 'メンテナンスを作成',
   'admin_dashboard.edit_maintenance': 'メンテナンスを編集',
+  'admin_dashboard.monitor_visibility_hidden': '非公開',
 
   'admin_analytics.analytics_title': '分析',
   'admin_analytics.overview_title': '概要',
@@ -1302,6 +1312,7 @@ const es: LocaleMessages = {
   'admin_dashboard.resolve_incident': 'Resolver incidente',
   'admin_dashboard.create_maintenance': 'Crear mantenimiento',
   'admin_dashboard.edit_maintenance': 'Editar mantenimiento',
+  'admin_dashboard.monitor_visibility_hidden': 'Oculto',
 
   'admin_analytics.analytics_title': 'Analitica',
   'admin_analytics.overview_title': 'Resumen',

--- a/apps/web/src/pages/AdminDashboard.tsx
+++ b/apps/web/src/pages/AdminDashboard.tsx
@@ -217,7 +217,10 @@ function formatMonitorDisplayName(monitor: Pick<AdminMonitor, 'id' | 'name'>): s
   return `${monitor.name} (#${monitor.id})`;
 }
 
-function formatMonitorDisplayNameById(monitorId: number, monitorNameById: Map<number, string>): string {
+function formatMonitorDisplayNameById(
+  monitorId: number,
+  monitorNameById: Map<number, string>,
+): string {
   const monitorName = monitorNameById.get(monitorId);
   return monitorName ? `${monitorName} (#${monitorId})` : `#${monitorId}`;
 }
@@ -1101,10 +1104,7 @@ export function AdminDashboard() {
               <Card className="p-3 border-red-200 bg-red-50/70 dark:bg-red-500/10 dark:border-red-400/30">
                 <div className="text-sm font-medium text-red-700 dark:text-red-300">
                   {t('admin_dashboard.monitor_test_failed', {
-                    name: formatMonitorDisplayNameById(
-                      monitorTestError.monitorId,
-                      monitorNameById,
-                    ),
+                    name: formatMonitorDisplayNameById(monitorTestError.monitorId, monitorNameById),
                   })}
                 </div>
                 <div className="mt-1 text-xs text-red-600 dark:text-red-400">
@@ -1499,11 +1499,16 @@ export function AdminDashboard() {
                                       />
                                     </td>
                                     <td className="px-3 sm:px-4 py-3 text-sm font-medium text-slate-900 dark:text-slate-100">
-                                      <div className="flex items-center gap-1.5">
+                                      <div className="flex flex-wrap items-center gap-1.5">
                                         <span className="truncate">{m.name}</span>
                                         <span className="text-xs font-normal text-slate-500 dark:text-slate-400">
                                           #{m.id}
                                         </span>
+                                        {!m.show_on_status_page && (
+                                          <Badge variant="unknown">
+                                            {t('admin_dashboard.monitor_visibility_hidden')}
+                                          </Badge>
+                                        )}
                                       </div>
                                     </td>
                                     <td className="px-3 sm:px-4 py-3 text-xs text-slate-600 dark:text-slate-300">

--- a/apps/worker/migrations/0009_monitor_status_page_visibility.sql
+++ b/apps/worker/migrations/0009_monitor_status_page_visibility.sql
@@ -1,0 +1,5 @@
+-- Phase 16: allow monitors to be hidden from the public status page
+-- NOTE: Keep this file append-only.
+
+ALTER TABLE monitors
+  ADD COLUMN show_on_status_page INTEGER NOT NULL DEFAULT 1 CHECK (show_on_status_page IN (0, 1));

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -3,15 +3,28 @@ import { createMiddleware } from 'hono/factory';
 import type { Env } from '../env';
 import { AppError } from './errors';
 
+function readBearerToken(authHeader: string | undefined | null): string | null {
+  if (!authHeader) return null;
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] ?? null;
+}
+
+export function hasValidAdminTokenRequest(input: {
+  env: Pick<Env, 'ADMIN_TOKEN'>;
+  req: { header(name: string): string | undefined };
+}): boolean {
+  const token = input.env.ADMIN_TOKEN;
+  if (!token) return false;
+  return readBearerToken(input.req.header('authorization')) === token;
+}
+
 export const requireAdmin = createMiddleware<{ Bindings: Env }>(async (c, next) => {
   const token = c.env.ADMIN_TOKEN;
   if (!token) {
     throw new AppError(500, 'INTERNAL', 'Admin token not configured');
   }
 
-  const auth = c.req.header('authorization') ?? '';
-  const m = auth.match(/^Bearer\s+(.+)$/i);
-  if (!m || m[1] !== token) {
+  if (!hasValidAdminTokenRequest(c)) {
     throw new AppError(401, 'UNAUTHORIZED', 'Unauthorized');
   }
 

--- a/apps/worker/src/middleware/cache-public.ts
+++ b/apps/worker/src/middleware/cache-public.ts
@@ -1,13 +1,19 @@
 import type { MiddlewareHandler } from 'hono';
 
+function hasAuthorizationHeader(req: { header?(name: string): string | undefined }): boolean {
+  return Boolean(req.header?.('Authorization'));
+}
+
 // Cache public (unauthenticated) GET responses at the edge.
 // This reduces D1 read pressure and greatly improves TTFB on slow networks.
 //
-// IMPORTANT: If a handler already set Cache-Control, we respect it (do not override).
+// IMPORTANT: Authorization-bearing requests bypass the shared cache entirely because
+// public endpoints can return admin-only payloads when a valid bearer token is present.
+// If a handler already set Cache-Control, we respect it (do not override).
 // This allows endpoints like `/public/status` to precisely control freshness (<= 60s).
 export function cachePublic(opts: { cacheName: string; maxAgeSeconds: number }): MiddlewareHandler {
   return async (c, next) => {
-    if (c.req.method !== 'GET') {
+    if (c.req.method !== 'GET' || hasAuthorizationHeader(c.req)) {
       await next();
       return;
     }

--- a/apps/worker/src/public/status.ts
+++ b/apps/worker/src/public/status.ts
@@ -6,6 +6,12 @@ import {
   overlapSeconds,
   sumIntervals,
 } from '../analytics/uptime';
+import {
+  filterStatusPageScopedMonitorIds,
+  listStatusPageVisibleMonitorIds,
+  monitorVisibilityPredicate,
+  shouldIncludeStatusPageScopedItem,
+} from './visibility';
 import { readSettings } from '../settings';
 
 type PublicStatusMonitorRow = {
@@ -551,7 +557,9 @@ function toUptimePct(totalSec: number, uptimeSec: number): number | null {
 export async function computePublicStatusPayload(
   db: D1Database,
   now: number,
+  opts: { includeHiddenMonitors?: boolean } = {},
 ): Promise<PublicStatusResponse> {
+  const includeHiddenMonitors = opts.includeHiddenMonitors ?? false;
   // 30d bars should reflect today's (partial) uptime too; daily rollups only cover full UTC days.
   const rangeEndFullDays = utcDayStart(now);
   const rangeEnd = now;
@@ -573,6 +581,7 @@ export async function computePublicStatusPayload(
       FROM monitors m
       LEFT JOIN monitor_state s ON s.monitor_id = m.id
       WHERE m.is_active = 1
+        AND ${monitorVisibilityPredicate(includeHiddenMonitors, 'm')}
       ORDER BY
         m.group_sort_order ASC,
         lower(
@@ -780,10 +789,9 @@ export async function computePublicStatusPayload(
       FROM incidents
       WHERE status != 'resolved'
       ORDER BY started_at DESC, id DESC
-      LIMIT ?1
     `,
       )
-      .bind(STATUS_ACTIVE_INCIDENT_LIMIT)
+      .bind()
       .all<IncidentRow>(),
     db
       .prepare(
@@ -792,10 +800,9 @@ export async function computePublicStatusPayload(
       FROM maintenance_windows
       WHERE starts_at <= ?1 AND ends_at > ?1
       ORDER BY starts_at ASC, id ASC
-      LIMIT ?2
     `,
       )
-      .bind(now, STATUS_ACTIVE_MAINTENANCE_LIMIT)
+      .bind(now)
       .all<MaintenanceWindowRow>(),
     db
       .prepare(
@@ -804,10 +811,9 @@ export async function computePublicStatusPayload(
       FROM maintenance_windows
       WHERE starts_at > ?1
       ORDER BY starts_at ASC, id ASC
-      LIMIT ?2
     `,
       )
-      .bind(now, STATUS_UPCOMING_MAINTENANCE_LIMIT)
+      .bind(now)
       .all<MaintenanceWindowRow>(),
     readSettings(db),
   ]);
@@ -840,8 +846,82 @@ export async function computePublicStatusPayload(
     ),
   ]);
 
+  const statusPageVisibleMonitorIds = includeHiddenMonitors
+    ? new Set<number>()
+    : await listStatusPageVisibleMonitorIds(
+        db,
+        [
+          ...incidentMonitorIdsByIncidentId.values(),
+          ...activeWindowMonitorIdsByWindowId.values(),
+          ...upcomingWindowMonitorIdsByWindowId.values(),
+        ].flat(),
+      );
+
+  const filteredActiveIncidents = activeIncidentRows
+    .map((row) => {
+      const originalMonitorIds = incidentMonitorIdsByIncidentId.get(row.id) ?? [];
+      const visibleMonitorIds = filterStatusPageScopedMonitorIds(
+        originalMonitorIds,
+        statusPageVisibleMonitorIds,
+        includeHiddenMonitors,
+      );
+
+      if (!shouldIncludeStatusPageScopedItem(originalMonitorIds, visibleMonitorIds)) {
+        return null;
+      }
+
+      return {
+        row,
+        monitorIds: visibleMonitorIds,
+      };
+    })
+    .filter((entry): entry is { row: IncidentRow; monitorIds: number[] } => entry !== null)
+    .slice(0, STATUS_ACTIVE_INCIDENT_LIMIT);
+
+  const filteredActiveWindows = activeWindowRows
+    .map((row) => {
+      const originalMonitorIds = activeWindowMonitorIdsByWindowId.get(row.id) ?? [];
+      const visibleMonitorIds = filterStatusPageScopedMonitorIds(
+        originalMonitorIds,
+        statusPageVisibleMonitorIds,
+        includeHiddenMonitors,
+      );
+
+      if (!shouldIncludeStatusPageScopedItem(originalMonitorIds, visibleMonitorIds)) {
+        return null;
+      }
+
+      return {
+        row,
+        monitorIds: visibleMonitorIds,
+      };
+    })
+    .filter((entry): entry is { row: MaintenanceWindowRow; monitorIds: number[] } => entry !== null)
+    .slice(0, STATUS_ACTIVE_MAINTENANCE_LIMIT);
+
+  const filteredUpcomingWindows = upcomingWindowRows
+    .map((row) => {
+      const originalMonitorIds = upcomingWindowMonitorIdsByWindowId.get(row.id) ?? [];
+      const visibleMonitorIds = filterStatusPageScopedMonitorIds(
+        originalMonitorIds,
+        statusPageVisibleMonitorIds,
+        includeHiddenMonitors,
+      );
+
+      if (!shouldIncludeStatusPageScopedItem(originalMonitorIds, visibleMonitorIds)) {
+        return null;
+      }
+
+      return {
+        row,
+        monitorIds: visibleMonitorIds,
+      };
+    })
+    .filter((entry): entry is { row: MaintenanceWindowRow; monitorIds: number[] } => entry !== null)
+    .slice(0, STATUS_UPCOMING_MAINTENANCE_LIMIT);
+
   const banner: Banner = (() => {
-    const incidents = activeIncidentRows;
+    const incidents = filteredActiveIncidents.map((entry) => entry.row);
     if (incidents.length > 0) {
       const impactRank = (impact: PublicStatusResponse['active_incidents'][number]['impact']) => {
         switch (impact) {
@@ -908,7 +988,7 @@ export async function computePublicStatusPayload(
       return { source: 'monitors', status: 'unknown', title: 'Status Unknown' };
     }
 
-    const maint = activeWindowRows;
+    const maint = filteredActiveWindows.map((entry) => entry.row);
     const hasMaintenance = maint.length > 0 || counts.maintenance > 0;
     if (hasMaintenance) {
       const top = maint[0];
@@ -942,19 +1022,15 @@ export async function computePublicStatusPayload(
     banner,
     summary: counts,
     monitors: monitorsList,
-    active_incidents: activeIncidentRows.map((r) =>
-      incidentRowToApi(
-        r,
-        incidentUpdatesByIncidentId.get(r.id) ?? [],
-        incidentMonitorIdsByIncidentId.get(r.id) ?? [],
-      ),
+    active_incidents: filteredActiveIncidents.map(({ row, monitorIds }) =>
+      incidentRowToApi(row, incidentUpdatesByIncidentId.get(row.id) ?? [], monitorIds),
     ),
     maintenance_windows: {
-      active: activeWindowRows.map((w) =>
-        maintenanceWindowRowToApi(w, activeWindowMonitorIdsByWindowId.get(w.id) ?? []),
+      active: filteredActiveWindows.map(({ row, monitorIds }) =>
+        maintenanceWindowRowToApi(row, monitorIds),
       ),
-      upcoming: upcomingWindowRows.map((w) =>
-        maintenanceWindowRowToApi(w, upcomingWindowMonitorIdsByWindowId.get(w.id) ?? []),
+      upcoming: filteredUpcomingWindows.map(({ row, monitorIds }) =>
+        maintenanceWindowRowToApi(row, monitorIds),
       ),
     },
   };

--- a/apps/worker/src/public/status.ts
+++ b/apps/worker/src/public/status.ts
@@ -7,8 +7,12 @@ import {
   sumIntervals,
 } from '../analytics/uptime';
 import {
+  buildNumberedPlaceholders,
+  chunkPositiveIntegerIds,
   filterStatusPageScopedMonitorIds,
+  incidentStatusPageVisibilityPredicate,
   listStatusPageVisibleMonitorIds,
+  maintenanceWindowStatusPageVisibilityPredicate,
   monitorVisibilityPredicate,
   shouldIncludeStatusPageScopedItem,
 } from './visibility';
@@ -260,22 +264,23 @@ async function listIncidentUpdatesByIncidentId(
   incidentIds: number[],
 ): Promise<Map<number, IncidentUpdateRow[]>> {
   const byIncident = new Map<number, IncidentUpdateRow[]>();
-  if (incidentIds.length === 0) return byIncident;
 
-  const placeholders = incidentIds.map((_, idx) => `?${idx + 1}`).join(', ');
-  const sql = `
-    SELECT id, incident_id, status, message, created_at
-    FROM incident_updates
-    WHERE incident_id IN (${placeholders})
-    ORDER BY incident_id, created_at, id
-  `;
+  for (const ids of chunkPositiveIntegerIds(incidentIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length);
+    const sql = `
+      SELECT id, incident_id, status, message, created_at
+      FROM incident_updates
+      WHERE incident_id IN (${placeholders})
+      ORDER BY incident_id, created_at, id
+    `;
 
-  const { results } = await db
-    .prepare(sql)
-    .bind(...incidentIds)
-    .all<IncidentUpdateRow>();
-  for (const r of results ?? []) {
-    appendMapValue(byIncident, r.incident_id, r);
+    const { results } = await db
+      .prepare(sql)
+      .bind(...ids)
+      .all<IncidentUpdateRow>();
+    for (const r of results ?? []) {
+      appendMapValue(byIncident, r.incident_id, r);
+    }
   }
 
   return byIncident;
@@ -286,22 +291,23 @@ async function listIncidentMonitorIdsByIncidentId(
   incidentIds: number[],
 ): Promise<Map<number, number[]>> {
   const byIncident = new Map<number, number[]>();
-  if (incidentIds.length === 0) return byIncident;
 
-  const placeholders = incidentIds.map((_, idx) => `?${idx + 1}`).join(', ');
-  const sql = `
-    SELECT incident_id, monitor_id
-    FROM incident_monitors
-    WHERE incident_id IN (${placeholders})
-    ORDER BY incident_id, monitor_id
-  `;
+  for (const ids of chunkPositiveIntegerIds(incidentIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length);
+    const sql = `
+      SELECT incident_id, monitor_id
+      FROM incident_monitors
+      WHERE incident_id IN (${placeholders})
+      ORDER BY incident_id, monitor_id
+    `;
 
-  const { results } = await db
-    .prepare(sql)
-    .bind(...incidentIds)
-    .all<IncidentMonitorLinkRow>();
-  for (const r of results ?? []) {
-    appendMapValue(byIncident, r.incident_id, r.monitor_id);
+    const { results } = await db
+      .prepare(sql)
+      .bind(...ids)
+      .all<IncidentMonitorLinkRow>();
+    for (const r of results ?? []) {
+      appendMapValue(byIncident, r.incident_id, r.monitor_id);
+    }
   }
 
   return byIncident;
@@ -312,22 +318,23 @@ async function listMaintenanceWindowMonitorIdsByWindowId(
   windowIds: number[],
 ): Promise<Map<number, number[]>> {
   const byWindow = new Map<number, number[]>();
-  if (windowIds.length === 0) return byWindow;
 
-  const placeholders = windowIds.map((_, idx) => `?${idx + 1}`).join(', ');
-  const sql = `
-    SELECT maintenance_window_id, monitor_id
-    FROM maintenance_window_monitors
-    WHERE maintenance_window_id IN (${placeholders})
-    ORDER BY maintenance_window_id, monitor_id
-  `;
+  for (const ids of chunkPositiveIntegerIds(windowIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length);
+    const sql = `
+      SELECT maintenance_window_id, monitor_id
+      FROM maintenance_window_monitors
+      WHERE maintenance_window_id IN (${placeholders})
+      ORDER BY maintenance_window_id, monitor_id
+    `;
 
-  const { results } = await db
-    .prepare(sql)
-    .bind(...windowIds)
-    .all<MaintenanceWindowMonitorLinkRow>();
-  for (const r of results ?? []) {
-    appendMapValue(byWindow, r.maintenance_window_id, r.monitor_id);
+    const { results } = await db
+      .prepare(sql)
+      .bind(...ids)
+      .all<MaintenanceWindowMonitorLinkRow>();
+    for (const r of results ?? []) {
+      appendMapValue(byWindow, r.maintenance_window_id, r.monitor_id);
+    }
   }
 
   return byWindow;
@@ -338,23 +345,28 @@ async function listActiveMaintenanceMonitorIds(
   at: number,
   monitorIds: number[],
 ): Promise<Set<number>> {
-  const ids = [...new Set(monitorIds)];
-  if (ids.length === 0) return new Set();
+  const activeMonitorIds = new Set<number>();
 
-  const placeholders = ids.map((_, idx) => `?${idx + 2}`).join(', ');
-  const sql = `
-    SELECT DISTINCT mwm.monitor_id
-    FROM maintenance_window_monitors mwm
-    JOIN maintenance_windows mw ON mw.id = mwm.maintenance_window_id
-    WHERE mw.starts_at <= ?1 AND mw.ends_at > ?1
-      AND mwm.monitor_id IN (${placeholders})
-  `;
+  for (const ids of chunkPositiveIntegerIds(monitorIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length, 2);
+    const sql = `
+      SELECT DISTINCT mwm.monitor_id
+      FROM maintenance_window_monitors mwm
+      JOIN maintenance_windows mw ON mw.id = mwm.maintenance_window_id
+      WHERE mw.starts_at <= ?1 AND mw.ends_at > ?1
+        AND mwm.monitor_id IN (${placeholders})
+    `;
 
-  const { results } = await db
-    .prepare(sql)
-    .bind(at, ...ids)
-    .all<{ monitor_id: number }>();
-  return new Set((results ?? []).map((r) => r.monitor_id));
+    const { results } = await db
+      .prepare(sql)
+      .bind(at, ...ids)
+      .all<{ monitor_id: number }>();
+    for (const row of results ?? []) {
+      activeMonitorIds.add(row.monitor_id);
+    }
+  }
+
+  return activeMonitorIds;
 }
 
 function utcDayStart(timestampSec: number): number {
@@ -776,6 +788,11 @@ export async function computePublicStatusPayload(
               ? 'paused'
               : 'unknown';
 
+  const incidentVisibilitySql = incidentStatusPageVisibilityPredicate(includeHiddenMonitors);
+  const maintenanceVisibilitySql = maintenanceWindowStatusPageVisibilityPredicate(
+    includeHiddenMonitors,
+  );
+
   const [
     { results: activeIncidents },
     { results: activeMaintenanceWindows },
@@ -788,10 +805,12 @@ export async function computePublicStatusPayload(
       SELECT id, title, status, impact, message, started_at, resolved_at
       FROM incidents
       WHERE status != 'resolved'
+        AND ${incidentVisibilitySql}
       ORDER BY started_at DESC, id DESC
+      LIMIT ?1
     `,
       )
-      .bind()
+      .bind(STATUS_ACTIVE_INCIDENT_LIMIT)
       .all<IncidentRow>(),
     db
       .prepare(
@@ -799,10 +818,12 @@ export async function computePublicStatusPayload(
       SELECT id, title, message, starts_at, ends_at, created_at
       FROM maintenance_windows
       WHERE starts_at <= ?1 AND ends_at > ?1
+        AND ${maintenanceVisibilitySql}
       ORDER BY starts_at ASC, id ASC
+      LIMIT ?2
     `,
       )
-      .bind(now)
+      .bind(now, STATUS_ACTIVE_MAINTENANCE_LIMIT)
       .all<MaintenanceWindowRow>(),
     db
       .prepare(
@@ -810,10 +831,12 @@ export async function computePublicStatusPayload(
       SELECT id, title, message, starts_at, ends_at, created_at
       FROM maintenance_windows
       WHERE starts_at > ?1
+        AND ${maintenanceVisibilitySql}
       ORDER BY starts_at ASC, id ASC
+      LIMIT ?2
     `,
       )
-      .bind(now)
+      .bind(now, STATUS_UPCOMING_MAINTENANCE_LIMIT)
       .all<MaintenanceWindowRow>(),
     readSettings(db),
   ]);

--- a/apps/worker/src/public/visibility.ts
+++ b/apps/worker/src/public/visibility.ts
@@ -1,0 +1,46 @@
+function normalizeMonitorIds(monitorIds: number[]): number[] {
+  return [...new Set(monitorIds.filter((id) => Number.isInteger(id) && id > 0))];
+}
+
+export function monitorVisibilityPredicate(includeHiddenMonitors: boolean, alias?: string): string {
+  const column = alias ? `${alias}.show_on_status_page` : 'show_on_status_page';
+  return includeHiddenMonitors ? '1 = 1' : `${column} = 1`;
+}
+
+export async function listStatusPageVisibleMonitorIds(
+  db: D1Database,
+  monitorIds: number[],
+): Promise<Set<number>> {
+  const ids = normalizeMonitorIds(monitorIds);
+  if (ids.length === 0) return new Set();
+
+  const placeholders = ids.map((_, idx) => `?${idx + 1}`).join(', ');
+  const { results } = await db
+    .prepare(
+      `
+        SELECT id
+        FROM monitors
+        WHERE id IN (${placeholders})
+          AND show_on_status_page = 1
+      `,
+    )
+    .bind(...ids)
+    .all<{ id: number }>();
+
+  return new Set((results ?? []).map((row) => row.id));
+}
+
+export function filterStatusPageScopedMonitorIds(
+  monitorIds: number[],
+  visibleMonitorIds: Set<number>,
+  includeHiddenMonitors: boolean,
+): number[] {
+  return includeHiddenMonitors ? monitorIds : monitorIds.filter((id) => visibleMonitorIds.has(id));
+}
+
+export function shouldIncludeStatusPageScopedItem(
+  originalMonitorIds: number[],
+  visibleMonitorIds: number[],
+): boolean {
+  return originalMonitorIds.length === 0 || visibleMonitorIds.length > 0;
+}

--- a/apps/worker/src/public/visibility.ts
+++ b/apps/worker/src/public/visibility.ts
@@ -1,5 +1,23 @@
-function normalizeMonitorIds(monitorIds: number[]): number[] {
-  return [...new Set(monitorIds.filter((id) => Number.isInteger(id) && id > 0))];
+const D1_ID_CHUNK_SIZE = 200;
+
+function normalizePositiveIntegerIds(ids: number[]): number[] {
+  return [...new Set(ids.filter((id) => Number.isInteger(id) && id > 0))];
+}
+
+export function buildNumberedPlaceholders(count: number, startIndex = 1): string {
+  return Array.from({ length: count }, (_, idx) => `?${idx + startIndex}`).join(', ');
+}
+
+export function chunkPositiveIntegerIds(ids: number[], chunkSize = D1_ID_CHUNK_SIZE): number[][] {
+  const normalizedIds = normalizePositiveIntegerIds(ids);
+  const safeChunkSize = Math.max(1, Math.floor(chunkSize));
+
+  const chunks: number[][] = [];
+  for (let idx = 0; idx < normalizedIds.length; idx += safeChunkSize) {
+    chunks.push(normalizedIds.slice(idx, idx + safeChunkSize));
+  }
+
+  return chunks;
 }
 
 export function monitorVisibilityPredicate(includeHiddenMonitors: boolean, alias?: string): string {
@@ -7,27 +25,82 @@ export function monitorVisibilityPredicate(includeHiddenMonitors: boolean, alias
   return includeHiddenMonitors ? '1 = 1' : `${column} = 1`;
 }
 
+function statusPageScopedItemVisibilityPredicate(
+  includeHiddenMonitors: boolean,
+  itemAlias: string,
+  linkTable: string,
+  linkItemColumn: string,
+): string {
+  if (includeHiddenMonitors) return '1 = 1';
+
+  return `
+    (
+      NOT EXISTS (
+        SELECT 1
+        FROM ${linkTable} scoped_links
+        WHERE scoped_links.${linkItemColumn} = ${itemAlias}.id
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM ${linkTable} scoped_links
+        JOIN monitors scoped_monitors ON scoped_monitors.id = scoped_links.monitor_id
+        WHERE scoped_links.${linkItemColumn} = ${itemAlias}.id
+          AND ${monitorVisibilityPredicate(false, 'scoped_monitors')}
+      )
+    )
+  `;
+}
+
+export function incidentStatusPageVisibilityPredicate(
+  includeHiddenMonitors: boolean,
+  alias = 'incidents',
+): string {
+  return statusPageScopedItemVisibilityPredicate(
+    includeHiddenMonitors,
+    alias,
+    'incident_monitors',
+    'incident_id',
+  );
+}
+
+export function maintenanceWindowStatusPageVisibilityPredicate(
+  includeHiddenMonitors: boolean,
+  alias = 'maintenance_windows',
+): string {
+  return statusPageScopedItemVisibilityPredicate(
+    includeHiddenMonitors,
+    alias,
+    'maintenance_window_monitors',
+    'maintenance_window_id',
+  );
+}
+
 export async function listStatusPageVisibleMonitorIds(
   db: D1Database,
   monitorIds: number[],
 ): Promise<Set<number>> {
-  const ids = normalizeMonitorIds(monitorIds);
-  if (ids.length === 0) return new Set();
+  const visibleMonitorIds = new Set<number>();
 
-  const placeholders = ids.map((_, idx) => `?${idx + 1}`).join(', ');
-  const { results } = await db
-    .prepare(
-      `
-        SELECT id
-        FROM monitors
-        WHERE id IN (${placeholders})
-          AND show_on_status_page = 1
-      `,
-    )
-    .bind(...ids)
-    .all<{ id: number }>();
+  for (const ids of chunkPositiveIntegerIds(monitorIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length);
+    const { results } = await db
+      .prepare(
+        `
+          SELECT id
+          FROM monitors
+          WHERE id IN (${placeholders})
+            AND show_on_status_page = 1
+        `,
+      )
+      .bind(...ids)
+      .all<{ id: number }>();
 
-  return new Set((results ?? []).map((row) => row.id));
+    for (const row of results ?? []) {
+      visibleMonitorIds.add(row.id);
+    }
+  }
+
+  return visibleMonitorIds;
 }
 
 export function filterStatusPageScopedMonitorIds(

--- a/apps/worker/src/routes/admin.ts
+++ b/apps/worker/src/routes/admin.ts
@@ -245,6 +245,7 @@ function monitorRowToApi(
     group_name: groupName,
     group_sort_order: row.groupSortOrder,
     sort_order: row.sortOrder,
+    show_on_status_page: row.showOnStatusPage,
     is_active: row.isActive,
     created_at: row.createdAt,
     updated_at: row.updatedAt,
@@ -418,6 +419,7 @@ adminRoutes.post('/monitors', async (c) => {
       groupName,
       groupSortOrder,
       sortOrder: input.sort_order ?? 0,
+      showOnStatusPage: input.show_on_status_page ?? true,
       isActive: input.is_active ?? true,
       createdAt: now,
       updatedAt: now,
@@ -519,6 +521,7 @@ adminRoutes.patch('/monitors/:id', async (c) => {
       groupName: nextGroupName,
       groupSortOrder: nextGroupSortOrder,
       sortOrder: input.sort_order ?? existing.sortOrder,
+      showOnStatusPage: input.show_on_status_page ?? existing.showOnStatusPage,
       isActive: input.is_active ?? existing.isActive,
       updatedAt: now,
     })

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -4,7 +4,14 @@ import { z } from 'zod';
 import { getDb, monitors } from '@uptimer/db';
 
 import type { Env } from '../env';
+import { hasValidAdminTokenRequest } from '../middleware/auth';
 import { computePublicStatusPayload } from '../public/status';
+import {
+  filterStatusPageScopedMonitorIds,
+  listStatusPageVisibleMonitorIds,
+  monitorVisibilityPredicate,
+  shouldIncludeStatusPageScopedItem,
+} from '../public/visibility';
 import {
   applyStatusCacheHeaders,
   readStatusSnapshot,
@@ -28,6 +35,29 @@ function safeJsonParse(text: string): unknown | null {
   } catch {
     return null;
   }
+}
+
+function isAuthorizedStatusAdminRequest(c: {
+  env: Pick<Env, 'ADMIN_TOKEN'>;
+  req: { header(name: string): string | undefined };
+}): boolean {
+  return hasValidAdminTokenRequest(c);
+}
+
+function applyPrivateNoStore(res: Response): Response {
+  const vary = res.headers.get('Vary');
+  if (!vary) {
+    res.headers.set('Vary', 'Authorization');
+  } else if (!vary.split(',').some((part) => part.trim().toLowerCase() === 'authorization')) {
+    res.headers.set('Vary', `${vary}, Authorization`);
+  }
+
+  res.headers.set('Cache-Control', 'private, no-store');
+  return res;
+}
+
+function withVisibilityAwareCaching(res: Response, includeHiddenMonitors: boolean): Response {
+  return includeHiddenMonitors ? applyPrivateNoStore(res) : res;
 }
 
 async function readStaleStatusSnapshot(
@@ -434,8 +464,70 @@ async function listMaintenanceWindowMonitorIdsByWindowId(
   return byWindow;
 }
 
+async function listIncidentRowsVisibleOnStatusPage(
+  db: D1Database,
+  rows: IncidentRow[],
+  includeHiddenMonitors: boolean,
+): Promise<IncidentRow[]> {
+  if (includeHiddenMonitors || rows.length === 0) return rows;
+
+  const monitorIdsByIncidentId = await listIncidentMonitorIdsByIncidentId(
+    db,
+    rows.map((row) => row.id),
+  );
+  const visibleMonitorIds = await listStatusPageVisibleMonitorIds(
+    db,
+    [...monitorIdsByIncidentId.values()].flat(),
+  );
+
+  return rows.filter((row) => {
+    const originalMonitorIds = monitorIdsByIncidentId.get(row.id) ?? [];
+    const filteredMonitorIds = filterStatusPageScopedMonitorIds(
+      originalMonitorIds,
+      visibleMonitorIds,
+      includeHiddenMonitors,
+    );
+    return shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds);
+  });
+}
+
+async function listMaintenanceWindowRowsVisibleOnStatusPage(
+  db: D1Database,
+  rows: MaintenanceWindowRow[],
+  includeHiddenMonitors: boolean,
+): Promise<MaintenanceWindowRow[]> {
+  if (includeHiddenMonitors || rows.length === 0) return rows;
+
+  const monitorIdsByWindowId = await listMaintenanceWindowMonitorIdsByWindowId(
+    db,
+    rows.map((row) => row.id),
+  );
+  const visibleMonitorIds = await listStatusPageVisibleMonitorIds(
+    db,
+    [...monitorIdsByWindowId.values()].flat(),
+  );
+
+  return rows.filter((row) => {
+    const originalMonitorIds = monitorIdsByWindowId.get(row.id) ?? [];
+    const filteredMonitorIds = filterStatusPageScopedMonitorIds(
+      originalMonitorIds,
+      visibleMonitorIds,
+      includeHiddenMonitors,
+    );
+    return shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds);
+  });
+}
+
 publicRoutes.get('/status', async (c) => {
   const now = Math.floor(Date.now() / 1000);
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
+
+  if (includeHiddenMonitors) {
+    const payload = await computePublicStatusPayload(c.env.DB, now, {
+      includeHiddenMonitors: true,
+    });
+    return applyPrivateNoStore(c.json(payload));
+  }
 
   const snapshot = await readStatusSnapshot(c.env.DB, now);
   if (snapshot) {
@@ -486,6 +578,7 @@ publicRoutes.get('/status', async (c) => {
 });
 
 publicRoutes.get('/incidents', async (c) => {
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
   const limit = z.coerce
     .number()
     .int()
@@ -515,13 +608,15 @@ publicRoutes.get('/incidents', async (c) => {
         FROM incidents
         WHERE status != 'resolved'
         ORDER BY started_at DESC, id DESC
-        LIMIT ?1
       `,
-    )
-      .bind(limit)
-      .all<IncidentRow>();
+    ).all<IncidentRow>();
 
-    active = activeRows ?? [];
+    active = await listIncidentRowsVisibleOnStatusPage(
+      c.env.DB,
+      activeRows ?? [],
+      includeHiddenMonitors,
+    );
+    active = active.slice(0, limit);
     remaining = Math.max(0, limit - active.length);
   }
 
@@ -529,42 +624,56 @@ publicRoutes.get('/incidents', async (c) => {
   let next_cursor: number | null = null;
 
   if (remaining > 0) {
-    const resolvedLimitPlusOne = remaining + 1;
-
     const baseSql = `
       SELECT id, title, status, impact, message, started_at, resolved_at
       FROM incidents
       WHERE status = 'resolved'
     `;
 
-    const { results: resolvedRows } = cursor
-      ? await c.env.DB.prepare(
-          `
-            ${baseSql}
-              AND id < ?2
-            ORDER BY id DESC
-            LIMIT ?1
-          `,
-        )
-          .bind(resolvedLimitPlusOne, cursor)
-          .all<IncidentRow>()
-      : await c.env.DB.prepare(
-          `
-            ${baseSql}
-            ORDER BY id DESC
-            LIMIT ?1
-          `,
-        )
-          .bind(resolvedLimitPlusOne)
-          .all<IncidentRow>();
+    const resolvedLimitPlusOne = remaining + 1;
+    const batchLimit = Math.max(50, resolvedLimitPlusOne);
+    let seekCursor = cursor;
+    const collected: IncidentRow[] = [];
 
-    const allResolved = resolvedRows ?? [];
-    resolved = allResolved.slice(0, remaining);
+    while (collected.length < resolvedLimitPlusOne) {
+      const { results: resolvedRows } = seekCursor
+        ? await c.env.DB.prepare(
+            `
+              ${baseSql}
+                AND id < ?2
+              ORDER BY id DESC
+              LIMIT ?1
+            `,
+          )
+            .bind(batchLimit, seekCursor)
+            .all<IncidentRow>()
+        : await c.env.DB.prepare(
+            `
+              ${baseSql}
+              ORDER BY id DESC
+              LIMIT ?1
+            `,
+          )
+            .bind(batchLimit)
+            .all<IncidentRow>();
 
-    if (allResolved.length > remaining) {
-      const last = resolved[resolved.length - 1];
-      next_cursor = last ? last.id : null;
+      const allResolved = resolvedRows ?? [];
+      if (allResolved.length === 0) break;
+
+      const visibleResolved = await listIncidentRowsVisibleOnStatusPage(
+        c.env.DB,
+        allResolved,
+        includeHiddenMonitors,
+      );
+      collected.push(...visibleResolved);
+
+      const lastRow = allResolved[allResolved.length - 1];
+      if (allResolved.length < batchLimit || !lastRow) break;
+      seekCursor = lastRow.id;
     }
+
+    resolved = collected.slice(0, remaining);
+    next_cursor = collected.length > remaining ? (resolved[resolved.length - 1]?.id ?? null) : null;
   }
 
   const combined = [...active, ...resolved];
@@ -577,19 +686,34 @@ publicRoutes.get('/incidents', async (c) => {
     combined.map((r) => r.id),
   );
 
-  return c.json({
-    incidents: combined.map((r) =>
-      incidentRowToApi(
-        r,
-        updatesByIncidentId.get(r.id) ?? [],
-        monitorIdsByIncidentId.get(r.id) ?? [],
-      ),
-    ),
-    next_cursor,
-  });
+  const visibleMonitorIds = includeHiddenMonitors
+    ? new Set<number>()
+    : await listStatusPageVisibleMonitorIds(c.env.DB, [...monitorIdsByIncidentId.values()].flat());
+
+  return withVisibilityAwareCaching(
+    c.json({
+      incidents: combined.flatMap((r) => {
+        const originalMonitorIds = monitorIdsByIncidentId.get(r.id) ?? [];
+        const filteredMonitorIds = filterStatusPageScopedMonitorIds(
+          originalMonitorIds,
+          visibleMonitorIds,
+          includeHiddenMonitors,
+        );
+
+        if (!shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds)) {
+          return [];
+        }
+
+        return [incidentRowToApi(r, updatesByIncidentId.get(r.id) ?? [], filteredMonitorIds)];
+      }),
+      next_cursor,
+    }),
+    includeHiddenMonitors,
+  );
 });
 
 publicRoutes.get('/maintenance-windows', async (c) => {
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
   const limit = z.coerce
     .number()
     .int()
@@ -601,58 +725,89 @@ publicRoutes.get('/maintenance-windows', async (c) => {
   const cursor = z.coerce.number().int().positive().optional().parse(c.req.query('cursor'));
 
   const now = Math.floor(Date.now() / 1000);
-  const limitPlusOne = limit + 1;
-
   const baseSql = `
     SELECT id, title, message, starts_at, ends_at, created_at
     FROM maintenance_windows
     WHERE ends_at <= ?1
   `;
+  const limitPlusOne = limit + 1;
+  const batchLimit = Math.max(50, limitPlusOne);
+  let seekCursor = cursor;
+  const collected: MaintenanceWindowRow[] = [];
 
-  const { results: windowRows } = cursor
-    ? await c.env.DB.prepare(
-        `
-          ${baseSql}
-            AND id < ?3
-          ORDER BY id DESC
-          LIMIT ?2
-        `,
-      )
-        .bind(now, limitPlusOne, cursor)
-        .all<MaintenanceWindowRow>()
-    : await c.env.DB.prepare(
-        `
-          ${baseSql}
-          ORDER BY id DESC
-          LIMIT ?2
-        `,
-      )
-        .bind(now, limitPlusOne)
-        .all<MaintenanceWindowRow>();
+  while (collected.length < limitPlusOne) {
+    const { results: windowRows } = seekCursor
+      ? await c.env.DB.prepare(
+          `
+            ${baseSql}
+              AND id < ?3
+            ORDER BY id DESC
+            LIMIT ?2
+          `,
+        )
+          .bind(now, batchLimit, seekCursor)
+          .all<MaintenanceWindowRow>()
+      : await c.env.DB.prepare(
+          `
+            ${baseSql}
+            ORDER BY id DESC
+            LIMIT ?2
+          `,
+        )
+          .bind(now, batchLimit)
+          .all<MaintenanceWindowRow>();
 
-  const allWindows = windowRows ?? [];
-  const windows = allWindows.slice(0, limit);
+    const allWindows = windowRows ?? [];
+    if (allWindows.length === 0) break;
 
-  let next_cursor: number | null = null;
-  if (allWindows.length > limit) {
-    const last = windows[windows.length - 1];
-    next_cursor = last ? last.id : null;
+    const visibleWindows = await listMaintenanceWindowRowsVisibleOnStatusPage(
+      c.env.DB,
+      allWindows,
+      includeHiddenMonitors,
+    );
+    collected.push(...visibleWindows);
+
+    const lastRow = allWindows[allWindows.length - 1];
+    if (allWindows.length < batchLimit || !lastRow) break;
+    seekCursor = lastRow.id;
   }
+
+  const windows = collected.slice(0, limit);
+  const next_cursor = collected.length > limit ? (windows[windows.length - 1]?.id ?? null) : null;
 
   const monitorIdsByWindowId = await listMaintenanceWindowMonitorIdsByWindowId(
     c.env.DB,
     windows.map((w) => w.id),
   );
 
-  return c.json({
-    maintenance_windows: windows.map((w) =>
-      maintenanceWindowRowToApi(w, monitorIdsByWindowId.get(w.id) ?? []),
-    ),
-    next_cursor,
-  });
+  const visibleMonitorIds = includeHiddenMonitors
+    ? new Set<number>()
+    : await listStatusPageVisibleMonitorIds(c.env.DB, [...monitorIdsByWindowId.values()].flat());
+
+  return withVisibilityAwareCaching(
+    c.json({
+      maintenance_windows: windows.flatMap((w) => {
+        const originalMonitorIds = monitorIdsByWindowId.get(w.id) ?? [];
+        const filteredMonitorIds = filterStatusPageScopedMonitorIds(
+          originalMonitorIds,
+          visibleMonitorIds,
+          includeHiddenMonitors,
+        );
+
+        if (!shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds)) {
+          return [];
+        }
+
+        return [maintenanceWindowRowToApi(w, filteredMonitorIds)];
+      }),
+      next_cursor,
+    }),
+    includeHiddenMonitors,
+  );
 });
 
 publicRoutes.get('/monitors/:id/day-context', async (c) => {
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
   const id = z.coerce.number().int().positive().parse(c.req.param('id'));
   const dayStartAt = z.coerce.number().int().nonnegative().parse(c.req.query('day_start_at'));
   const dayEndAt = dayStartAt + 86400;
@@ -662,6 +817,7 @@ publicRoutes.get('/monitors/:id/day-context', async (c) => {
       SELECT id
       FROM monitors
       WHERE id = ?1 AND is_active = 1
+        AND ${monitorVisibilityPredicate(includeHiddenMonitors)}
     `,
   )
     .bind(id)
@@ -717,23 +873,52 @@ publicRoutes.get('/monitors/:id/day-context', async (c) => {
     incidents.map((r) => r.id),
   );
 
-  return c.json({
-    day_start_at: dayStartAt,
-    day_end_at: dayEndAt,
-    maintenance_windows: maintenance.map((w) =>
-      maintenanceWindowRowToApi(w, monitorIdsByWindowId.get(w.id) ?? []),
-    ),
-    incidents: incidents.map((r) =>
-      incidentRowToApi(
-        r,
-        updatesByIncidentId.get(r.id) ?? [],
-        monitorIdsByIncidentId.get(r.id) ?? [],
-      ),
-    ),
-  });
+  const visibleMonitorIds = includeHiddenMonitors
+    ? new Set<number>()
+    : await listStatusPageVisibleMonitorIds(
+        c.env.DB,
+        [...monitorIdsByWindowId.values(), ...monitorIdsByIncidentId.values()].flat(),
+      );
+
+  return withVisibilityAwareCaching(
+    c.json({
+      day_start_at: dayStartAt,
+      day_end_at: dayEndAt,
+      maintenance_windows: maintenance.flatMap((w) => {
+        const originalMonitorIds = monitorIdsByWindowId.get(w.id) ?? [];
+        const filteredMonitorIds = filterStatusPageScopedMonitorIds(
+          originalMonitorIds,
+          visibleMonitorIds,
+          includeHiddenMonitors,
+        );
+
+        if (!shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds)) {
+          return [];
+        }
+
+        return [maintenanceWindowRowToApi(w, filteredMonitorIds)];
+      }),
+      incidents: incidents.flatMap((r) => {
+        const originalMonitorIds = monitorIdsByIncidentId.get(r.id) ?? [];
+        const filteredMonitorIds = filterStatusPageScopedMonitorIds(
+          originalMonitorIds,
+          visibleMonitorIds,
+          includeHiddenMonitors,
+        );
+
+        if (!shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds)) {
+          return [];
+        }
+
+        return [incidentRowToApi(r, updatesByIncidentId.get(r.id) ?? [], filteredMonitorIds)];
+      }),
+    }),
+    includeHiddenMonitors,
+  );
 });
 
 publicRoutes.get('/monitors/:id/latency', async (c) => {
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
   const id = z.coerce.number().int().positive().parse(c.req.param('id'));
   const range = latencyRangeSchema.optional().default('24h').parse(c.req.query('range'));
 
@@ -742,6 +927,7 @@ publicRoutes.get('/monitors/:id/latency', async (c) => {
       SELECT id, name
       FROM monitors
       WHERE id = ?1 AND is_active = 1
+        AND ${monitorVisibilityPredicate(includeHiddenMonitors)}
     `,
   )
     .bind(id)
@@ -783,15 +969,18 @@ publicRoutes.get('/monitors/:id/latency', async (c) => {
       ? null
       : Math.round(upLatencies.reduce((acc, v) => acc + v, 0) / upLatencies.length);
 
-  return c.json({
-    monitor: { id: monitor.id, name: monitor.name },
-    range,
-    range_start_at: rangeStart,
-    range_end_at: rangeEnd,
-    avg_latency_ms,
-    p95_latency_ms: p95(upLatencies),
-    points,
-  });
+  return withVisibilityAwareCaching(
+    c.json({
+      monitor: { id: monitor.id, name: monitor.name },
+      range,
+      range_start_at: rangeStart,
+      range_end_at: rangeEnd,
+      avg_latency_ms,
+      p95_latency_ms: p95(upLatencies),
+      points,
+    }),
+    includeHiddenMonitors,
+  );
 });
 
 type OutageRow = { started_at: number; ended_at: number | null };
@@ -822,6 +1011,7 @@ function resolveUptimeRangeStart(
 }
 
 publicRoutes.get('/monitors/:id/uptime', async (c) => {
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
   const id = z.coerce.number().int().positive().parse(c.req.param('id'));
   const range = uptimeRangeSchema.optional().default('24h').parse(c.req.query('range'));
 
@@ -831,6 +1021,7 @@ publicRoutes.get('/monitors/:id/uptime', async (c) => {
       FROM monitors m
       LEFT JOIN monitor_state s ON s.monitor_id = m.id
       WHERE m.id = ?1 AND m.is_active = 1
+        AND ${monitorVisibilityPredicate(includeHiddenMonitors, 'm')}
     `,
   )
     .bind(id)
@@ -865,7 +1056,10 @@ publicRoutes.get('/monitors/:id/uptime', async (c) => {
     .bind(id, checksStart, rangeEnd)
     .all<{ checked_at: number; status: string }>();
 
-  const checks = (checkRows ?? []).map((r) => ({ checked_at: r.checked_at, status: toCheckStatus(r.status) }));
+  const checks = (checkRows ?? []).map((r) => ({
+    checked_at: r.checked_at,
+    status: toCheckStatus(r.status),
+  }));
   const effectiveRangeStart = resolveUptimeRangeStart(
     rangeStart,
     rangeEnd,
@@ -875,17 +1069,20 @@ publicRoutes.get('/monitors/:id/uptime', async (c) => {
   );
   const rangeStartAt = effectiveRangeStart ?? rangeStart;
   if (effectiveRangeStart === null || rangeEnd <= effectiveRangeStart) {
-    return c.json({
-      monitor: { id: monitor.id, name: monitor.name },
-      range,
-      range_start_at: rangeStartAt,
-      range_end_at: rangeEnd,
-      total_sec: 0,
-      downtime_sec: 0,
-      unknown_sec: 0,
-      uptime_sec: 0,
-      uptime_pct: 0,
-    });
+    return withVisibilityAwareCaching(
+      c.json({
+        monitor: { id: monitor.id, name: monitor.name },
+        range,
+        range_start_at: rangeStartAt,
+        range_end_at: rangeEnd,
+        total_sec: 0,
+        downtime_sec: 0,
+        unknown_sec: 0,
+        uptime_sec: 0,
+        uptime_pct: 0,
+      }),
+      includeHiddenMonitors,
+    );
   }
 
   const total_sec = rangeEnd - effectiveRangeStart;
@@ -934,17 +1131,20 @@ publicRoutes.get('/monitors/:id/uptime', async (c) => {
   const uptime_sec = Math.max(0, total_sec - unavailable_sec);
   const uptime_pct = total_sec === 0 ? 0 : (uptime_sec / total_sec) * 100;
 
-  return c.json({
-    monitor: { id: monitor.id, name: monitor.name },
-    range,
-    range_start_at: rangeStartAt,
-    range_end_at: rangeEnd,
-    total_sec,
-    downtime_sec,
-    unknown_sec,
-    uptime_sec,
-    uptime_pct,
-  });
+  return withVisibilityAwareCaching(
+    c.json({
+      monitor: { id: monitor.id, name: monitor.name },
+      range,
+      range_start_at: rangeStartAt,
+      range_end_at: rangeEnd,
+      total_sec,
+      downtime_sec,
+      unknown_sec,
+      uptime_sec,
+      uptime_pct,
+    }),
+    includeHiddenMonitors,
+  );
 });
 
 async function computePartialUptimeTotals(
@@ -975,7 +1175,10 @@ async function computePartialUptimeTotals(
     .bind(monitorId, checksStart, rangeEnd)
     .all<{ checked_at: number; status: string }>();
 
-  const checks = (checkRows ?? []).map((r) => ({ checked_at: r.checked_at, status: toCheckStatus(r.status) }));
+  const checks = (checkRows ?? []).map((r) => ({
+    checked_at: r.checked_at,
+    status: toCheckStatus(r.status),
+  }));
   const effectiveRangeStart = resolveUptimeRangeStart(
     rangeStart,
     rangeEnd,
@@ -1034,6 +1237,7 @@ async function computePartialUptimeTotals(
 }
 
 publicRoutes.get('/analytics/uptime', async (c) => {
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
   const range = uptimeOverviewRangeSchema.optional().default('30d').parse(c.req.query('range'));
 
   const now = Math.floor(Date.now() / 1000);
@@ -1048,6 +1252,7 @@ publicRoutes.get('/analytics/uptime', async (c) => {
       FROM monitors m
       LEFT JOIN monitor_state s ON s.monitor_id = m.id
       WHERE m.is_active = 1
+        AND ${monitorVisibilityPredicate(includeHiddenMonitors, 'm')}
       ORDER BY m.id
     `,
   ).all<{
@@ -1155,17 +1360,27 @@ publicRoutes.get('/analytics/uptime', async (c) => {
 
   const overall_uptime_pct = total_sec === 0 ? 0 : (uptime_sec / total_sec) * 100;
 
-  return c.json({
-    generated_at: now,
-    range,
-    range_start_at: rangeStart,
-    range_end_at: rangeEnd,
-    overall: { total_sec, downtime_sec, unknown_sec, uptime_sec, uptime_pct: overall_uptime_pct },
-    monitors: out,
-  });
+  return withVisibilityAwareCaching(
+    c.json({
+      generated_at: now,
+      range,
+      range_start_at: rangeStart,
+      range_end_at: rangeEnd,
+      overall: {
+        total_sec,
+        downtime_sec,
+        unknown_sec,
+        uptime_sec,
+        uptime_pct: overall_uptime_pct,
+      },
+      monitors: out,
+    }),
+    includeHiddenMonitors,
+  );
 });
 
 publicRoutes.get('/monitors/:id/outages', async (c) => {
+  const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
   const id = z.coerce.number().int().positive().parse(c.req.param('id'));
   const range = z.enum(['30d']).optional().default('30d').parse(c.req.query('range'));
   const limit = z.coerce
@@ -1179,7 +1394,12 @@ publicRoutes.get('/monitors/:id/outages', async (c) => {
   const cursor = z.coerce.number().int().positive().optional().parse(c.req.query('cursor'));
 
   const monitor = await c.env.DB.prepare(
-    'SELECT id, created_at FROM monitors WHERE id = ?1 AND is_active = 1',
+    `
+      SELECT id, created_at
+      FROM monitors
+      WHERE id = ?1 AND is_active = 1
+        AND ${monitorVisibilityPredicate(includeHiddenMonitors)}
+    `,
   )
     .bind(id)
     .first<{ id: number; created_at: number }>();
@@ -1238,20 +1458,23 @@ publicRoutes.get('/monitors/:id/outages', async (c) => {
   const page = rows.slice(0, limit);
   const next_cursor = rows.length > limit ? (page[page.length - 1]?.id ?? null) : null;
 
-  return c.json({
-    range: range as '30d',
-    range_start_at: rangeStart,
-    range_end_at: rangeEnd,
-    outages: page.map((r) => ({
-      id: r.id,
-      monitor_id: id,
-      started_at: r.started_at,
-      ended_at: r.ended_at,
-      initial_error: r.initial_error,
-      last_error: r.last_error,
-    })),
-    next_cursor,
-  });
+  return withVisibilityAwareCaching(
+    c.json({
+      range: range as '30d',
+      range_start_at: rangeStart,
+      range_end_at: rangeEnd,
+      outages: page.map((r) => ({
+        id: r.id,
+        monitor_id: id,
+        started_at: r.started_at,
+        ended_at: r.ended_at,
+        initial_error: r.initial_error,
+        last_error: r.last_error,
+      })),
+      next_cursor,
+    }),
+    includeHiddenMonitors,
+  );
 });
 publicRoutes.get('/health', async (c) => {
   // Minimal DB touch to verify the Worker can connect to D1.

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -7,8 +7,12 @@ import type { Env } from '../env';
 import { hasValidAdminTokenRequest } from '../middleware/auth';
 import { computePublicStatusPayload } from '../public/status';
 import {
+  buildNumberedPlaceholders,
+  chunkPositiveIntegerIds,
   filterStatusPageScopedMonitorIds,
+  incidentStatusPageVisibilityPredicate,
   listStatusPageVisibleMonitorIds,
+  maintenanceWindowStatusPageVisibilityPredicate,
   monitorVisibilityPredicate,
   shouldIncludeStatusPageScopedItem,
 } from '../public/visibility';
@@ -359,24 +363,25 @@ async function listIncidentUpdatesByIncidentId(
   incidentIds: number[],
 ): Promise<Map<number, IncidentUpdateRow[]>> {
   const byIncident = new Map<number, IncidentUpdateRow[]>();
-  if (incidentIds.length === 0) return byIncident;
 
-  const placeholders = incidentIds.map((_, idx) => `?${idx + 1}`).join(', ');
-  const sql = `
-    SELECT id, incident_id, status, message, created_at
-    FROM incident_updates
-    WHERE incident_id IN (${placeholders})
-    ORDER BY incident_id, created_at, id
-  `;
+  for (const ids of chunkPositiveIntegerIds(incidentIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length);
+    const sql = `
+      SELECT id, incident_id, status, message, created_at
+      FROM incident_updates
+      WHERE incident_id IN (${placeholders})
+      ORDER BY incident_id, created_at, id
+    `;
 
-  const { results } = await db
-    .prepare(sql)
-    .bind(...incidentIds)
-    .all<IncidentUpdateRow>();
-  for (const r of results ?? []) {
-    const existing = byIncident.get(r.incident_id) ?? [];
-    existing.push(r);
-    byIncident.set(r.incident_id, existing);
+    const { results } = await db
+      .prepare(sql)
+      .bind(...ids)
+      .all<IncidentUpdateRow>();
+    for (const r of results ?? []) {
+      const existing = byIncident.get(r.incident_id) ?? [];
+      existing.push(r);
+      byIncident.set(r.incident_id, existing);
+    }
   }
 
   return byIncident;
@@ -387,24 +392,25 @@ async function listIncidentMonitorIdsByIncidentId(
   incidentIds: number[],
 ): Promise<Map<number, number[]>> {
   const byIncident = new Map<number, number[]>();
-  if (incidentIds.length === 0) return byIncident;
 
-  const placeholders = incidentIds.map((_, idx) => `?${idx + 1}`).join(', ');
-  const sql = `
-    SELECT incident_id, monitor_id
-    FROM incident_monitors
-    WHERE incident_id IN (${placeholders})
-    ORDER BY incident_id, monitor_id
-  `;
+  for (const ids of chunkPositiveIntegerIds(incidentIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length);
+    const sql = `
+      SELECT incident_id, monitor_id
+      FROM incident_monitors
+      WHERE incident_id IN (${placeholders})
+      ORDER BY incident_id, monitor_id
+    `;
 
-  const { results } = await db
-    .prepare(sql)
-    .bind(...incidentIds)
-    .all<IncidentMonitorLinkRow>();
-  for (const r of results ?? []) {
-    const existing = byIncident.get(r.incident_id) ?? [];
-    existing.push(r.monitor_id);
-    byIncident.set(r.incident_id, existing);
+    const { results } = await db
+      .prepare(sql)
+      .bind(...ids)
+      .all<IncidentMonitorLinkRow>();
+    for (const r of results ?? []) {
+      const existing = byIncident.get(r.incident_id) ?? [];
+      existing.push(r.monitor_id);
+      byIncident.set(r.incident_id, existing);
+    }
   }
 
   return byIncident;
@@ -441,81 +447,28 @@ async function listMaintenanceWindowMonitorIdsByWindowId(
   windowIds: number[],
 ): Promise<Map<number, number[]>> {
   const byWindow = new Map<number, number[]>();
-  if (windowIds.length === 0) return byWindow;
 
-  const placeholders = windowIds.map((_, idx) => `?${idx + 1}`).join(', ');
-  const sql = `
-    SELECT maintenance_window_id, monitor_id
-    FROM maintenance_window_monitors
-    WHERE maintenance_window_id IN (${placeholders})
-    ORDER BY maintenance_window_id, monitor_id
-  `;
+  for (const ids of chunkPositiveIntegerIds(windowIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length);
+    const sql = `
+      SELECT maintenance_window_id, monitor_id
+      FROM maintenance_window_monitors
+      WHERE maintenance_window_id IN (${placeholders})
+      ORDER BY maintenance_window_id, monitor_id
+    `;
 
-  const { results } = await db
-    .prepare(sql)
-    .bind(...windowIds)
-    .all<MaintenanceWindowMonitorLinkRow>();
-  for (const r of results ?? []) {
-    const existing = byWindow.get(r.maintenance_window_id) ?? [];
-    existing.push(r.monitor_id);
-    byWindow.set(r.maintenance_window_id, existing);
+    const { results } = await db
+      .prepare(sql)
+      .bind(...ids)
+      .all<MaintenanceWindowMonitorLinkRow>();
+    for (const r of results ?? []) {
+      const existing = byWindow.get(r.maintenance_window_id) ?? [];
+      existing.push(r.monitor_id);
+      byWindow.set(r.maintenance_window_id, existing);
+    }
   }
 
   return byWindow;
-}
-
-async function listIncidentRowsVisibleOnStatusPage(
-  db: D1Database,
-  rows: IncidentRow[],
-  includeHiddenMonitors: boolean,
-): Promise<IncidentRow[]> {
-  if (includeHiddenMonitors || rows.length === 0) return rows;
-
-  const monitorIdsByIncidentId = await listIncidentMonitorIdsByIncidentId(
-    db,
-    rows.map((row) => row.id),
-  );
-  const visibleMonitorIds = await listStatusPageVisibleMonitorIds(
-    db,
-    [...monitorIdsByIncidentId.values()].flat(),
-  );
-
-  return rows.filter((row) => {
-    const originalMonitorIds = monitorIdsByIncidentId.get(row.id) ?? [];
-    const filteredMonitorIds = filterStatusPageScopedMonitorIds(
-      originalMonitorIds,
-      visibleMonitorIds,
-      includeHiddenMonitors,
-    );
-    return shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds);
-  });
-}
-
-async function listMaintenanceWindowRowsVisibleOnStatusPage(
-  db: D1Database,
-  rows: MaintenanceWindowRow[],
-  includeHiddenMonitors: boolean,
-): Promise<MaintenanceWindowRow[]> {
-  if (includeHiddenMonitors || rows.length === 0) return rows;
-
-  const monitorIdsByWindowId = await listMaintenanceWindowMonitorIdsByWindowId(
-    db,
-    rows.map((row) => row.id),
-  );
-  const visibleMonitorIds = await listStatusPageVisibleMonitorIds(
-    db,
-    [...monitorIdsByWindowId.values()].flat(),
-  );
-
-  return rows.filter((row) => {
-    const originalMonitorIds = monitorIdsByWindowId.get(row.id) ?? [];
-    const filteredMonitorIds = filterStatusPageScopedMonitorIds(
-      originalMonitorIds,
-      visibleMonitorIds,
-      includeHiddenMonitors,
-    );
-    return shouldIncludeStatusPageScopedItem(originalMonitorIds, filteredMonitorIds);
-  });
 }
 
 publicRoutes.get('/status', async (c) => {
@@ -597,6 +550,7 @@ publicRoutes.get('/incidents', async (c) => {
       .optional()
       .default(0)
       .parse(c.req.query('resolved_only')) === 1;
+  const incidentVisibilitySql = incidentStatusPageVisibilityPredicate(includeHiddenMonitors);
 
   let active: IncidentRow[] = [];
   let remaining = limit;
@@ -607,16 +561,15 @@ publicRoutes.get('/incidents', async (c) => {
         SELECT id, title, status, impact, message, started_at, resolved_at
         FROM incidents
         WHERE status != 'resolved'
+          AND ${incidentVisibilitySql}
         ORDER BY started_at DESC, id DESC
+        LIMIT ?1
       `,
-    ).all<IncidentRow>();
+    )
+      .bind(limit)
+      .all<IncidentRow>();
 
-    active = await listIncidentRowsVisibleOnStatusPage(
-      c.env.DB,
-      activeRows ?? [],
-      includeHiddenMonitors,
-    );
-    active = active.slice(0, limit);
+    active = activeRows ?? [];
     remaining = Math.max(0, limit - active.length);
   }
 
@@ -628,6 +581,7 @@ publicRoutes.get('/incidents', async (c) => {
       SELECT id, title, status, impact, message, started_at, resolved_at
       FROM incidents
       WHERE status = 'resolved'
+        AND ${incidentVisibilitySql}
     `;
 
     const resolvedLimitPlusOne = remaining + 1;
@@ -660,12 +614,7 @@ publicRoutes.get('/incidents', async (c) => {
       const allResolved = resolvedRows ?? [];
       if (allResolved.length === 0) break;
 
-      const visibleResolved = await listIncidentRowsVisibleOnStatusPage(
-        c.env.DB,
-        allResolved,
-        includeHiddenMonitors,
-      );
-      collected.push(...visibleResolved);
+      collected.push(...allResolved);
 
       const lastRow = allResolved[allResolved.length - 1];
       if (allResolved.length < batchLimit || !lastRow) break;
@@ -725,10 +674,14 @@ publicRoutes.get('/maintenance-windows', async (c) => {
   const cursor = z.coerce.number().int().positive().optional().parse(c.req.query('cursor'));
 
   const now = Math.floor(Date.now() / 1000);
+  const maintenanceVisibilitySql = maintenanceWindowStatusPageVisibilityPredicate(
+    includeHiddenMonitors,
+  );
   const baseSql = `
     SELECT id, title, message, starts_at, ends_at, created_at
     FROM maintenance_windows
     WHERE ends_at <= ?1
+      AND ${maintenanceVisibilitySql}
   `;
   const limitPlusOne = limit + 1;
   const batchLimit = Math.max(50, limitPlusOne);
@@ -760,12 +713,7 @@ publicRoutes.get('/maintenance-windows', async (c) => {
     const allWindows = windowRows ?? [];
     if (allWindows.length === 0) break;
 
-    const visibleWindows = await listMaintenanceWindowRowsVisibleOnStatusPage(
-      c.env.DB,
-      allWindows,
-      includeHiddenMonitors,
-    );
-    collected.push(...visibleWindows);
+    collected.push(...allWindows);
 
     const lastRow = allWindows[allWindows.length - 1];
     if (allWindows.length < batchLimit || !lastRow) break;

--- a/apps/worker/src/schemas/monitors.ts
+++ b/apps/worker/src/schemas/monitors.ts
@@ -26,6 +26,7 @@ export const createMonitorInputSchema = z
     group_name: monitorGroupNameSchema.optional(),
     group_sort_order: monitorGroupSortOrderSchema.optional(),
     sort_order: monitorSortOrderSchema.optional(),
+    show_on_status_page: z.boolean().optional(),
     is_active: z.boolean().optional(),
   })
   .superRefine((val, ctx) => {
@@ -71,6 +72,7 @@ export const patchMonitorInputSchema = z
     group_name: monitorGroupNameSchema.nullable().optional(),
     group_sort_order: monitorGroupSortOrderSchema.optional(),
     sort_order: monitorSortOrderSchema.optional(),
+    show_on_status_page: z.boolean().optional(),
     is_active: z.boolean().optional(),
   })
   .refine((val) => Object.keys(val).length > 0, {

--- a/apps/worker/test/middleware-cache-public.test.ts
+++ b/apps/worker/test/middleware-cache-public.test.ts
@@ -27,12 +27,31 @@ function makeContext(options: {
   method: string;
   url: string;
   response: Response;
+  authorization?: string;
   waitUntil?: ReturnType<typeof vi.fn>;
-}): { c: { req: { method: string; url: string }; res: Response; executionCtx: { waitUntil: ReturnType<typeof vi.fn> } }; waitUntil: ReturnType<typeof vi.fn> } {
+}): {
+  c: {
+    req: { method: string; url: string; header(name: string): string | undefined };
+    res: Response;
+    executionCtx: { waitUntil: ReturnType<typeof vi.fn> };
+  };
+  waitUntil: ReturnType<typeof vi.fn>;
+} {
   const waitUntil = options.waitUntil ?? vi.fn();
+  const headers = new Headers();
+  if (options.authorization) {
+    headers.set('Authorization', options.authorization);
+  }
+
   return {
     c: {
-      req: { method: options.method, url: options.url },
+      req: {
+        method: options.method,
+        url: options.url,
+        header(name: string) {
+          return headers.get(name) ?? undefined;
+        },
+      },
       res: options.response,
       executionCtx: { waitUntil },
     },
@@ -141,5 +160,34 @@ describe('middleware/cache-public', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(open).not.toHaveBeenCalled();
     expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+
+  it('bypasses shared cache for GET requests that carry Authorization', async () => {
+    const store = new Map<string, Response>();
+    const url = 'https://status.example.com/api/v1/public/status';
+    store.set(url, new Response('cached-anon', { status: 200 }));
+    const open = installCacheMock(store);
+    const middleware = cachePublic({ cacheName: 'uptimer-public', maxAgeSeconds: 45 });
+    const { c, waitUntil } = makeContext({
+      method: 'GET',
+      url,
+      authorization: 'Bearer secret-token',
+      response: new Response('seed', { status: 200 }),
+    });
+    const next = vi.fn(async () => {
+      c.res = new Response('live-admin', {
+        status: 200,
+        headers: { 'Cache-Control': 'private, no-store' },
+      });
+    });
+
+    await middleware(c as never, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(open).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+    expect(await c.res.text()).toBe('live-admin');
+    expect(await store.get(url)?.text()).toBe('cached-anon');
   });
 });

--- a/apps/worker/test/public-status.test.ts
+++ b/apps/worker/test/public-status.test.ts
@@ -149,6 +149,10 @@ describe('public/status payload regression', () => {
         all: () => [{ incident_id: 5, monitor_id: 11 }],
       },
       {
+        match: (sql) => sql.includes('from monitors') && sql.includes('show_on_status_page = 1'),
+        all: () => [{ id: 11 }],
+      },
+      {
         match: 'from incident_updates',
         all: () => [
           {
@@ -676,5 +680,193 @@ describe('public/status payload regression', () => {
       uptime_sec: 210,
     });
     expect(today?.uptime_pct).toBeCloseTo(100, 6);
+  });
+});
+
+it('filters hidden monitors and hidden-only scoped events from anonymous status payloads', async () => {
+  const now = 1_728_500_000;
+
+  const handlers: FakeD1QueryHandler[] = [
+    {
+      match: (sql) => sql.includes('from monitors m') && sql.includes('show_on_status_page = 1'),
+      all: () => [
+        {
+          id: 11,
+          name: 'Public API',
+          type: 'http',
+          group_name: 'Core',
+          group_sort_order: 0,
+          sort_order: 0,
+          interval_sec: 60,
+          created_at: now - 40 * 86_400,
+          state_status: 'up',
+          last_checked_at: now - 30,
+          last_latency_ms: 84,
+        },
+      ],
+    },
+    {
+      match: (sql) => sql.includes('from monitors m') && sql.includes('and 1 = 1'),
+      all: () => [
+        {
+          id: 11,
+          name: 'Public API',
+          type: 'http',
+          group_name: 'Core',
+          group_sort_order: 0,
+          sort_order: 0,
+          interval_sec: 60,
+          created_at: now - 40 * 86_400,
+          state_status: 'up',
+          last_checked_at: now - 30,
+          last_latency_ms: 84,
+        },
+        {
+          id: 22,
+          name: 'Private Admin',
+          type: 'http',
+          group_name: 'Internal',
+          group_sort_order: 1,
+          sort_order: 0,
+          interval_sec: 60,
+          created_at: now - 40 * 86_400,
+          state_status: 'down',
+          last_checked_at: now - 30,
+          last_latency_ms: 120,
+        },
+      ],
+    },
+    {
+      match: 'select distinct mwm.monitor_id',
+      all: () => [],
+    },
+    {
+      match: 'select value from settings where key = ?1',
+      first: (args) => (args[0] === 'uptime_rating_level' ? { value: '3' } : null),
+    },
+    {
+      match: 'row_number() over',
+      all: () => [],
+    },
+    {
+      match: 'from monitor_daily_rollups',
+      all: () => [],
+    },
+    {
+      match: (sql) => sql.includes('from outages') && sql.includes('monitor_id in'),
+      all: () => [],
+    },
+    {
+      match: (sql) =>
+        sql.includes('select monitor_id, checked_at, status') && sql.includes('monitor_id in'),
+      all: () => [],
+    },
+    {
+      match: (sql) => sql.includes('from incidents') && sql.includes("where status != 'resolved'"),
+      all: () => [
+        {
+          id: 1,
+          title: 'Private control plane outage',
+          status: 'identified',
+          impact: 'major',
+          message: 'Internal only',
+          started_at: now - 600,
+          resolved_at: null,
+        },
+        {
+          id: 2,
+          title: 'Shared API latency',
+          status: 'monitoring',
+          impact: 'minor',
+          message: 'Customer-visible',
+          started_at: now - 300,
+          resolved_at: null,
+        },
+      ],
+    },
+    {
+      match: 'from incident_monitors',
+      all: () => [
+        { incident_id: 1, monitor_id: 22 },
+        { incident_id: 2, monitor_id: 11 },
+        { incident_id: 2, monitor_id: 22 },
+      ],
+    },
+    {
+      match: 'from incident_updates',
+      all: () => [],
+    },
+    {
+      match: 'from maintenance_windows where starts_at <= ?1 and ends_at > ?1',
+      all: () => [
+        {
+          id: 5,
+          title: 'Private cluster maintenance',
+          message: 'Do not expose',
+          starts_at: now - 900,
+          ends_at: now + 900,
+          created_at: now - 1_800,
+        },
+      ],
+    },
+    {
+      match: 'from maintenance_windows where starts_at > ?1',
+      all: () => [
+        {
+          id: 6,
+          title: 'Shared API rollout',
+          message: 'Public notice',
+          starts_at: now + 3_600,
+          ends_at: now + 7_200,
+          created_at: now - 1_200,
+        },
+      ],
+    },
+    {
+      match: 'from maintenance_window_monitors',
+      all: () => [
+        { maintenance_window_id: 5, monitor_id: 22 },
+        { maintenance_window_id: 6, monitor_id: 11 },
+        { maintenance_window_id: 6, monitor_id: 22 },
+      ],
+    },
+    {
+      match: (sql) => sql.includes('from monitors') && sql.includes('show_on_status_page = 1'),
+      all: () => [{ id: 11 }],
+    },
+    {
+      match: 'select key, value from settings',
+      all: () => [{ key: 'site_title', value: 'Status Hub' }],
+    },
+  ];
+
+  const db = createFakeD1Database(handlers);
+
+  const anonymousPayload = await computePublicStatusPayload(db, now);
+  expect(anonymousPayload.monitors.map((monitor) => monitor.id)).toEqual([11]);
+  expect(anonymousPayload.active_incidents).toHaveLength(1);
+  expect(anonymousPayload.active_incidents[0]).toMatchObject({
+    id: 2,
+    monitor_ids: [11],
+  });
+  expect(anonymousPayload.maintenance_windows.active).toEqual([]);
+  expect(anonymousPayload.maintenance_windows.upcoming[0]).toMatchObject({
+    id: 6,
+    monitor_ids: [11],
+  });
+  expect(anonymousPayload.banner).toMatchObject({
+    source: 'incident',
+    status: 'partial_outage',
+  });
+
+  const adminPayload = await computePublicStatusPayload(db, now, { includeHiddenMonitors: true });
+  expect(adminPayload.monitors.map((monitor) => monitor.id)).toEqual([11, 22]);
+  expect(adminPayload.active_incidents.map((incident) => incident.id)).toEqual([1, 2]);
+  expect(adminPayload.active_incidents[0]?.monitor_ids).toEqual([22]);
+  expect(adminPayload.maintenance_windows.active[0]?.monitor_ids).toEqual([22]);
+  expect(adminPayload.maintenance_windows.upcoming[0]?.monitor_ids).toEqual([11, 22]);
+  expect(adminPayload.banner).toMatchObject({
+    source: 'incident',
+    status: 'major_outage',
   });
 });

--- a/apps/worker/test/public-status.test.ts
+++ b/apps/worker/test/public-status.test.ts
@@ -870,3 +870,150 @@ it('filters hidden monitors and hidden-only scoped events from anonymous status 
     status: 'major_outage',
   });
 });
+
+it('bounds anonymous incident and maintenance status queries before expanding related rows', async () => {
+  const now = 1_728_510_000;
+  const activeIncidentSqls: string[] = [];
+  const activeIncidentArgs: unknown[][] = [];
+  const activeMaintenanceSqls: string[] = [];
+  const activeMaintenanceArgs: unknown[][] = [];
+  const upcomingMaintenanceSqls: string[] = [];
+  const upcomingMaintenanceArgs: unknown[][] = [];
+
+  const handlers: FakeD1QueryHandler[] = [
+    {
+      match: (sql) => sql.includes('from monitors m') && sql.includes('show_on_status_page = 1'),
+      all: () => [
+        {
+          id: 11,
+          name: 'Public API',
+          type: 'http',
+          group_name: 'Core',
+          group_sort_order: 0,
+          sort_order: 0,
+          interval_sec: 60,
+          created_at: now - 40 * 86_400,
+          state_status: 'up',
+          last_checked_at: now - 30,
+          last_latency_ms: 84,
+        },
+      ],
+    },
+    {
+      match: 'select distinct mwm.monitor_id',
+      all: () => [],
+    },
+    {
+      match: 'select value from settings where key = ?1',
+      first: (args) => (args[0] === 'uptime_rating_level' ? { value: '3' } : null),
+    },
+    {
+      match: 'row_number() over',
+      all: () => [],
+    },
+    {
+      match: 'from monitor_daily_rollups',
+      all: () => [],
+    },
+    {
+      match: (sql) => sql.includes('from outages') && sql.includes('monitor_id in'),
+      all: () => [],
+    },
+    {
+      match: (sql) =>
+        sql.includes('select monitor_id, checked_at, status') && sql.includes('monitor_id in'),
+      all: () => [],
+    },
+    {
+      match: (sql) => sql.includes('from incidents') && sql.includes("where status != 'resolved'"),
+      all: (args, sql) => {
+        activeIncidentArgs.push([...args]);
+        activeIncidentSqls.push(sql);
+        return [
+          {
+            id: 2,
+            title: 'Shared API latency',
+            status: 'monitoring',
+            impact: 'minor',
+            message: 'Customer-visible',
+            started_at: now - 300,
+            resolved_at: null,
+          },
+        ];
+      },
+    },
+    {
+      match: 'from incident_monitors',
+      all: () => [{ incident_id: 2, monitor_id: 11 }],
+    },
+    {
+      match: 'from incident_updates',
+      all: () => [],
+    },
+    {
+      match: 'from maintenance_windows where starts_at <= ?1 and ends_at > ?1',
+      all: (args, sql) => {
+        activeMaintenanceArgs.push([...args]);
+        activeMaintenanceSqls.push(sql);
+        return [
+          {
+            id: 5,
+            title: 'Shared API maintenance',
+            message: 'Public notice',
+            starts_at: now - 900,
+            ends_at: now + 900,
+            created_at: now - 1_800,
+          },
+        ];
+      },
+    },
+    {
+      match: 'from maintenance_windows where starts_at > ?1',
+      all: (args, sql) => {
+        upcomingMaintenanceArgs.push([...args]);
+        upcomingMaintenanceSqls.push(sql);
+        return [
+          {
+            id: 6,
+            title: 'Shared API rollout',
+            message: 'Public notice',
+            starts_at: now + 3_600,
+            ends_at: now + 7_200,
+            created_at: now - 1_200,
+          },
+        ];
+      },
+    },
+    {
+      match: 'from maintenance_window_monitors',
+      all: () => [
+        { maintenance_window_id: 5, monitor_id: 11 },
+        { maintenance_window_id: 6, monitor_id: 11 },
+      ],
+    },
+    {
+      match: (sql) => sql.includes('from monitors') && sql.includes('show_on_status_page = 1'),
+      all: () => [{ id: 11 }],
+    },
+    {
+      match: 'select key, value from settings',
+      all: () => [],
+    },
+  ];
+
+  const payload = await computePublicStatusPayload(createFakeD1Database(handlers), now);
+
+  expect(activeIncidentArgs[0]).toEqual([5]);
+  expect(activeIncidentSqls[0]).toContain('limit ?1');
+  expect(activeIncidentSqls[0]).toContain('not exists');
+  expect(activeIncidentSqls[0]).toContain('show_on_status_page = 1');
+  expect(activeMaintenanceArgs[0]).toEqual([now, 3]);
+  expect(activeMaintenanceSqls[0]).toContain('limit ?2');
+  expect(activeMaintenanceSqls[0]).toContain('not exists');
+  expect(upcomingMaintenanceArgs[0]).toEqual([now, 5]);
+  expect(upcomingMaintenanceSqls[0]).toContain('limit ?2');
+  expect(upcomingMaintenanceSqls[0]).toContain('show_on_status_page = 1');
+  expect(payload.active_incidents.map((incident) => incident.id)).toEqual([2]);
+  expect(payload.maintenance_windows.active.map((window) => window.id)).toEqual([5]);
+  expect(payload.maintenance_windows.upcoming.map((window) => window.id)).toEqual([6]);
+});

--- a/apps/worker/test/public-uptime-routes.test.ts
+++ b/apps/worker/test/public-uptime-routes.test.ts
@@ -25,10 +25,19 @@ function installCacheMock(store: CacheStore) {
   return open;
 }
 
-async function requestPublic(path: string, handlers: FakeD1QueryHandler[]) {
-  const env = { DB: createFakeD1Database(handlers) } as unknown as Env;
+async function requestPublic(
+  path: string,
+  handlers: FakeD1QueryHandler[],
+  opts: { adminToken?: string; authorization?: string } = {},
+) {
+  const env = {
+    DB: createFakeD1Database(handlers),
+    ADMIN_TOKEN: opts.adminToken ?? 'test-admin-token',
+  } as unknown as Env;
   const res = await publicRoutes.fetch(
-    new Request(`https://status.example.com${path}`),
+    new Request(`https://status.example.com${path}`, {
+      headers: opts.authorization ? { Authorization: opts.authorization } : undefined,
+    }),
     env,
     { waitUntil: vi.fn() } as unknown as ExecutionContext,
   );
@@ -161,6 +170,53 @@ describe('public routes uptime regression', () => {
           downtime_sec: 300,
         },
       ],
+    });
+  });
+
+  it('serves hidden monitor uptime to authorized admins with private cache headers', async () => {
+    const rangeEnd = 1_728_000_000;
+    const rangeStart = rangeEnd - 86_400;
+
+    vi.spyOn(Date, 'now').mockReturnValue(rangeEnd * 1000 + 5_000);
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: (sql) => sql.includes('from monitors m') && sql.includes('and 1 = 1'),
+        first: () => ({
+          id: 77,
+          name: 'Private Admin API',
+          interval_sec: 60,
+          created_at: rangeStart - 10 * 86_400,
+          last_checked_at: rangeEnd - 30,
+        }),
+      },
+      {
+        match: 'from check_results',
+        all: () => [
+          { checked_at: rangeStart - 60, status: 'up' },
+          { checked_at: rangeEnd - 60, status: 'up' },
+        ],
+      },
+      {
+        match: 'from outages',
+        all: () => [],
+      },
+    ];
+
+    const { res, body } = await requestPublic('/monitors/77/uptime?range=24h', handlers, {
+      adminToken: 'secret-token',
+      authorization: 'Bearer secret-token',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(res.headers.get('Vary')).toContain('Authorization');
+    expect(body).toMatchObject({
+      monitor: { id: 77, name: 'Private Admin API' },
+      range_start_at: rangeStart,
+      range_end_at: rangeEnd,
+      total_sec: 86_400,
+      downtime_sec: 0,
     });
   });
 });

--- a/apps/worker/test/public-uptime-routes.test.ts
+++ b/apps/worker/test/public-uptime-routes.test.ts
@@ -298,3 +298,124 @@ describe('public incident feed regression', () => {
     });
   });
 });
+
+describe('public route cache/auth regression', () => {
+  const originalCaches = (globalThis as { caches?: unknown }).caches;
+
+  afterEach(() => {
+    if (originalCaches === undefined) {
+      delete (globalThis as { caches?: unknown }).caches;
+    } else {
+      Object.defineProperty(globalThis, 'caches', {
+        configurable: true,
+        value: originalCaches,
+      });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('bypasses anonymous cache entries for authorized incident requests', async () => {
+    const store = new Map<string, Response>();
+    installCacheMock(store);
+    const now = 1_728_530_000;
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: (sql) =>
+          sql.includes('from incidents') &&
+          sql.includes("where status != 'resolved'") &&
+          sql.includes('show_on_status_page = 1'),
+        all: () => [
+          {
+            id: 2,
+            title: 'Shared API latency',
+            status: 'monitoring',
+            impact: 'minor',
+            message: 'Customer-visible',
+            started_at: now - 300,
+            resolved_at: null,
+          },
+        ],
+      },
+      {
+        match: (sql) =>
+          sql.includes('from incidents') &&
+          sql.includes("where status != 'resolved'") &&
+          sql.includes('1 = 1'),
+        all: () => [
+          {
+            id: 1,
+            title: 'Private control plane outage',
+            status: 'identified',
+            impact: 'major',
+            message: 'Internal only',
+            started_at: now - 120,
+            resolved_at: null,
+          },
+        ],
+      },
+      {
+        match: 'from incident_updates',
+        all: () => [],
+      },
+      {
+        match: 'from incident_monitors',
+        all: () => [
+          { incident_id: 1, monitor_id: 22 },
+          { incident_id: 2, monitor_id: 11 },
+        ],
+      },
+      {
+        match: (sql) => sql.includes('from monitors') && sql.includes('show_on_status_page = 1'),
+        all: () => [{ id: 11 }],
+      },
+    ];
+
+    const anonymous = await requestPublic('/incidents?limit=1', handlers);
+    expect(anonymous.res.status).toBe(200);
+    expect(anonymous.body).toMatchObject({
+      incidents: [
+        {
+          id: 2,
+          monitor_ids: [11],
+        },
+      ],
+    });
+
+    const cachedAnonymous = store.get('https://status.example.com/incidents?limit=1')?.clone();
+    expect(cachedAnonymous).toBeDefined();
+    expect(await cachedAnonymous?.json()).toMatchObject({
+      incidents: [
+        {
+          id: 2,
+        },
+      ],
+    });
+
+    const admin = await requestPublic('/incidents?limit=1', handlers, {
+      adminToken: 'secret-token',
+      authorization: 'Bearer secret-token',
+    });
+
+    expect(admin.res.status).toBe(200);
+    expect(admin.res.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(admin.res.headers.get('Vary')).toContain('Authorization');
+    expect(admin.body).toMatchObject({
+      incidents: [
+        {
+          id: 1,
+          monitor_ids: [22],
+        },
+      ],
+    });
+
+    const cachedAfterAdmin = store.get('https://status.example.com/incidents?limit=1')?.clone();
+    expect(await cachedAfterAdmin?.json()).toMatchObject({
+      incidents: [
+        {
+          id: 2,
+        },
+      ],
+    });
+  });
+});

--- a/apps/worker/test/public-uptime-routes.test.ts
+++ b/apps/worker/test/public-uptime-routes.test.ts
@@ -220,3 +220,81 @@ describe('public routes uptime regression', () => {
     });
   });
 });
+
+describe('public incident feed regression', () => {
+  const originalCaches = (globalThis as { caches?: unknown }).caches;
+
+  beforeEach(() => {
+    installCacheMock(new Map());
+  });
+
+  afterEach(() => {
+    if (originalCaches === undefined) {
+      delete (globalThis as { caches?: unknown }).caches;
+    } else {
+      Object.defineProperty(globalThis, 'caches', {
+        configurable: true,
+        value: originalCaches,
+      });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('filters anonymous incident feeds in SQL before applying the active limit', async () => {
+    const now = 1_728_520_000;
+    const activeIncidentSqls: string[] = [];
+    const activeIncidentArgs: unknown[][] = [];
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: (sql) => sql.includes('from incidents') && sql.includes("where status != 'resolved'"),
+        all: (args, sql) => {
+          activeIncidentArgs.push([...args]);
+          activeIncidentSqls.push(sql);
+          return [
+            {
+              id: 2,
+              title: 'Shared API latency',
+              status: 'monitoring',
+              impact: 'minor',
+              message: 'Customer-visible',
+              started_at: now - 300,
+              resolved_at: null,
+            },
+          ];
+        },
+      },
+      {
+        match: 'from incident_updates',
+        all: () => [],
+      },
+      {
+        match: 'from incident_monitors',
+        all: () => [{ incident_id: 2, monitor_id: 11 }],
+      },
+      {
+        match: (sql) => sql.includes('from monitors') && sql.includes('show_on_status_page = 1'),
+        all: () => [{ id: 11 }],
+      },
+    ];
+
+    const { res, body } = await requestPublic('/incidents?limit=1', handlers);
+
+    expect(res.status).toBe(200);
+    expect(activeIncidentArgs[0]).toEqual([1]);
+    expect(activeIncidentSqls[0]).toContain('limit ?1');
+    expect(activeIncidentSqls[0]).toContain('not exists');
+    expect(activeIncidentSqls[0]).toContain('show_on_status_page = 1');
+    expect(body).toMatchObject({
+      incidents: [
+        {
+          id: 2,
+          status: 'monitoring',
+          monitor_ids: [11],
+          updates: [],
+        },
+      ],
+      next_cursor: null,
+    });
+  });
+});

--- a/apps/worker/test/public-visibility.test.ts
+++ b/apps/worker/test/public-visibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { listStatusPageVisibleMonitorIds } from '../src/public/visibility';
+import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
+
+describe('public visibility helpers', () => {
+  it('chunks visible monitor lookups before building D1 IN clauses', async () => {
+    const bindCalls: unknown[][] = [];
+    const ids = Array.from({ length: 450 }, (_, idx) => idx + 1);
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: (sql) => sql.includes('from monitors') && sql.includes('show_on_status_page = 1'),
+        all: (args) => {
+          bindCalls.push([...args]);
+          return args
+            .map((id) => Number(id))
+            .filter((id) => id % 2 === 0)
+            .map((id) => ({ id }));
+        },
+      },
+    ];
+
+    const visibleMonitorIds = await listStatusPageVisibleMonitorIds(
+      createFakeD1Database(handlers),
+      ids,
+    );
+
+    expect(bindCalls.length).toBeGreaterThan(1);
+    expect(visibleMonitorIds.has(2)).toBe(true);
+    expect(visibleMonitorIds.has(3)).toBe(false);
+    expect(visibleMonitorIds.has(450)).toBe(true);
+  });
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -37,6 +37,7 @@ export const monitors = sqliteTable(
     groupName: text('group_name'),
     groupSortOrder: integer('group_sort_order').notNull().default(0),
     sortOrder: integer('sort_order').notNull().default(0),
+    showOnStatusPage: integer('show_on_status_page', { mode: 'boolean' }).notNull().default(true),
     isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
     createdAt: integer('created_at')
       .notNull()


### PR DESCRIPTION
## What
- add a `show_on_status_page` flag for monitors, with a new D1 migration and admin create/update/list support
- hide flagged monitors from anonymous public status payloads and public monitor-scoped endpoints while still showing them to authenticated admins
- show a hidden/private badge in the admin monitor list so operators can spot hidden monitors without opening the edit dialog

## Why
- some monitors are operationally useful for checks and notifications but should not be exposed on the public status page
- authenticated admin views must stay cache-safe, so admin-visible public responses bypass shared public snapshots and return `private, no-store`

## Where
- worker/public filtering and auth-aware caching in `apps/worker/src/public/status.ts`, `apps/worker/src/public/visibility.ts`, and `apps/worker/src/routes/public.ts`
- admin monitor flag plumbing in `packages/db/src/schema.ts`, `apps/worker/migrations/0009_monitor_status_page_visibility.sql`, `apps/worker/src/routes/admin.ts`, and `apps/web/src/components/MonitorForm.tsx`
- admin list visibility badge in `apps/web/src/pages/AdminDashboard.tsx`

## How to verify
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- create or edit a monitor, turn off `Show on status page`, confirm it disappears for anonymous visitors and still appears after admin login

Closes #21.
