### PR TITLE
perf(worker): batch scheduler persistence to reduce CPU time

### DIFF
--- a/Develop/LOCAL-TESTING.md
+++ b/Develop/LOCAL-TESTING.md
@@ -390,6 +390,36 @@ Wrangler 支持手动触发 cron 任务：
 curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"
 ```
 
+### Scheduler CPU 压测
+
+对 `runScheduledTick` 做本地 synthetic benchmark：
+
+```bash
+pnpm --filter @uptimer/worker bench:scheduler
+```
+
+默认会把当前工作树与 `HEAD` 对比，适合做未提交调优的前后复测。
+
+如果要和特定基线比（例如 `origin/master` 或某个 commit），可覆盖基线 ref：
+
+```bash
+SCHEDULER_BENCH_BASE_REF=origin/master pnpm --filter @uptimer/worker bench:scheduler
+SCHEDULER_BENCH_BASE_REF=ee9207b pnpm --filter @uptimer/worker bench:scheduler
+```
+
+可选参数：
+
+```bash
+SCHEDULER_BENCH_RUNS=20 SCHEDULER_BENCH_WARMUPS=5 pnpm --filter @uptimer/worker bench:scheduler
+SCHEDULER_BENCH_WRITE_JSON=./scheduler-bench.json pnpm --filter @uptimer/worker bench:scheduler
+```
+
+说明：
+
+- 基准只测 scheduler 自身的调度、状态计算和 D1 编排开销。
+- HTTP/TCP probe 会被 mock 掉，避免真实网络波动污染结果。
+- 输出里的 `DB.batch()` 次数可直接反映批量写入是否生效。
+
 ---
 
 ## Phase 8/9: 事件与维护窗口验证步骤（最小示例）

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run --config vitest.config.ts --coverage",
     "test:cron": "vitest run --config vitest.config.ts test/scheduled.test.ts --coverage --coverage.include=src/scheduler/scheduled.ts --coverage.reportsDirectory=coverage-cron --coverage.thresholds.lines=80 --coverage.thresholds.functions=100 --coverage.thresholds.statements=80 --coverage.thresholds.branches=55",
     "test:watch": "vitest --config vitest.config.ts",
+    "bench:scheduler": "node ./scripts/bench-scheduler.mjs",
     "migrate:local": "CI=1 wrangler d1 migrations apply uptimer --local",
     "init:local": "pnpm migrate:local && pnpm seed:local",
     "seed:local": "wrangler d1 execute uptimer --local --file ./scripts/seed-local.sql"

--- a/apps/worker/scripts/bench-scheduler.mjs
+++ b/apps/worker/scripts/bench-scheduler.mjs
@@ -1,0 +1,225 @@
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const workerRoot = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(workerRoot, '..', '..');
+
+const benchConfigRelativePath = path.join('apps', 'worker', 'vitest.bench.config.ts');
+const benchFileRelativePath = path.join('apps', 'worker', 'test', 'scheduled.bench.ts');
+const currentBenchConfigPath = path.join(repoRoot, benchConfigRelativePath);
+const currentBenchFilePath = path.join(repoRoot, benchFileRelativePath);
+const vitestEntrypoint = path.join(workerRoot, 'node_modules', 'vitest', 'vitest.mjs');
+
+const currentRootNodeModules = path.join(repoRoot, 'node_modules');
+const currentWorkerNodeModules = path.join(workerRoot, 'node_modules');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: options.env ?? process.env,
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    const pieces = [
+      `command failed: ${command} ${args.join(' ')}`,
+      result.stdout?.trim() ? `stdout:\n${result.stdout.trim()}` : '',
+      result.stderr?.trim() ? `stderr:\n${result.stderr.trim()}` : '',
+    ].filter(Boolean);
+    throw new Error(pieces.join('\n\n'));
+  }
+
+  return result.stdout ?? '';
+}
+
+function git(args, options = {}) {
+  return run('git', args, { cwd: repoRoot, ...options }).trim();
+}
+
+function sanitizeLabel(raw) {
+  return raw.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+function resolveBaselineRef() {
+  return process.env.SCHEDULER_BENCH_BASE_REF ?? 'HEAD';
+}
+
+function createOutputPath(label) {
+  return path.join(os.tmpdir(), `uptimer-scheduler-bench-${sanitizeLabel(label)}-${Date.now()}.json`);
+}
+
+function ensureTreeDependencies(treeRoot) {
+  symlinkSync(currentRootNodeModules, path.join(treeRoot, 'node_modules'), 'dir');
+  cpSync(currentWorkerNodeModules, path.join(treeRoot, 'apps', 'worker', 'node_modules'), {
+    recursive: true,
+    force: true,
+    dereference: false,
+  });
+  cpSync(currentBenchConfigPath, path.join(treeRoot, benchConfigRelativePath), { force: true });
+  cpSync(currentBenchFilePath, path.join(treeRoot, benchFileRelativePath), { force: true });
+}
+
+function listTrackedWorkingTreeChanges() {
+  const output = git(['diff', '--name-status', '--no-renames', 'HEAD', '--']);
+  if (!output) return [];
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [status, filePath] = line.split('\t');
+      return { status, filePath };
+    });
+}
+
+function listUntrackedFiles() {
+  const output = git(['ls-files', '--others', '--exclude-standard']);
+  if (!output) return [];
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function overlayCurrentWorkingTree(treeRoot) {
+  for (const change of listTrackedWorkingTreeChanges()) {
+    const targetPath = path.join(treeRoot, change.filePath);
+
+    if (change.status === 'D') {
+      rmSync(targetPath, { recursive: true, force: true });
+      continue;
+    }
+
+    const sourcePath = path.join(repoRoot, change.filePath);
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    cpSync(sourcePath, targetPath, { force: true, recursive: true, dereference: false });
+  }
+
+  for (const filePath of listUntrackedFiles()) {
+    const sourcePath = path.join(repoRoot, filePath);
+    const targetPath = path.join(treeRoot, filePath);
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    cpSync(sourcePath, targetPath, { force: true, recursive: true, dereference: false });
+  }
+}
+
+function runBenchmarkForTree(treeRoot, label) {
+  const outputPath = createOutputPath(label);
+  const workerCwd = path.join(treeRoot, 'apps', 'worker');
+  const benchConfigPath = path.join(workerCwd, 'vitest.bench.config.ts');
+
+  const env = {
+    ...process.env,
+    SCHEDULER_BENCH_LABEL: label,
+    SCHEDULER_BENCH_OUTPUT: outputPath,
+  };
+
+  run(
+    'node',
+    [vitestEntrypoint, 'run', '--config', benchConfigPath, 'test/scheduled.bench.ts', '--reporter=dot'],
+    {
+      cwd: workerCwd,
+      env,
+    },
+  );
+
+  const parsed = JSON.parse(readFileSync(outputPath, 'utf8'));
+  rmSync(outputPath, { force: true });
+  return parsed;
+}
+
+function summarizeComparison(baselineRows, currentRows) {
+  return baselineRows.map((baselineRow, index) => {
+    const currentRow = currentRows[index];
+    const baselineMean = baselineRow.meanMs;
+    const currentMean = currentRow.meanMs;
+    const meanReductionPct = baselineMean === 0 ? 0 : ((baselineMean - currentMean) / baselineMean) * 100;
+
+    return {
+      scenario: baselineRow.scenario,
+      baselineMeanMs: baselineMean.toFixed(3),
+      currentMeanMs: currentMean.toFixed(3),
+      meanReductionPct: `${meanReductionPct.toFixed(1)}%`,
+      speedupX: currentMean === 0 ? 'inf' : (baselineMean / currentMean).toFixed(2),
+      baselineMedianMs: baselineRow.medianMs.toFixed(3),
+      currentMedianMs: currentRow.medianMs.toFixed(3),
+      baselineP95Ms: baselineRow.p95Ms.toFixed(3),
+      currentP95Ms: currentRow.p95Ms.toFixed(3),
+      batchCalls: `${baselineRow.batchCallsAvg} -> ${currentRow.batchCallsAvg}`,
+    };
+  });
+}
+
+function main() {
+  const baselineRef = resolveBaselineRef();
+  const currentLabel = process.env.SCHEDULER_BENCH_CURRENT_LABEL ?? 'current-working-tree';
+  const baselineLabel = process.env.SCHEDULER_BENCH_BASE_LABEL ?? `baseline-${baselineRef}`;
+
+  const baselineTreeRoot = mkdtempSync(path.join(os.tmpdir(), 'uptimer-scheduler-bench-base-'));
+  const currentTreeRoot = mkdtempSync(path.join(os.tmpdir(), 'uptimer-scheduler-bench-current-'));
+  const worktreeRoots = [];
+
+  try {
+    git(['worktree', 'add', '--detach', baselineTreeRoot, baselineRef]);
+    worktreeRoots.push(baselineTreeRoot);
+    ensureTreeDependencies(baselineTreeRoot);
+
+    git(['worktree', 'add', '--detach', currentTreeRoot, 'HEAD']);
+    worktreeRoots.push(currentTreeRoot);
+    ensureTreeDependencies(currentTreeRoot);
+    overlayCurrentWorkingTree(currentTreeRoot);
+
+    // Prime both trees once so the measured run is less sensitive to first-load filesystem noise.
+    runBenchmarkForTree(baselineTreeRoot, `${baselineLabel}-warmup`);
+    runBenchmarkForTree(currentTreeRoot, `${currentLabel}-warmup`);
+
+    const baselineRows = runBenchmarkForTree(baselineTreeRoot, baselineLabel);
+    const currentRows = runBenchmarkForTree(currentTreeRoot, currentLabel);
+    const comparison = summarizeComparison(baselineRows, currentRows);
+
+    console.log('Scheduler benchmark');
+    console.log(`Base ref: ${baselineRef}`);
+    console.log(`Current label: ${currentLabel}`);
+    console.log(`Baseline label: ${baselineLabel}`);
+    if (process.env.SCHEDULER_BENCH_RUNS || process.env.SCHEDULER_BENCH_WARMUPS) {
+      console.log(
+        `Runs: ${process.env.SCHEDULER_BENCH_RUNS ?? '12'} (warmups: ${process.env.SCHEDULER_BENCH_WARMUPS ?? '3'})`,
+      );
+    }
+    console.log('');
+    console.table(comparison);
+
+    if (process.env.SCHEDULER_BENCH_WRITE_JSON) {
+      const jsonPath = path.resolve(process.env.SCHEDULER_BENCH_WRITE_JSON);
+      writeFileSync(
+        jsonPath,
+        JSON.stringify({ baselineRef, baselineRows, currentRows, comparison }, null, 2),
+        'utf8',
+      );
+      console.log(`\nWrote raw benchmark data to ${jsonPath}`);
+    }
+  } finally {
+    for (const worktreeRoot of worktreeRoots.reverse()) {
+      git(['worktree', 'remove', '--force', worktreeRoot]);
+    }
+
+    rmSync(baselineTreeRoot, { recursive: true, force: true });
+    rmSync(currentTreeRoot, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -11,7 +11,12 @@ import {
 
 import type { Env } from '../env';
 import { runHttpCheck } from '../monitor/http';
-import { computeNextState, type MonitorStateSnapshot } from '../monitor/state-machine';
+import {
+  computeNextState,
+  type MonitorStateSnapshot,
+  type NextState,
+  type OutageAction,
+} from '../monitor/state-machine';
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
@@ -22,6 +27,7 @@ const LOCK_NAME = 'scheduler:tick';
 const LOCK_LEASE_SECONDS = 55;
 
 const CHECK_CONCURRENCY = 5;
+const PERSIST_BATCH_SIZE = 25;
 
 // Look back a bit so maintenance start/end notifications are not missed if a tick is delayed.
 const MAINTENANCE_EVENT_LOOKBACK_SECONDS = 10 * 60;
@@ -59,6 +65,17 @@ type NotifyContext = {
   ctx: ExecutionContext;
   envRecord: Record<string, unknown>;
   channels: WebhookChannelWithMeta[];
+};
+
+type CompletedDueMonitor = {
+  row: DueMonitorRow;
+  checkedAt: number;
+  prevStatus: MonitorStatus | null;
+  outcome: CheckOutcome;
+  next: NextState;
+  outageAction: OutageAction;
+  stateLastError: string | null;
+  maintenanceSuppressed: boolean;
 };
 
 async function listActiveWebhookChannels(db: D1Database): Promise<WebhookChannelWithMeta[]> {
@@ -285,26 +302,21 @@ function computeStateLastError(
   return outcome.status === 'up' ? null : outcome.error;
 }
 
-async function persistCheckAndState(
-  env: Env,
-  monitorId: number,
-  checkedAt: number,
-  outcome: CheckOutcome,
-  next: {
-    status: MonitorStatus;
-    lastChangedAt: number;
-    consecutiveFailures: number;
-    consecutiveSuccesses: number;
-  },
-  outageAction: 'open' | 'close' | 'update' | 'none',
-  stateLastError: string | null,
-): Promise<void> {
+function buildPersistStatements(completed: CompletedDueMonitor, db: D1Database): D1PreparedStatement[] {
+  const {
+    row,
+    checkedAt,
+    outcome,
+    next,
+    outageAction,
+    stateLastError,
+  } = completed;
   const checkError = outcome.status === 'up' ? null : outcome.error;
 
   const statements: D1PreparedStatement[] = [];
 
   statements.push(
-    env.DB.prepare(
+    db.prepare(
       `
       INSERT INTO check_results (
         monitor_id,
@@ -318,7 +330,7 @@ async function persistCheckAndState(
       ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
     `,
     ).bind(
-      monitorId,
+      row.id,
       checkedAt,
       outcome.status,
       outcome.latencyMs,
@@ -330,7 +342,7 @@ async function persistCheckAndState(
   );
 
   statements.push(
-    env.DB.prepare(
+    db.prepare(
       `
       INSERT INTO monitor_state (
         monitor_id,
@@ -352,7 +364,7 @@ async function persistCheckAndState(
         consecutive_successes = excluded.consecutive_successes
     `,
     ).bind(
-      monitorId,
+      row.id,
       next.status,
       checkedAt,
       next.lastChangedAt,
@@ -365,7 +377,7 @@ async function persistCheckAndState(
 
   if (outageAction === 'open') {
     statements.push(
-      env.DB.prepare(
+      db.prepare(
         `
         INSERT INTO outages (monitor_id, started_at, ended_at, initial_error, last_error)
         SELECT ?1, ?2, NULL, ?3, ?4
@@ -373,41 +385,39 @@ async function persistCheckAndState(
           SELECT 1 FROM outages WHERE monitor_id = ?5 AND ended_at IS NULL
         )
       `,
-      ).bind(monitorId, checkedAt, checkError ?? 'down', checkError ?? 'down', monitorId),
+      ).bind(row.id, checkedAt, checkError ?? 'down', checkError ?? 'down', row.id),
     );
   } else if (outageAction === 'close') {
     statements.push(
-      env.DB.prepare(
+      db.prepare(
         `
         UPDATE outages
         SET ended_at = ?1
         WHERE monitor_id = ?2 AND ended_at IS NULL
       `,
-      ).bind(checkedAt, monitorId),
+      ).bind(checkedAt, row.id),
     );
   } else if (outageAction === 'update' && checkError) {
     statements.push(
-      env.DB.prepare(
+      db.prepare(
         `
         UPDATE outages
         SET last_error = ?1
         WHERE monitor_id = ?2 AND ended_at IS NULL
       `,
-      ).bind(checkError, monitorId),
+      ).bind(checkError, row.id),
     );
   }
 
-  await env.DB.batch(statements);
+  return statements;
 }
 
 async function runDueMonitor(
-  env: Env,
   row: DueMonitorRow,
   checkedAt: number,
-  notify: NotifyContext | null,
   maintenanceSuppressed: boolean,
   stateMachineConfig: { failuresToDownFromUp: number; successesToUpFromDown: number },
-): Promise<void> {
+): Promise<CompletedDueMonitor> {
   const prevStatus = toMonitorStatus(row.state_status);
   const prev: MonitorStateSnapshot | null =
     prevStatus === null
@@ -479,24 +489,46 @@ async function runDueMonitor(
   const { next, outageAction } = computeNextState(prev, outcome, checkedAt, stateMachineConfig);
   const stateLastError = computeStateLastError(next.status, outcome, row.state_last_error);
 
-  await persistCheckAndState(
-    env,
-    row.id,
+  return {
+    row,
     checkedAt,
+    prevStatus,
     outcome,
-    {
-      status: next.status,
-      lastChangedAt: next.lastChangedAt,
-      consecutiveFailures: next.consecutiveFailures,
-      consecutiveSuccesses: next.consecutiveSuccesses,
-    },
+    next,
     outageAction,
     stateLastError,
-  );
+    maintenanceSuppressed,
+  };
+}
 
-  if (!notify || maintenanceSuppressed || !next.changed) {
+async function persistCompletedMonitors(
+  db: D1Database,
+  completed: CompletedDueMonitor[],
+): Promise<void> {
+  for (let i = 0; i < completed.length; i += PERSIST_BATCH_SIZE) {
+    const chunk = completed.slice(i, i + PERSIST_BATCH_SIZE);
+    const statements: D1PreparedStatement[] = [];
+
+    for (const monitor of chunk) {
+      statements.push(...buildPersistStatements(monitor, db));
+    }
+
+    if (statements.length > 0) {
+      await db.batch(statements);
+    }
+  }
+}
+
+function queueMonitorNotification(
+  env: Env,
+  notify: NotifyContext | null,
+  completed: CompletedDueMonitor,
+): void {
+  if (!notify || completed.maintenanceSuppressed || !completed.next.changed) {
     return;
   }
+
+  const { row, checkedAt, prevStatus, outcome, next } = completed;
 
   const prevForEvent: MonitorStatus = prevStatus ?? 'unknown';
   let eventType: 'monitor.down' | 'monitor.up' | null = null;
@@ -648,21 +680,18 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
 
   // Maintenance suppression is monitor-scoped.
   const dueMonitorIds = due.map((m) => m.id);
-  const suppressedMonitorIds = await listMaintenanceSuppressedMonitorIds(
-    env.DB,
-    now,
-    dueMonitorIds,
-  );
+  const suppressedMonitorIds =
+    notify === null
+      ? new Set<number>()
+      : await listMaintenanceSuppressedMonitorIds(env.DB, now, dueMonitorIds);
 
   const limit = pLimit(CHECK_CONCURRENCY);
   const settled = await Promise.allSettled(
     due.map((m) =>
       limit(() =>
         runDueMonitor(
-          env,
           m,
           checkedAt,
-          notify,
           suppressedMonitorIds.has(m.id),
           stateMachineConfig,
         ),
@@ -671,6 +700,18 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
   );
 
   const rejected = settled.filter((r) => r.status === 'rejected');
+  const completed = settled
+    .filter((r): r is PromiseFulfilledResult<CompletedDueMonitor> => r.status === 'fulfilled')
+    .map((r) => r.value);
+
+  if (completed.length > 0) {
+    await persistCompletedMonitors(env.DB, completed);
+
+    for (const monitor of completed) {
+      queueMonitorNotification(env, notify, monitor);
+    }
+  }
+
   if (rejected.length > 0) {
     console.error(`scheduled: ${rejected.length}/${settled.length} monitors failed`, rejected[0]);
   } else {

--- a/apps/worker/test/scheduled.bench.ts
+++ b/apps/worker/test/scheduled.bench.ts
@@ -1,0 +1,260 @@
+import { writeFile } from 'node:fs/promises';
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/monitor/http', () => ({
+  runHttpCheck: vi.fn(),
+}));
+vi.mock('../src/monitor/tcp', () => ({
+  runTcpCheck: vi.fn(),
+}));
+
+import type { Env } from '../src/env';
+import { runScheduledTick } from '../src/scheduler/scheduled';
+import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
+
+type Scenario = {
+  name: string;
+  monitorCount: number;
+  withChannel: boolean;
+};
+
+type Sample = {
+  elapsedMs: number;
+  batchCalls: number;
+  statementCount: number;
+  waitUntilCalls: number;
+};
+
+const BENCH_LABEL = process.env.SCHEDULER_BENCH_LABEL ?? 'current-working-tree';
+const OUTPUT_PATH = process.env.SCHEDULER_BENCH_OUTPUT ?? null;
+
+const SCENARIOS: Scenario[] = [
+  { name: '1000 due monitors / no channels', monitorCount: 1000, withChannel: false },
+  { name: '5000 due monitors / no channels', monitorCount: 5000, withChannel: false },
+  { name: '5000 due monitors / 1 webhook channel', monitorCount: 5000, withChannel: true },
+];
+
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+const WARMUP_RUNS = parsePositiveIntEnv('SCHEDULER_BENCH_WARMUPS', 3);
+const MEASURE_RUNS = parsePositiveIntEnv('SCHEDULER_BENCH_RUNS', 12);
+
+function makeDueRows(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    name: `Monitor ${index + 1}`,
+    type: 'unsupported',
+    target: `benchmark-target-${index + 1}`,
+    interval_sec: 60,
+    timeout_ms: 5000,
+    http_method: null,
+    http_headers_json: null,
+    http_body: null,
+    expected_status_json: null,
+    response_keyword: null,
+    response_forbidden_keyword: null,
+    state_status: 'up',
+    state_last_error: null,
+    last_changed_at: 1_700_000_000,
+    consecutive_failures: 0,
+    consecutive_successes: 3,
+  }));
+}
+
+function createEnvForScenario(scenario: Scenario): {
+  env: Env;
+  sampleState: Omit<Sample, 'elapsedMs'>;
+} {
+  const sampleState = {
+    batchCalls: 0,
+    statementCount: 0,
+    waitUntilCalls: 0,
+  };
+  const dueRows = makeDueRows(scenario.monitorCount);
+  const channels = scenario.withChannel
+    ? [
+        {
+          id: 1,
+          name: 'primary',
+          config_json: JSON.stringify({
+            url: 'https://hooks.example.com/uptimer',
+            method: 'POST',
+            payload_type: 'json',
+          }),
+          created_at: 1_700_000_000,
+        },
+      ]
+    : [];
+
+  const handlers: FakeD1QueryHandler[] = [
+    {
+      match: 'insert into locks',
+      run: () => ({ meta: { changes: 1 } }),
+    },
+    {
+      match: 'from notification_channels',
+      all: () => channels,
+    },
+    {
+      match: 'select key, value from settings',
+      all: () => [],
+    },
+    {
+      match: 'from monitors m',
+      all: () => dueRows,
+    },
+    {
+      match: 'select distinct mwm.monitor_id',
+      all: () => [],
+    },
+    {
+      match: 'from maintenance_windows',
+      all: () => [],
+    },
+    {
+      match: 'from maintenance_window_monitors',
+      all: () => [],
+    },
+    {
+      match: 'insert into check_results',
+      run: () => ({ meta: { changes: 1 } }),
+    },
+    {
+      match: 'insert into monitor_state',
+      run: () => ({ meta: { changes: 1 } }),
+    },
+    {
+      match: 'into outages',
+      run: () => ({ meta: { changes: 1 } }),
+    },
+    {
+      match: 'update outages',
+      run: () => ({ meta: { changes: 1 } }),
+    },
+  ];
+
+  const db = createFakeD1Database(handlers);
+  const originalBatch = db.batch.bind(db);
+  db.batch = async (statements) => {
+    sampleState.batchCalls += 1;
+    sampleState.statementCount += statements.length;
+    return originalBatch(statements);
+  };
+
+  return {
+    env: { DB: db } as unknown as Env,
+    sampleState,
+  };
+}
+
+async function runOne(scenario: Scenario): Promise<Sample> {
+  const { env, sampleState } = createEnvForScenario(scenario);
+  const ctx = {
+    waitUntil(promise: Promise<unknown>) {
+      sampleState.waitUntilCalls += 1;
+      void promise.catch(() => undefined);
+    },
+  } as unknown as ExecutionContext;
+
+  const started = performance.now();
+  await runScheduledTick(env, ctx);
+  const elapsedMs = performance.now() - started;
+
+  return {
+    elapsedMs,
+    ...sampleState,
+  };
+}
+
+async function withMutedConsole<T>(fn: () => Promise<T>): Promise<T> {
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = () => undefined;
+  console.error = () => undefined;
+  try {
+    return await fn();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+function percentile(sorted: number[], ratio: number): number {
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * ratio) - 1));
+  return sorted[index] ?? 0;
+}
+
+function summarize(samples: Sample[]) {
+  const elapsed = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const batchCalls = samples.map((sample) => sample.batchCalls);
+  const statementCounts = samples.map((sample) => sample.statementCount);
+  const waitUntilCalls = samples.map((sample) => sample.waitUntilCalls);
+  const totalElapsed = elapsed.reduce((sum, value) => sum + value, 0);
+
+  return {
+    runs: samples.length,
+    meanMs: totalElapsed / samples.length,
+    medianMs: percentile(elapsed, 0.5),
+    p95Ms: percentile(elapsed, 0.95),
+    minMs: elapsed[0] ?? 0,
+    maxMs: elapsed.at(-1) ?? 0,
+    batchCallsAvg: batchCalls.reduce((sum, value) => sum + value, 0) / batchCalls.length,
+    statementCountAvg:
+      statementCounts.reduce((sum, value) => sum + value, 0) / statementCounts.length,
+    waitUntilCallsAvg: waitUntilCalls.reduce((sum, value) => sum + value, 0) / waitUntilCalls.length,
+  };
+}
+
+async function benchmarkScenario(scenario: Scenario) {
+  for (let index = 0; index < WARMUP_RUNS; index += 1) {
+    await runOne(scenario);
+  }
+
+  const samples: Sample[] = [];
+  for (let index = 0; index < MEASURE_RUNS; index += 1) {
+    samples.push(await runOne(scenario));
+  }
+
+  return {
+    label: BENCH_LABEL,
+    scenario: scenario.name,
+    monitorCount: scenario.monitorCount,
+    withChannel: scenario.withChannel,
+    ...summarize(samples),
+  };
+}
+
+describe('scheduler benchmark', () => {
+  it(
+    'measures local scheduled tick throughput',
+    async () => {
+      const rows: Array<Record<string, unknown>> = [];
+
+      await withMutedConsole(async () => {
+        for (const scenario of SCENARIOS) {
+          rows.push(await benchmarkScenario(scenario));
+        }
+      });
+
+      const payload = JSON.stringify(rows, null, 2);
+      if (OUTPUT_PATH) {
+        await writeFile(OUTPUT_PATH, payload, 'utf8');
+      } else {
+        console.log(payload);
+      }
+
+      expect(rows).toHaveLength(SCENARIOS.length);
+    },
+    120_000,
+  );
+});

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -243,6 +243,56 @@ describe('scheduler/scheduled regression', () => {
     expect(waitUntil).not.toHaveBeenCalled();
   });
 
+  it('batches persistence for multiple due monitors', async () => {
+    const dueRows = [
+      {
+        id: 111,
+        name: 'API A',
+        type: 'http',
+        target: 'https://example.com/a',
+        interval_sec: 60,
+        timeout_ms: 5000,
+        http_method: 'GET',
+        http_headers_json: null,
+        http_body: null,
+        expected_status_json: null,
+        response_keyword: null,
+        response_forbidden_keyword: null,
+        state_status: 'up',
+        state_last_error: null,
+        last_changed_at: 1700000000,
+        consecutive_failures: 0,
+        consecutive_successes: 3,
+      },
+      {
+        id: 112,
+        name: 'API B',
+        type: 'http',
+        target: 'https://example.com/b',
+        interval_sec: 60,
+        timeout_ms: 5000,
+        http_method: 'GET',
+        http_headers_json: null,
+        http_body: null,
+        expected_status_json: null,
+        response_keyword: null,
+        response_forbidden_keyword: null,
+        state_status: 'up',
+        state_last_error: null,
+        last_changed_at: 1700000000,
+        consecutive_failures: 0,
+        consecutive_successes: 2,
+      },
+    ];
+    const env = createEnv({ dueRows });
+    const batchSpy = vi.spyOn(env.DB, 'batch');
+
+    await runScheduledTick(env, { waitUntil: vi.fn() } as unknown as ExecutionContext);
+
+    expect(runHttpCheck).toHaveBeenCalledTimes(2);
+    expect(batchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('sends monitor.down notification when status changes and monitor is not suppressed', async () => {
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'down',

--- a/apps/worker/vitest.bench.config.ts
+++ b/apps/worker/vitest.bench.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.bench.ts'],
+    environment: 'node',
+  },
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,4 +69,12 @@ export default [
       },
     },
   },
+  {
+    files: ['**/scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## What

- Refactor the scheduled monitor tick so probes and state transitions are collected first, then persisted to D1 in write batches instead of one `DB.batch()` per monitor.
- Skip maintenance suppression lookup when there are no active webhook channels.
- Add a regression test to ensure multiple due monitors are persisted through batched writes.
- Add a reusable `pnpm --filter @uptimer/worker bench:scheduler` command that benchmarks the scheduler against a baseline ref without introducing new dependencies.

## Why

The previous scheduler path still spent avoidable CPU time on D1 orchestration: each due monitor triggered its own prepare/bind/batch cycle, so JS and D1 overhead scaled linearly with monitor count.

This change reduces the number of D1 batch calls from `N` to `ceil(N / 25)` while preserving existing state-machine and notification behavior. The benchmark runner makes future tuning work reproducible instead of relying on one-off temp scripts.

## Where

- [apps/worker/src/scheduler/scheduled.ts](/Users/cxm/Code_New/Uptimer/apps/worker/src/scheduler/scheduled.ts)
- [apps/worker/test/scheduled.test.ts](/Users/cxm/Code_New/Uptimer/apps/worker/test/scheduled.test.ts)
- [apps/worker/scripts/bench-scheduler.mjs](/Users/cxm/Code_New/Uptimer/apps/worker/scripts/bench-scheduler.mjs)
- [apps/worker/test/scheduled.bench.ts](/Users/cxm/Code_New/Uptimer/apps/worker/test/scheduled.bench.ts)
- [apps/worker/vitest.bench.config.ts](/Users/cxm/Code_New/Uptimer/apps/worker/vitest.bench.config.ts)
- [Develop/LOCAL-TESTING.md](/Users/cxm/Code_New/Uptimer/Develop/LOCAL-TESTING.md)

## Benchmark

Local synthetic benchmark of `runScheduledTick` only.
Baseline: `ee9207b`
Comparison target: current scheduler optimization branch

- `1000` due monitors, no channels: `5.206ms -> 4.563ms` (`-12.4%`), `DB.batch()` calls `1000 -> 40`
- `5000` due monitors, no channels: `22.945ms -> 21.911ms` (`-4.5%`), `DB.batch()` calls `5000 -> 200`
- `5000` due monitors, 1 webhook channel: `22.884ms -> 22.078ms` (`-3.5%`), `DB.batch()` calls `5000 -> 200`

Benchmark command for future tuning:

- `pnpm --filter @uptimer/worker bench:scheduler`
- `SCHEDULER_BENCH_BASE_REF=origin/master pnpm --filter @uptimer/worker bench:scheduler`

Note: this benchmark isolates scheduler CPU and D1 orchestration with fake D1 and mocked probes, so it is directional rather than a full Cloudflare runtime measurement.

## How to verify

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @uptimer/worker bench:scheduler`

Link #24 