### PR TITLE
perf: shrink homepage bootstrap CPU path

### DIFF
--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -16,11 +16,72 @@ function escapeHtml(value) {
     .replace(/'/g, '&#39;');
 }
 
+function safeJsonForInlineScript(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
 function normalizeSnapshotText(value, fallback) {
   if (typeof value !== 'string') return fallback;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : fallback;
 }
+
+const HOMEPAGE_PRELOAD_STYLE_TAG = `<style id="uptimer-preload-style">
+#uptimer-preload{min-height:100vh;background:#f8fafc;color:#0f172a;font:400 14px/1.45 ui-sans-serif,system-ui,sans-serif}
+#uptimer-preload *{box-sizing:border-box}
+#uptimer-preload .uw{max-width:80rem;margin:0 auto;padding:0 16px}
+#uptimer-preload .uh{position:sticky;top:0;z-index:20;background:rgba(255,255,255,.95);backdrop-filter:blur(12px);border-bottom:1px solid rgba(226,232,240,.8)}
+#uptimer-preload .uhw{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:16px 0}
+#uptimer-preload .ut{min-width:0}
+#uptimer-preload .un{font-size:20px;font-weight:700;line-height:1.1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#uptimer-preload .ud{margin-top:4px;color:#64748b;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#uptimer-preload .sb{display:inline-flex;align-items:center;border-radius:999px;padding:4px 10px;font-size:12px;font-weight:600;border:1px solid transparent}
+#uptimer-preload .sb-up{background:#ecfdf5;color:#047857;border-color:#a7f3d0}
+#uptimer-preload .sb-down{background:#fef2f2;color:#b91c1c;border-color:#fecaca}
+#uptimer-preload .sb-maintenance{background:#eff6ff;color:#1d4ed8;border-color:#bfdbfe}
+#uptimer-preload .sb-paused{background:#fffbeb;color:#b45309;border-color:#fde68a}
+#uptimer-preload .sb-unknown{background:#f8fafc;color:#475569;border-color:#cbd5e1}
+#uptimer-preload .um{padding:24px 0 40px}
+#uptimer-preload .bn{margin:0 0 24px;border:1px solid #e2e8f0;border-radius:18px;padding:20px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.04)}
+#uptimer-preload .bt{color:#475569}
+#uptimer-preload .bu{margin-top:4px;font-size:12px;color:#94a3b8}
+#uptimer-preload .sec{margin-top:24px}
+#uptimer-preload .sh{margin:0 0 12px;font-size:16px;font-weight:700}
+#uptimer-preload .st{display:grid;gap:12px}
+#uptimer-preload .sg{margin-top:20px}
+#uptimer-preload .sgh{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
+#uptimer-preload .sgt{font-size:13px;font-weight:700;color:#475569}
+#uptimer-preload .sgc{font-size:12px;color:#94a3b8}
+#uptimer-preload .grid{display:grid;gap:12px}
+#uptimer-preload .card{border:1px solid rgba(226,232,240,.9);border-radius:16px;padding:14px;background:#fff}
+#uptimer-preload .row{display:flex;align-items:flex-start;justify-content:space-between;gap:10px}
+#uptimer-preload .lhs{min-width:0;display:flex;align-items:flex-start;gap:10px}
+#uptimer-preload .dot{display:block;width:10px;height:10px;border-radius:999px;margin-top:5px}
+#uptimer-preload .dot-up{background:#10b981}
+#uptimer-preload .dot-down{background:#ef4444}
+#uptimer-preload .dot-maintenance{background:#3b82f6}
+#uptimer-preload .dot-paused{background:#f59e0b}
+#uptimer-preload .dot-unknown{background:#94a3b8}
+#uptimer-preload .mn{font-size:15px;font-weight:700;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#uptimer-preload .mt{margin-top:3px;font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:.08em}
+#uptimer-preload .rhs{display:flex;align-items:center;gap:8px;white-space:nowrap}
+#uptimer-preload .up{font-size:12px;color:#94a3b8}
+#uptimer-preload .lbl{margin:12px 0 6px;font-size:11px;color:#94a3b8}
+#uptimer-preload .strip{height:20px;border-radius:8px;background:#e2e8f0;overflow:hidden}
+#uptimer-preload .usv{display:block;width:100%;height:100%}
+#uptimer-preload .ft{margin-top:12px;font-size:11px;color:#94a3b8}
+#uptimer-preload .ih{padding-top:24px;border-top:1px solid #e2e8f0}
+@media (min-width:640px){#uptimer-preload .grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+html.dark #uptimer-preload{background:#0f172a;color:#f8fafc}
+html.dark #uptimer-preload .uh{background:rgba(15,23,42,.95);border-bottom-color:rgba(51,65,85,.9)}
+html.dark #uptimer-preload .ud,#uptimer-preload .sgt{color:#cbd5e1}
+html.dark #uptimer-preload .bn,html.dark #uptimer-preload .card{background:#1e293b;border-color:rgba(51,65,85,.95);box-shadow:none}
+html.dark #uptimer-preload .bt{color:#cbd5e1}
+html.dark #uptimer-preload .bu,#uptimer-preload .sgc,#uptimer-preload .up,#uptimer-preload .lbl,#uptimer-preload .ft{color:#94a3b8}
+html.dark #uptimer-preload .mt{color:#94a3b8}
+html.dark #uptimer-preload .strip{background:#334155}
+html.dark #uptimer-preload .ih{border-top-color:#334155}
+</style>`;
 
 function computeCacheControl(ageSeconds) {
   const remaining = Math.max(0, SNAPSHOT_MAX_AGE_SECONDS - ageSeconds);
@@ -138,9 +199,8 @@ async function fetchPublicHomepageArtifact(env) {
     const data = await resp.json();
     if (!data || typeof data !== 'object') return null;
 
-    if (typeof data.style_tag !== 'string') return null;
     if (typeof data.preload_html !== 'string') return null;
-    if (typeof data.bootstrap_script !== 'string') return null;
+    if (!data.snapshot || typeof data.snapshot !== 'object') return null;
 
     return data;
   } catch {
@@ -198,7 +258,7 @@ export default {
 
       injected = injected.replace(
         '</head>',
-        `  ${artifact.style_tag}\n  ${artifact.bootstrap_script}\n</head>`,
+        `  ${HOMEPAGE_PRELOAD_STYLE_TAG}\n  <script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${safeJsonForInlineScript(artifact.snapshot)};</script>\n</head>`,
       );
 
       const headers = new Headers(base.headers);

--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -16,11 +16,6 @@ function escapeHtml(value) {
     .replace(/'/g, '&#39;');
 }
 
-function safeJsonForInlineScript(value) {
-  // Prevent breaking out of <script> tags via `</script>`.
-  return JSON.stringify(value).replace(/</g, '\\u003c');
-}
-
 function normalizeSnapshotText(value, fallback) {
   if (typeof value !== 'string') return fallback;
   const trimmed = value.trim();
@@ -34,44 +29,6 @@ function computeCacheControl(ageSeconds) {
   return `public, max-age=${maxAge}, stale-while-revalidate=${stale}, stale-if-error=${stale}`;
 }
 
-function formatTime(tsSec) {
-  try {
-    return new Date(tsSec * 1000).toLocaleString();
-  } catch {
-    return '';
-  }
-}
-
-function statusDotClass(status) {
-  switch (status) {
-    case 'up':
-      return 'bg-emerald-500 dark:bg-emerald-400';
-    case 'down':
-      return 'bg-red-500 dark:bg-red-400';
-    case 'maintenance':
-      return 'bg-blue-500 dark:bg-blue-400';
-    case 'paused':
-      return 'bg-amber-500 dark:bg-amber-400';
-    default:
-      return 'bg-slate-400 dark:bg-slate-500';
-  }
-}
-
-function statusBadgeClass(status) {
-  switch (status) {
-    case 'up':
-      return 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-emerald-400/20';
-    case 'down':
-      return 'bg-red-50 text-red-700 ring-red-600/20 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-400/20';
-    case 'maintenance':
-      return 'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-500/10 dark:text-blue-400 dark:ring-blue-400/20';
-    case 'paused':
-      return 'bg-amber-50 text-amber-700 ring-amber-600/20 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-400/20';
-    default:
-      return 'bg-slate-50 text-slate-600 ring-slate-500/20 dark:bg-slate-500/10 dark:text-slate-400 dark:ring-slate-400/20';
-  }
-}
-
 function upsertHeadTag(html, pattern, tag) {
   if (pattern.test(html)) {
     return html.replace(pattern, tag);
@@ -79,13 +36,12 @@ function upsertHeadTag(html, pattern, tag) {
   return html.replace('</head>', `  ${tag}\n</head>`);
 }
 
-function injectStatusMetaTags(html, snapshot, url) {
-  const siteTitle = normalizeSnapshotText(snapshot?.site_title, 'Uptimer');
-  const fallbackDescription = normalizeSnapshotText(
-    snapshot?.banner?.title,
+function injectStatusMetaTags(html, artifact, url) {
+  const siteTitle = normalizeSnapshotText(artifact?.meta_title, 'Uptimer');
+  const siteDescription = normalizeSnapshotText(
+    artifact?.meta_description,
     'Real-time status and incident updates.',
-  );
-  const siteDescription = normalizeSnapshotText(snapshot?.site_description, fallbackDescription)
+  )
     .replace(/\s+/g, ' ')
     .trim();
   const pageUrl = new URL('/', url).toString();
@@ -145,263 +101,6 @@ function injectStatusMetaTags(html, snapshot, url) {
   return injected;
 }
 
-function monitorGroupLabel(value) {
-  if (typeof value !== 'string') return 'Ungrouped';
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : 'Ungrouped';
-}
-
-function uptimeBarClass(uptimePct) {
-  if (typeof uptimePct !== 'number') {
-    return 'bg-slate-300 dark:bg-slate-600';
-  }
-  if (uptimePct >= 99.95) return 'bg-emerald-500 dark:bg-emerald-400';
-  if (uptimePct >= 99) return 'bg-lime-500 dark:bg-lime-400';
-  if (uptimePct >= 95) return 'bg-amber-500 dark:bg-amber-400';
-  return 'bg-red-500 dark:bg-red-400';
-}
-
-function heartbeatBarClass(status) {
-  switch (status) {
-    case 'up':
-      return 'bg-emerald-500 dark:bg-emerald-400';
-    case 'down':
-      return 'bg-red-500 dark:bg-red-400';
-    case 'maintenance':
-      return 'bg-blue-500 dark:bg-blue-400';
-    default:
-      return 'bg-slate-300 dark:bg-slate-600';
-  }
-}
-
-function renderMiniUptimeBars(days) {
-  const items = Array.isArray(days) ? days.slice(-30) : [];
-  return items
-    .map(
-      (day) =>
-        `<span class="h-5 flex-1 rounded-sm ${uptimeBarClass(day?.uptime_pct)}" aria-hidden="true"></span>`,
-    )
-    .join('');
-}
-
-function renderMiniHeartbeatBars(heartbeats) {
-  const items = Array.isArray(heartbeats) ? heartbeats.slice(0, 30) : [];
-  return items
-    .map(
-      (heartbeat) =>
-        `<span class="h-5 flex-1 rounded-sm ${heartbeatBarClass(heartbeat?.status)}" aria-hidden="true"></span>`,
-    )
-    .join('');
-}
-
-function renderIncidentCard(incident) {
-  return `
-    <div class="ui-panel rounded-xl border border-slate-200/80 dark:border-slate-700/80 bg-white dark:bg-slate-800 p-4">
-      <div class="flex items-start justify-between gap-4 mb-2">
-        <h4 class="font-semibold text-slate-900 dark:text-slate-100">${escapeHtml(incident?.title ?? 'Incident')}</h4>
-        <span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs ${statusBadgeClass(
-          incident?.impact === 'major' || incident?.impact === 'critical' ? 'down' : 'paused',
-        )}">${escapeHtml(incident?.impact ?? 'minor')}</span>
-      </div>
-      <div class="text-xs text-slate-500 dark:text-slate-400 mb-2">${escapeHtml(formatTime(incident?.started_at ?? 0))}</div>
-      ${
-        incident?.message
-          ? `<p class="text-sm text-slate-600 dark:text-slate-300">${escapeHtml(incident.message)}</p>`
-          : ''
-      }
-    </div>
-  `;
-}
-
-function renderMaintenanceCard(window, monitorNames) {
-  const affected = Array.isArray(window?.monitor_ids)
-    ? window.monitor_ids.map((id) => escapeHtml(monitorNames.get(id) || `#${id}`)).join(', ')
-    : '';
-
-  return `
-    <div class="ui-panel rounded-xl border border-slate-200/80 dark:border-slate-700/80 bg-white dark:bg-slate-800 p-4">
-      <div class="flex flex-col gap-2 mb-2">
-        <h4 class="font-semibold text-slate-900 dark:text-slate-100">${escapeHtml(window?.title ?? 'Maintenance')}</h4>
-        <div class="text-xs text-slate-500 dark:text-slate-400">${escapeHtml(formatTime(window?.starts_at ?? 0))} - ${escapeHtml(formatTime(window?.ends_at ?? 0))}</div>
-      </div>
-      ${affected ? `<div class="text-sm text-slate-600 dark:text-slate-300 mb-2">Affected: ${affected}</div>` : ''}
-      ${window?.message ? `<p class="text-sm text-slate-600 dark:text-slate-300">${escapeHtml(window.message)}</p>` : ''}
-    </div>
-  `;
-}
-
-function renderPreload(snapshot) {
-  const overall = typeof snapshot.overall_status === 'string' ? snapshot.overall_status : 'unknown';
-  const siteTitle = typeof snapshot.site_title === 'string' ? snapshot.site_title : 'Uptimer';
-  const siteDescription =
-    typeof snapshot.site_description === 'string' ? snapshot.site_description : '';
-  const bannerTitle =
-    snapshot && snapshot.banner && typeof snapshot.banner.title === 'string'
-      ? snapshot.banner.title
-      : 'Status';
-  const generatedAt =
-    typeof snapshot.generated_at === 'number'
-      ? snapshot.generated_at
-      : Math.floor(Date.now() / 1000);
-
-  const monitors = Array.isArray(snapshot.monitors) ? snapshot.monitors : [];
-  const monitorNames = new Map(
-    monitors.map((monitor) => [monitor.id, typeof monitor.name === 'string' ? monitor.name : `#${monitor.id}`]),
-  );
-  const groups = new Map();
-  for (const monitor of monitors) {
-    const key = monitorGroupLabel(monitor?.group_name);
-    const existing = groups.get(key) || [];
-    existing.push(monitor);
-    groups.set(key, existing);
-  }
-
-  const groupedMonitors = [...groups.entries()]
-    .map(
-      ([groupName, groupMonitors]) => `
-        <div>
-          <div class="mb-2 flex items-center justify-between">
-            <h4 class="text-sm font-semibold text-slate-600 dark:text-slate-300">${escapeHtml(groupName)}</h4>
-            <span class="text-xs text-slate-400 dark:text-slate-500">${groupMonitors.length}</span>
-          </div>
-          <div class="grid gap-3 sm:grid-cols-2">
-            ${groupMonitors
-              .map((monitor) => {
-                const id = typeof monitor.id === 'number' ? monitor.id : 0;
-                const lastCheckedAt =
-                  typeof monitor.last_checked_at === 'number' ? monitor.last_checked_at : null;
-                const uptimePct =
-                  monitor?.uptime_30d && typeof monitor.uptime_30d.uptime_pct === 'number'
-                    ? `${monitor.uptime_30d.uptime_pct.toFixed(3)}%`
-                    : '-';
-
-                return `
-                  <div class="ui-panel rounded-xl border border-slate-200/80 dark:border-slate-700/80 bg-white dark:bg-slate-800 p-4">
-                    <div class="mb-3 flex items-start justify-between gap-2">
-                      <div class="min-w-0 flex items-center gap-2.5">
-                        <span class="relative flex h-2.5 w-2.5"><span class="relative inline-flex h-2.5 w-2.5 rounded-full ${statusDotClass(
-                          monitor?.status,
-                        )}"></span></span>
-                        <div class="min-w-0">
-                          <div class="truncate text-base font-semibold text-slate-900 dark:text-slate-100">${escapeHtml(monitor?.name ?? `#${id}`)}</div>
-                          <div class="mt-0.5 text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide">${escapeHtml(monitor?.type ?? '')}</div>
-                        </div>
-                      </div>
-                      <div class="flex items-center gap-2">
-                        <span class="text-xs text-slate-400 dark:text-slate-500">${escapeHtml(uptimePct)}</span>
-                        <span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs ${statusBadgeClass(
-                          monitor?.status,
-                        )}">${escapeHtml(monitor?.status ?? 'unknown')}</span>
-                      </div>
-                    </div>
-
-                    <div class="mb-2">
-                      <div class="mb-2 text-[11px] text-slate-400 dark:text-slate-500">Availability (30d)</div>
-                      <div class="flex h-5 items-end gap-[2px] overflow-hidden">${renderMiniUptimeBars(
-                        monitor?.uptime_days,
-                      )}</div>
-                    </div>
-
-                    <div class="mt-2">
-                      <div class="mb-2 text-[11px] text-slate-400 dark:text-slate-500">Recent checks</div>
-                      <div class="flex h-5 items-end gap-[2px] overflow-hidden">${renderMiniHeartbeatBars(
-                        monitor?.heartbeats,
-                      )}</div>
-                    </div>
-
-                    <div class="mt-3 text-[11px] text-slate-400 dark:text-slate-500">${lastCheckedAt ? `Last checked: ${escapeHtml(formatTime(lastCheckedAt))}` : 'Never checked'}</div>
-                  </div>
-                `;
-              })
-              .join('')}
-          </div>
-        </div>
-      `,
-    )
-    .join('');
-
-  const activeIncidents = Array.isArray(snapshot.active_incidents) ? snapshot.active_incidents : [];
-  const activeMaintenance = Array.isArray(snapshot?.maintenance_windows?.active)
-    ? snapshot.maintenance_windows.active
-    : [];
-  const upcomingMaintenance = Array.isArray(snapshot?.maintenance_windows?.upcoming)
-    ? snapshot.maintenance_windows.upcoming
-    : [];
-  const resolvedIncidentPreview = snapshot?.resolved_incident_preview ?? null;
-  const maintenanceHistoryPreview = snapshot?.maintenance_history_preview ?? null;
-
-  return `
-    <div class="min-h-screen bg-slate-50 dark:bg-slate-900">
-      <header class="sticky top-0 z-20 border-b border-slate-200/70 bg-white/95 backdrop-blur dark:border-slate-700/80 dark:bg-slate-800/95">
-        <div class="mx-auto max-w-5xl px-4 py-4 flex justify-between items-center">
-          <div class="min-w-0">
-            <div class="text-lg font-bold text-slate-900 dark:text-slate-100">${escapeHtml(siteTitle)}</div>
-            ${siteDescription ? `<div class="text-sm text-slate-500 dark:text-slate-400 truncate">${escapeHtml(siteDescription)}</div>` : ''}
-          </div>
-          <span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2.5 py-1 text-sm ${statusBadgeClass(
-            overall,
-          )}">${escapeHtml(overall)}</span>
-        </div>
-      </header>
-
-      <main class="max-w-5xl mx-auto px-4 py-6">
-        <div class="rounded-2xl p-5 border border-slate-100 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-soft dark:shadow-none mb-6">
-          <div class="text-sm text-slate-500 dark:text-slate-300">${escapeHtml(bannerTitle)}</div>
-          <div class="text-xs text-slate-400 dark:text-slate-500 mt-1">Updated: ${escapeHtml(formatTime(generatedAt))}</div>
-        </div>
-
-        ${
-          activeMaintenance.length > 0 || upcomingMaintenance.length > 0
-            ? `
-            <section class="mb-6">
-              <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100 mb-3">Scheduled Maintenance</h3>
-              ${activeMaintenance.length > 0 ? `<div class="space-y-3 mb-4">${activeMaintenance.map((window) => renderMaintenanceCard(window, monitorNames)).join('')}</div>` : ''}
-              ${upcomingMaintenance.length > 0 ? `<div class="space-y-3">${upcomingMaintenance.map((window) => renderMaintenanceCard(window, monitorNames)).join('')}</div>` : ''}
-            </section>
-          `
-            : ''
-        }
-
-        ${
-          activeIncidents.length > 0
-            ? `
-            <section class="mb-6">
-              <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100 mb-3">Active Incidents</h3>
-              <div class="space-y-3">${activeIncidents.map((incident) => renderIncidentCard(incident)).join('')}</div>
-            </section>
-          `
-            : ''
-        }
-
-        <section>
-          <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100 mb-3">Services</h3>
-          <div class="space-y-5">${groupedMonitors}</div>
-        </section>
-
-        <section class="mt-6 pt-6 border-t border-slate-100 dark:border-slate-800 space-y-6">
-          <div>
-            <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100 mb-3">Incident History</h3>
-            ${
-              resolvedIncidentPreview
-                ? renderIncidentCard(resolvedIncidentPreview)
-                : `<div class="ui-panel rounded-xl border border-slate-200/80 dark:border-slate-700/80 bg-white dark:bg-slate-800 p-6 text-center text-slate-500 dark:text-slate-400">No past incidents</div>`
-            }
-          </div>
-
-          <div>
-            <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100 mb-3">Maintenance History</h3>
-            ${
-              maintenanceHistoryPreview
-                ? renderMaintenanceCard(maintenanceHistoryPreview, monitorNames)
-                : `<div class="ui-panel rounded-xl border border-slate-200/80 dark:border-slate-700/80 bg-white dark:bg-slate-800 p-6 text-center text-slate-500 dark:text-slate-400">No past maintenance</div>`
-            }
-          </div>
-        </section>
-      </main>
-    </div>
-  `;
-}
-
 async function fetchIndexHtml(env, url) {
   const indexUrl = new URL('/index.html', url);
 
@@ -418,11 +117,11 @@ async function fetchIndexHtml(env, url) {
   return env.ASSETS.fetch(req);
 }
 
-async function fetchPublicHomepageSnapshot(env) {
+async function fetchPublicHomepageArtifact(env) {
   const apiOrigin = env.UPTIMER_API_ORIGIN;
   if (typeof apiOrigin !== 'string' || apiOrigin.length === 0) return null;
 
-  const statusUrl = new URL('/api/v1/public/homepage', apiOrigin);
+  const statusUrl = new URL('/api/v1/public/homepage-artifact', apiOrigin);
 
   // Keep HTML fast: if the API is slow, fall back to a static HTML shell.
   const controller = new AbortController();
@@ -438,6 +137,10 @@ async function fetchPublicHomepageSnapshot(env) {
 
     const data = await resp.json();
     if (!data || typeof data !== 'object') return null;
+
+    if (typeof data.style_tag !== 'string') return null;
+    if (typeof data.preload_html !== 'string') return null;
+    if (typeof data.bootstrap_script !== 'string') return null;
 
     return data;
   } catch {
@@ -467,8 +170,8 @@ export default {
       const base = await fetchIndexHtml(env, url);
       const html = await base.text();
 
-      const snapshot = await fetchPublicHomepageSnapshot(env);
-      if (!snapshot) {
+      const artifact = await fetchPublicHomepageArtifact(env);
+      if (!artifact) {
         const fallback = await caches.default.match(fallbackCacheKey);
         if (fallback) {
           return fallback;
@@ -483,19 +186,19 @@ export default {
       }
 
       const now = Math.floor(Date.now() / 1000);
-      const generatedAt = typeof snapshot.generated_at === 'number' ? snapshot.generated_at : now;
+      const generatedAt = typeof artifact.generated_at === 'number' ? artifact.generated_at : now;
       const age = Math.max(0, now - generatedAt);
 
       let injected = html.replace(
         '<div id="root"></div>',
-        `<div id="uptimer-preload">${renderPreload(snapshot)}</div><div id="root"></div>`,
+        `${artifact.preload_html}<div id="root"></div>`,
       );
 
-      injected = injectStatusMetaTags(injected, snapshot, url);
+      injected = injectStatusMetaTags(injected, artifact, url);
 
       injected = injected.replace(
         '</head>',
-        `  <script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${safeJsonForInlineScript(snapshot)};</script>\n</head>`,
+        `  ${artifact.style_tag}\n  ${artifact.bootstrap_script}\n</head>`,
       );
 
       const headers = new Headers(base.headers);

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -6,6 +6,7 @@ export type MonitorType = 'http' | 'tcp';
 export type HttpResponseMatchMode = 'contains' | 'regex';
 export type SupportedLocale = 'en' | 'zh-CN' | 'zh-TW' | 'ja' | 'es';
 export type LocaleSetting = 'auto' | SupportedLocale;
+export type HomepageBootstrapMode = 'full' | 'partial';
 
 export type IncidentStatus = 'investigating' | 'identified' | 'monitoring' | 'resolved';
 export type IncidentImpact = 'none' | 'minor' | 'major' | 'critical';
@@ -88,6 +89,19 @@ export interface UptimeSummaryPreview {
   uptime_pct: number;
 }
 
+export interface HomepageHeartbeatStrip {
+  checked_at: number[];
+  status_codes: string;
+  latency_ms: Array<number | null>;
+}
+
+export interface HomepageUptimeDayStrip {
+  day_start_at: number[];
+  downtime_sec: number[];
+  unknown_sec: number[];
+  uptime_pct_milli: Array<number | null>;
+}
+
 export interface PublicMonitor {
   id: number;
   name: string;
@@ -165,13 +179,15 @@ export interface HomepageMonitorCard {
   status: MonitorStatus;
   is_stale: boolean;
   last_checked_at: number | null;
-  heartbeats: Heartbeat[];
+  heartbeat_strip: HomepageHeartbeatStrip;
   uptime_30d: UptimeSummaryPreview | null;
-  uptime_days: UptimeDayPreview[];
+  uptime_day_strip: HomepageUptimeDayStrip;
 }
 
 export interface PublicHomepageResponse {
   generated_at: number;
+  bootstrap_mode: HomepageBootstrapMode;
+  monitor_count_total: number;
   site_title: string;
   site_description: string;
   site_locale: LocaleSetting;

--- a/apps/web/src/components/HeartbeatBar.tsx
+++ b/apps/web/src/components/HeartbeatBar.tsx
@@ -1,40 +1,17 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import type { Heartbeat, CheckStatus } from '../api/types';
+
+import type { CheckStatus, Heartbeat, HomepageHeartbeatStrip } from '../api/types';
 import { useI18n } from '../app/I18nContext';
 import { statusLabel } from '../i18n/labels';
 import { clampLatencyToCeiling, suggestLatencyAxisCeiling } from '../utils/latencyScale';
 
 interface HeartbeatBarProps {
-  heartbeats: Heartbeat[];
+  heartbeats?: Heartbeat[] | undefined;
+  strip?: HomepageHeartbeatStrip | undefined;
   maxBars?: number;
   visualBars?: number;
   density?: 'default' | 'compact';
-}
-
-function getStatusColor(status: CheckStatus): string {
-  switch (status) {
-    case 'up':
-      return 'bg-emerald-500 dark:bg-emerald-400';
-    case 'down':
-      return 'bg-red-500 dark:bg-red-400';
-    case 'maintenance':
-      return 'bg-blue-500 dark:bg-blue-400';
-    case 'unknown':
-    default:
-      return 'bg-slate-300 dark:bg-slate-600';
-  }
-}
-
-function getStatusGlow(status: CheckStatus): string {
-  switch (status) {
-    case 'up':
-      return 'shadow-emerald-500/50';
-    case 'down':
-      return 'shadow-red-500/50';
-    default:
-      return '';
-  }
 }
 
 interface LatencyScale {
@@ -47,6 +24,61 @@ interface DisplayHeartbeat extends Heartbeat {
   from_checked_at: number;
   to_checked_at: number;
   sample_count: number;
+}
+
+type DisplaySlot = {
+  heartbeat: DisplayHeartbeat | null;
+};
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function decodeStatusCode(code: string | undefined): CheckStatus {
+  switch (code) {
+    case 'u':
+      return 'up';
+    case 'd':
+      return 'down';
+    case 'm':
+      return 'maintenance';
+    case 'x':
+    default:
+      return 'unknown';
+  }
+}
+
+function decodeHeartbeatStrip(strip: HomepageHeartbeatStrip | undefined): Heartbeat[] {
+  if (!strip) return [];
+
+  const out: Heartbeat[] = [];
+  const count = Math.min(
+    strip.checked_at.length,
+    strip.latency_ms.length,
+    strip.status_codes.length,
+  );
+
+  for (let index = 0; index < count; index += 1) {
+    out.push({
+      checked_at: strip.checked_at[index] ?? 0,
+      status: decodeStatusCode(strip.status_codes[index]),
+      latency_ms: strip.latency_ms[index] ?? null,
+    });
+  }
+
+  return out;
+}
+
+function statusPriority(status: CheckStatus): number {
+  switch (status) {
+    case 'down':
+      return 4;
+    case 'unknown':
+      return 3;
+    case 'maintenance':
+      return 2;
+    case 'up':
+    default:
+      return 1;
+  }
 }
 
 function buildLatencyScale(heartbeats: DisplayHeartbeat[]): LatencyScale | null {
@@ -72,82 +104,79 @@ function buildLatencyScale(heartbeats: DisplayHeartbeat[]): LatencyScale | null 
   return { min, span: Math.max(1, max - min), ceiling };
 }
 
-function getBarHeight(
+function getBarHeightPct(
   heartbeat: DisplayHeartbeat,
   scale: LatencyScale | null,
   compact: boolean,
-): string {
-  if (heartbeat.status === 'down') return '100%';
-  if (heartbeat.status === 'maintenance') return compact ? '62%' : '65%';
-  if (heartbeat.status === 'unknown') return compact ? '48%' : '52%';
+): number {
+  if (heartbeat.status === 'down') return 100;
+  if (heartbeat.status === 'maintenance') return compact ? 62 : 65;
+  if (heartbeat.status === 'unknown') return compact ? 48 : 52;
 
-  if (heartbeat.latency_ms === null || !scale) return compact ? '74%' : '78%';
+  if (heartbeat.latency_ms === null || !scale) return compact ? 74 : 78;
 
   const displayLatency = clampLatencyToCeiling(heartbeat.latency_ms, scale.ceiling);
   const normalized = (displayLatency - scale.min) / scale.span;
   const clamped = Math.max(0, Math.min(1, normalized));
   const minHeight = compact ? 36 : 38;
-  const pct = minHeight + clamped * (100 - minHeight);
-  return `${pct.toFixed(1)}%`;
+  return minHeight + clamped * (100 - minHeight);
+}
+
+function heartbeatFill(status: CheckStatus): string {
+  switch (status) {
+    case 'up':
+      return '#10b981';
+    case 'down':
+      return '#ef4444';
+    case 'maintenance':
+      return '#3b82f6';
+    case 'unknown':
+    default:
+      return '#cbd5e1';
+  }
+}
+
+function tooltipDotClass(status: CheckStatus): string {
+  switch (status) {
+    case 'up':
+      return 'bg-emerald-500 dark:bg-emerald-400';
+    case 'down':
+      return 'bg-red-500 dark:bg-red-400';
+    case 'maintenance':
+      return 'bg-blue-500 dark:bg-blue-400';
+    case 'unknown':
+    default:
+      return 'bg-slate-300 dark:bg-slate-600';
+  }
+}
+
+function buildSvgDataUri(slots: DisplaySlot[], compact: boolean, scale: LatencyScale | null): string {
+  const height = compact ? 20 : 24;
+  const barWidth = compact ? 4 : 6;
+  const gap = compact ? 2 : 3;
+  const width = slots.length === 0 ? barWidth : slots.length * barWidth + (slots.length - 1) * gap;
+
+  const rects = slots
+    .map((slot, index) => {
+      const x = index * (barWidth + gap);
+      if (!slot.heartbeat) {
+        const emptyHeight = compact ? height * 0.46 : height * 0.48;
+        const y = height - emptyHeight;
+        return `<rect x="${x}" y="${y.toFixed(2)}" width="${barWidth}" height="${emptyHeight.toFixed(2)}" rx="1" fill="transparent"/>`;
+      }
+
+      const barHeight = (height * getBarHeightPct(slot.heartbeat, scale, compact)) / 100;
+      const y = height - barHeight;
+      return `<rect x="${x}" y="${y.toFixed(2)}" width="${barWidth}" height="${barHeight.toFixed(2)}" rx="1" fill="${heartbeatFill(slot.heartbeat.status)}"/>`;
+    })
+    .join('');
+
+  const svg = `<svg xmlns="${SVG_NS}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">${rects}</svg>`;
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
 }
 
 function formatTime(timestamp: number, locale: string): string {
   return new Date(timestamp * 1000).toLocaleString(locale);
-}
-
-interface TooltipProps {
-  heartbeat: DisplayHeartbeat;
-  position: { x: number; y: number };
-}
-
-function Tooltip({ heartbeat, position }: TooltipProps) {
-  const { locale, t } = useI18n();
-  const hasWindow =
-    heartbeat.sample_count > 1 && heartbeat.from_checked_at !== heartbeat.to_checked_at;
-
-  return (
-    <div
-      className="fixed z-50 px-3 py-2 text-xs bg-slate-900 dark:bg-slate-700 text-white rounded-lg shadow-lg pointer-events-none animate-fade-in"
-      style={{
-        left: position.x,
-        top: position.y,
-        transform: 'translate(-50%, -100%) translateY(-8px)',
-      }}
-    >
-      <div className="font-medium mb-1">
-        {hasWindow
-          ? `${formatTime(heartbeat.from_checked_at, locale)} ${t('heartbeat.to')} ${formatTime(heartbeat.to_checked_at, locale)}`
-          : formatTime(heartbeat.checked_at, locale)}
-      </div>
-      <div className="flex items-center gap-2">
-        <span className={`w-2 h-2 rounded-full ${getStatusColor(heartbeat.status)}`} />
-        <span>{statusLabel(heartbeat.status, t)}</span>
-        {heartbeat.latency_ms !== null && (
-          <span className="text-slate-400 dark:text-slate-300">• {heartbeat.latency_ms}ms</span>
-        )}
-      </div>
-      {heartbeat.sample_count > 1 && (
-        <div className="mt-1 text-slate-300">
-          {t('heartbeat.sample_checks', { count: heartbeat.sample_count })}
-        </div>
-      )}
-      <div className="absolute left-1/2 -bottom-1 -translate-x-1/2 w-2 h-2 bg-slate-900 dark:bg-slate-700 rotate-45" />
-    </div>
-  );
-}
-
-function statusPriority(status: CheckStatus): number {
-  switch (status) {
-    case 'down':
-      return 4;
-    case 'unknown':
-      return 3;
-    case 'maintenance':
-      return 2;
-    case 'up':
-    default:
-      return 1;
-  }
 }
 
 function aggregateHeartbeats(heartbeats: Heartbeat[], slots: number): DisplayHeartbeat[] {
@@ -175,8 +204,8 @@ function aggregateHeartbeats(heartbeats: Heartbeat[], slots: number): DisplayHea
     let worst = first;
     let latencySum = 0;
     let latencyCount = 0;
-    for (let i = start; i < endExclusive; i++) {
-      const hb = chronological[i];
+    for (let index = start; index < endExclusive; index += 1) {
+      const hb = chronological[index];
       if (!hb) continue;
 
       if (statusPriority(hb.status) > statusPriority(worst.status)) {
@@ -193,12 +222,10 @@ function aggregateHeartbeats(heartbeats: Heartbeat[], slots: number): DisplayHea
       }
     }
 
-    const avgLatency = latencyCount > 0 ? Math.round(latencySum / latencyCount) : null;
-
     groups.push({
       checked_at: last.checked_at,
       status: worst.status,
-      latency_ms: avgLatency,
+      latency_ms: latencyCount > 0 ? Math.round(latencySum / latencyCount) : null,
       from_checked_at: first.checked_at,
       to_checked_at: last.checked_at,
       sample_count: endExclusive - start,
@@ -208,20 +235,67 @@ function aggregateHeartbeats(heartbeats: Heartbeat[], slots: number): DisplayHea
   return groups;
 }
 
+function Tooltip({
+  heartbeat,
+  position,
+}: {
+  heartbeat: DisplayHeartbeat;
+  position: { x: number; y: number };
+}) {
+  const { locale, t } = useI18n();
+  const hasWindow =
+    heartbeat.sample_count > 1 && heartbeat.from_checked_at !== heartbeat.to_checked_at;
+
+  return (
+    <div
+      className="fixed z-50 px-3 py-2 text-xs bg-slate-900 dark:bg-slate-700 text-white rounded-lg shadow-lg pointer-events-none animate-fade-in"
+      style={{
+        left: position.x,
+        top: position.y,
+        transform: 'translate(-50%, -100%) translateY(-8px)',
+      }}
+    >
+      <div className="font-medium mb-1">
+        {hasWindow
+          ? `${formatTime(heartbeat.from_checked_at, locale)} ${t('heartbeat.to')} ${formatTime(heartbeat.to_checked_at, locale)}`
+          : formatTime(heartbeat.checked_at, locale)}
+      </div>
+      <div className="flex items-center gap-2">
+        <span className={`w-2 h-2 rounded-full ${tooltipDotClass(heartbeat.status)}`} />
+        <span>{statusLabel(heartbeat.status, t)}</span>
+        {heartbeat.latency_ms !== null && (
+          <span className="text-slate-400 dark:text-slate-300">• {heartbeat.latency_ms}ms</span>
+        )}
+      </div>
+      {heartbeat.sample_count > 1 && (
+        <div className="mt-1 text-slate-300">
+          {t('heartbeat.sample_checks', { count: heartbeat.sample_count })}
+        </div>
+      )}
+      <div className="absolute left-1/2 -bottom-1 -translate-x-1/2 w-2 h-2 bg-slate-900 dark:bg-slate-700 rotate-45" />
+    </div>
+  );
+}
+
 export function HeartbeatBar({
   heartbeats,
+  strip,
   maxBars = 60,
   visualBars,
   density = 'default',
 }: HeartbeatBarProps) {
-  const { locale, t } = useI18n();
+  const { t } = useI18n();
   const [tooltip, setTooltip] = useState<{
     heartbeat: DisplayHeartbeat;
+    index: number;
     position: { x: number; y: number };
   } | null>(null);
   const compact = density === 'compact';
 
-  const sourceHeartbeats = useMemo(() => heartbeats.slice(0, maxBars), [heartbeats, maxBars]);
+  const sourceHeartbeats = useMemo(() => {
+    const decoded = heartbeats ?? decodeHeartbeatStrip(strip);
+    return decoded.slice(0, maxBars);
+  }, [heartbeats, maxBars, strip]);
   const slotCount = useMemo(() => {
     if (!visualBars || visualBars < 1) return maxBars;
     return Math.min(maxBars, visualBars);
@@ -231,53 +305,74 @@ export function HeartbeatBar({
     [sourceHeartbeats, slotCount],
   );
   const latencyScale = useMemo(() => buildLatencyScale(displayHeartbeats), [displayHeartbeats]);
+  const slots = useMemo<DisplaySlot[]>(
+    () => [
+      ...displayHeartbeats.map((heartbeat) => ({ heartbeat })),
+      ...Array.from({ length: Math.max(0, slotCount - displayHeartbeats.length) }, () => ({
+        heartbeat: null,
+      })),
+    ],
+    [displayHeartbeats, slotCount],
+  );
+  const backgroundImage = useMemo(
+    () => buildSvgDataUri(slots, compact, latencyScale),
+    [compact, latencyScale, slots],
+  );
 
-  const handleMouseEnter = (hb: DisplayHeartbeat, e: React.MouseEvent) => {
-    const rect = e.currentTarget.getBoundingClientRect();
+  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (slotCount === 0) return;
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(0.999999, (event.clientX - rect.left) / rect.width));
+    const index = Math.floor(ratio * slotCount);
+    const slot = slots[index];
+    if (!slot?.heartbeat) {
+      if (tooltip) setTooltip(null);
+      return;
+    }
+
     setTooltip({
-      heartbeat: hb,
-      position: { x: rect.left + rect.width / 2, y: rect.top },
+      heartbeat: slot.heartbeat,
+      index,
+      position: {
+        x: rect.left + ((index + 0.5) / slotCount) * rect.width,
+        y: rect.top,
+      },
     });
   };
 
   return (
     <>
       <div
-        data-bar-chart
         className={
-          compact
-            ? 'flex h-5 items-end gap-[2px] sm:h-6'
-            : 'flex h-6 items-end gap-[2px] sm:h-8 sm:gap-[3px]'
+          compact ? 'relative h-5 overflow-hidden sm:h-6' : 'relative h-6 overflow-hidden sm:h-8'
         }
       >
-        {displayHeartbeats.map((hb) => (
+        <div
+          data-bar-chart
+          role="img"
+          aria-label={t('monitor_card.last_checks', {
+            count: Math.min(sourceHeartbeats.length, slotCount),
+          })}
+          className="relative h-full w-full rounded-md bg-slate-200 dark:bg-slate-700"
+          style={{
+            backgroundImage,
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: '100% 100%',
+          }}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={() => setTooltip(null)}
+        />
+        {tooltip && (
           <div
-            key={`${hb.from_checked_at}-${hb.to_checked_at}`}
-            role="img"
-            aria-label={`${statusLabel(hb.status, t)} ${formatTime(hb.from_checked_at, locale)}${hb.to_checked_at !== hb.from_checked_at ? ` ${t('heartbeat.to')} ${formatTime(hb.to_checked_at, locale)}` : ''}${hb.latency_ms !== null ? ` ${hb.latency_ms}ms` : ''}`}
-            className={`${
-              compact
-                ? 'max-w-[6px] min-w-[3px] flex-1'
-                : 'max-w-[6px] min-w-[3px] flex-1 sm:max-w-[8px] sm:min-w-[4px]'
-            } rounded-sm transition-all duration-150 cursor-pointer
-              ${getStatusColor(hb.status)}
-              ${compact ? 'hover:scale-y-105' : 'hover:scale-y-110'} hover:shadow-md ${tooltip?.heartbeat === hb ? getStatusGlow(hb.status) : ''}`}
-            style={{ height: getBarHeight(hb, latencyScale, compact) }}
-            onMouseEnter={(e) => handleMouseEnter(hb, e)}
-            onMouseLeave={() => setTooltip(null)}
+            className="pointer-events-none absolute inset-y-0 rounded-sm ring-1 ring-white/70 shadow-[0_0_0_1px_rgba(15,23,42,0.08)]"
+            style={{
+              left: `${(tooltip.index / slotCount) * 100}%`,
+              width: `${100 / slotCount}%`,
+            }}
           />
-        ))}
-        {displayHeartbeats.length < slotCount &&
-          Array.from({ length: slotCount - displayHeartbeats.length }).map((_, idx) => (
-            <div
-              key={`empty-${idx}`}
-              className={
-                compact
-                  ? 'h-[46%] max-w-[6px] min-w-[3px] flex-1 rounded-sm bg-slate-200 dark:bg-slate-700'
-                  : 'h-[48%] max-w-[6px] min-w-[3px] flex-1 rounded-sm bg-slate-200 dark:bg-slate-700 sm:max-w-[8px] sm:min-w-[4px]'
-              }
-            />
-          ))}
+        )}
       </div>
       {tooltip &&
         createPortal(

--- a/apps/web/src/components/MonitorCard.tsx
+++ b/apps/web/src/components/MonitorCard.tsx
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
 
-import type { HomepageMonitorCard, PublicMonitor, UptimeRatingLevel } from '../api/types';
+import type {
+  HomepageHeartbeatStrip,
+  HomepageMonitorCard,
+  PublicMonitor,
+  UptimeRatingLevel,
+} from '../api/types';
 import { useI18n } from '../app/I18nContext';
 import { statusLabel } from '../i18n/labels';
 import { HeartbeatBar } from './HeartbeatBar';
@@ -18,18 +23,46 @@ import {
 const HEARTBEAT_BARS = 60;
 const AVAILABILITY_BARS = 60;
 
+type PublicMonitorLike = Pick<
+  PublicMonitor,
+  'id' | 'name' | 'type' | 'status' | 'is_stale' | 'last_checked_at' | 'heartbeats' | 'uptime_30d' | 'uptime_days'
+>;
+
+type HomepageMonitorLike = Pick<
+  HomepageMonitorCard,
+  | 'id'
+  | 'name'
+  | 'type'
+  | 'status'
+  | 'is_stale'
+  | 'last_checked_at'
+  | 'heartbeat_strip'
+  | 'uptime_30d'
+  | 'uptime_day_strip'
+>;
+
+type MonitorLike = PublicMonitorLike | HomepageMonitorLike;
+
 export interface MonitorCardProps {
-  monitor: Pick<
-    PublicMonitor | HomepageMonitorCard,
-    'id' | 'name' | 'type' | 'status' | 'is_stale' | 'last_checked_at' | 'heartbeats' | 'uptime_30d' | 'uptime_days'
-  >;
+  monitor: MonitorLike;
   ratingLevel: UptimeRatingLevel;
   timeZone: string;
   onSelect: () => void;
   onDayClick: (dayStartAt: number) => void;
 }
 
-function getHeartbeatLatencyStats(heartbeats: PublicMonitor['heartbeats']): {
+function hasHomepageStrips(monitor: MonitorLike): monitor is HomepageMonitorLike {
+  return 'heartbeat_strip' in monitor && 'uptime_day_strip' in monitor;
+}
+
+function hasPublicTimeseries(monitor: MonitorLike): monitor is PublicMonitorLike {
+  return 'heartbeats' in monitor && 'uptime_days' in monitor;
+}
+
+function getHeartbeatLatencyStats(
+  heartbeats: PublicMonitor['heartbeats'] | undefined,
+  heartbeatStrip: HomepageHeartbeatStrip | undefined,
+): {
   fastestMs: number | null;
   avgMs: number | null;
   slowestMs: number | null;
@@ -39,15 +72,28 @@ function getHeartbeatLatencyStats(heartbeats: PublicMonitor['heartbeats']): {
   let latencySum = 0;
   let latencyCount = 0;
 
-  for (const hb of heartbeats) {
-    if (hb.status !== 'up') continue;
-    if (typeof hb.latency_ms !== 'number' || !Number.isFinite(hb.latency_ms)) continue;
+  if (Array.isArray(heartbeats)) {
+    for (const hb of heartbeats) {
+      if (hb.status !== 'up') continue;
+      if (typeof hb.latency_ms !== 'number' || !Number.isFinite(hb.latency_ms)) continue;
 
-    const latency = hb.latency_ms;
-    if (latency < fastestMs) fastestMs = latency;
-    if (latency > slowestMs) slowestMs = latency;
-    latencySum += latency;
-    latencyCount++;
+      const latency = hb.latency_ms;
+      if (latency < fastestMs) fastestMs = latency;
+      if (latency > slowestMs) slowestMs = latency;
+      latencySum += latency;
+      latencyCount++;
+    }
+  } else if (heartbeatStrip) {
+    for (let index = 0; index < heartbeatStrip.status_codes.length; index += 1) {
+      if (heartbeatStrip.status_codes[index] !== 'u') continue;
+      const latency = heartbeatStrip.latency_ms[index];
+      if (typeof latency !== 'number' || !Number.isFinite(latency)) continue;
+
+      if (latency < fastestMs) fastestMs = latency;
+      if (latency > slowestMs) slowestMs = latency;
+      latencySum += latency;
+      latencyCount++;
+    }
   }
 
   if (latencyCount === 0) {
@@ -73,9 +119,13 @@ export function MonitorCard({
       ? formatTime(monitor.last_checked_at, { timeZone, locale })
       : formatTime(monitor.last_checked_at, { locale })
     : t('monitor_card.never_checked');
+  const heartbeatStrip = hasHomepageStrips(monitor) ? monitor.heartbeat_strip : undefined;
+  const uptimeDayStrip = hasHomepageStrips(monitor) ? monitor.uptime_day_strip : undefined;
+  const heartbeats = hasPublicTimeseries(monitor) ? monitor.heartbeats : undefined;
+  const uptimeDays = hasPublicTimeseries(monitor) ? monitor.uptime_days : undefined;
   const latencyStats = useMemo(
-    () => getHeartbeatLatencyStats(monitor.heartbeats ?? []),
-    [monitor.heartbeats],
+    () => getHeartbeatLatencyStats(heartbeats, heartbeatStrip),
+    [heartbeatStrip, heartbeats],
   );
 
   const tier = uptime30d ? getUptimeTier(uptime30d.uptime_pct, ratingLevel) : null;
@@ -123,7 +173,8 @@ export function MonitorCard({
           {t('monitor_card.availability_30d')}
         </div>
         <UptimeBar30d
-          days={monitor.uptime_days}
+          days={uptimeDays}
+          strip={uptimeDayStrip}
           ratingLevel={ratingLevel}
           maxBars={AVAILABILITY_BARS}
           timeZone={timeZone}
@@ -138,7 +189,8 @@ export function MonitorCard({
           {t('monitor_card.last_checks', { count: HEARTBEAT_BARS })}
         </div>
         <HeartbeatBar
-          heartbeats={monitor.heartbeats ?? []}
+          heartbeats={heartbeats}
+          strip={heartbeatStrip}
           maxBars={HEARTBEAT_BARS}
           density="compact"
         />

--- a/apps/web/src/components/UptimeBar30d.tsx
+++ b/apps/web/src/components/UptimeBar30d.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import type { UptimeDayPreview, UptimeRatingLevel } from '../api/types';
+import type { HomepageUptimeDayStrip, UptimeDayPreview, UptimeRatingLevel } from '../api/types';
 import { useI18n } from '../app/I18nContext';
 import { formatDate } from '../utils/datetime';
 import { getUptimeBgClasses, getUptimeTier } from '../utils/uptime';
@@ -9,13 +9,42 @@ import { getUptimeBgClasses, getUptimeTier } from '../utils/uptime';
 type DowntimeInterval = { start: number; end: number };
 
 interface UptimeBar30dProps {
-  days: UptimeDayPreview[];
+  days?: UptimeDayPreview[] | undefined;
+  strip?: HomepageUptimeDayStrip | undefined;
   ratingLevel?: UptimeRatingLevel;
   maxBars?: number;
   timeZone: string;
   onDayClick?: (dayStartAt: number) => void;
   density?: 'default' | 'compact';
   fillMode?: 'pad' | 'stretch';
+}
+
+type DisplaySlot = {
+  day: UptimeDayPreview | null;
+};
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function decodeUptimeDayStrip(strip: HomepageUptimeDayStrip | undefined): UptimeDayPreview[] {
+  if (!strip) return [];
+
+  const count = Math.min(
+    strip.day_start_at.length,
+    strip.downtime_sec.length,
+    strip.unknown_sec.length,
+    strip.uptime_pct_milli.length,
+  );
+  const out: UptimeDayPreview[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const milli = strip.uptime_pct_milli[index];
+    out.push({
+      day_start_at: strip.day_start_at[index] ?? 0,
+      downtime_sec: strip.downtime_sec[index] ?? 0,
+      unknown_sec: strip.unknown_sec[index] ?? 0,
+      uptime_pct: milli === null || milli === undefined ? null : milli / 1000,
+    });
+  }
+  return out;
 }
 
 function formatDay(ts: number, timeZone: string, locale: string): string {
@@ -33,37 +62,32 @@ function formatSec(totalSeconds: number): string {
   return `${d}d ${h % 24}h`;
 }
 
-function getUptimeColorClasses(uptimePct: number | null, level: UptimeRatingLevel): string {
+function tooltipDotClass(uptimePct: number | null, level: UptimeRatingLevel): string {
   if (uptimePct === null) return 'bg-slate-300 dark:bg-slate-600';
   return getUptimeBgClasses(getUptimeTier(uptimePct, level));
 }
 
-function getUptimeGlow(uptimePct: number | null, level: UptimeRatingLevel): string {
-  if (uptimePct === null) return '';
+function uptimeFill(uptimePct: number | null, level: UptimeRatingLevel): string {
+  if (uptimePct === null) return '#cbd5e1';
 
-  // Keep glow coarse: good (>= green), warn (>= amber), bad (< amber).
-  const goodThresholdByLevel: Record<UptimeRatingLevel, number> = {
-    1: 98.0,
-    2: 99.5,
-    3: 99.95,
-    4: 99.995,
-    5: 99.999,
-  };
-
-  const warnThresholdByLevel: Record<UptimeRatingLevel, number> = {
-    1: 95.0,
-    2: 98.0,
-    3: 99.0,
-    4: 99.9,
-    5: 99.95,
-  };
-
-  const good = goodThresholdByLevel[level] ?? goodThresholdByLevel[3];
-  const warn = warnThresholdByLevel[level] ?? warnThresholdByLevel[3];
-
-  if (uptimePct >= good) return 'shadow-emerald-500/50';
-  if (uptimePct >= warn) return 'shadow-amber-500/50';
-  return 'shadow-red-500/50';
+  const tier = getUptimeTier(uptimePct, level);
+  switch (tier) {
+    case 'emerald':
+    case 'green':
+      return '#10b981';
+    case 'lime':
+      return '#84cc16';
+    case 'yellow':
+    case 'amber':
+    case 'orange':
+      return '#f59e0b';
+    case 'red':
+    case 'rose':
+      return '#ef4444';
+    case 'slate':
+    default:
+      return '#cbd5e1';
+  }
 }
 
 function mergeIntervals(intervals: DowntimeInterval[]): DowntimeInterval[] {
@@ -90,10 +114,26 @@ function mergeIntervals(intervals: DowntimeInterval[]): DowntimeInterval[] {
   return merged;
 }
 
-interface TooltipState {
-  day: UptimeDayPreview;
-  slotKey: string;
-  position: { x: number; y: number };
+function buildSvgDataUri(
+  slots: DisplaySlot[],
+  ratingLevel: UptimeRatingLevel,
+  compact: boolean,
+): string {
+  const height = compact ? 20 : 24;
+  const barWidth = compact ? 4 : 6;
+  const gap = compact ? 2 : 3;
+  const width = slots.length === 0 ? barWidth : slots.length * barWidth + (slots.length - 1) * gap;
+
+  const rects = slots
+    .map((slot, index) => {
+      const x = index * (barWidth + gap);
+      const fill = slot.day ? uptimeFill(slot.day.uptime_pct, ratingLevel) : 'transparent';
+      return `<rect x="${x}" y="0" width="${barWidth}" height="${height}" rx="1" fill="${fill}"/>`;
+    })
+    .join('');
+
+  const svg = `<svg xmlns="${SVG_NS}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">${rects}</svg>`;
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
 }
 
 function Tooltip({
@@ -120,9 +160,7 @@ function Tooltip({
     >
       <div className="font-medium mb-1">{formatDay(day.day_start_at, timeZone, locale)}</div>
       <div className="flex items-center gap-2">
-        <span
-          className={`w-2 h-2 rounded-full ${getUptimeColorClasses(day.uptime_pct, ratingLevel)}`}
-        />
+        <span className={`w-2 h-2 rounded-full ${tooltipDotClass(day.uptime_pct, ratingLevel)}`} />
         <span>
           {day.uptime_pct === null ? t('uptime.no_data') : `${day.uptime_pct.toFixed(3)}%`}{' '}
           {t('uptime.uptime')}
@@ -143,6 +181,7 @@ function Tooltip({
 
 export function UptimeBar30d({
   days,
+  strip,
   ratingLevel = 3,
   maxBars = 30,
   timeZone,
@@ -151,14 +190,17 @@ export function UptimeBar30d({
   fillMode = 'pad',
 }: UptimeBar30dProps) {
   const { locale, t } = useI18n();
-  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const [tooltip, setTooltip] = useState<{
+    day: UptimeDayPreview;
+    index: number;
+    position: { x: number; y: number };
+  } | null>(null);
   const compact = density === 'compact';
 
   const sourceDays = useMemo(() => {
-    if (!Array.isArray(days)) return [];
-    // Backend returns oldest -> newest; we want newest on the right.
-    return days.slice(-maxBars);
-  }, [days, maxBars]);
+    const decoded = days ?? decodeUptimeDayStrip(strip);
+    return decoded.slice(-maxBars);
+  }, [days, maxBars, strip]);
 
   const displayBars = useMemo(() => {
     if (sourceDays.length === 0) return [];
@@ -170,73 +212,98 @@ export function UptimeBar30d({
           Math.floor((slot * sourceDays.length) / maxBars),
         );
         const day = sourceDays[mappedIndex];
-        if (!day) return null;
-        return { day, slotKey: `${day.day_start_at}-${slot}` };
-      }).filter((entry): entry is { day: UptimeDayPreview; slotKey: string } => entry !== null);
+        return day ?? null;
+      });
     }
 
-    return sourceDays.map((day) => ({ day, slotKey: `${day.day_start_at}` }));
+    return sourceDays;
   }, [fillMode, maxBars, sourceDays]);
 
-  // Ensure stable layout in default mode when fewer bars are available.
-  const emptyCount = fillMode === 'stretch' ? 0 : Math.max(0, maxBars - displayBars.length);
+  const slots = useMemo<DisplaySlot[]>(() => {
+    if (fillMode === 'stretch') {
+      return displayBars.map((day) => ({ day }));
+    }
 
-  const handleMouseEnter = (d: UptimeDayPreview, slotKey: string, e: React.MouseEvent) => {
-    const rect = e.currentTarget.getBoundingClientRect();
+    const emptyCount = Math.max(0, maxBars - displayBars.length);
+    return [
+      ...Array.from({ length: emptyCount }, () => ({ day: null })),
+      ...displayBars.map((day) => ({ day })),
+    ];
+  }, [displayBars, fillMode, maxBars]);
+  const slotCount = slots.length;
+  const backgroundImage = useMemo(
+    () => buildSvgDataUri(slots, ratingLevel, compact),
+    [compact, ratingLevel, slots],
+  );
+  const showTooltip = (day: UptimeDayPreview, index: number, element: HTMLElement) => {
+    const rect = element.getBoundingClientRect();
     setTooltip({
-      day: d,
-      slotKey,
-      position: { x: rect.left + rect.width / 2, y: rect.top },
+      day,
+      index,
+      position: {
+        x: rect.left + rect.width / 2,
+        y: rect.top,
+      },
     });
   };
 
   return (
     <>
       <div
-        data-bar-chart
         className={
-          compact
-            ? 'flex h-5 items-end gap-[2px] overflow-hidden sm:h-6'
-            : 'flex h-6 items-end gap-[2px] overflow-hidden sm:h-8 sm:gap-[3px]'
+          compact ? 'relative h-5 overflow-hidden sm:h-6' : 'relative h-6 overflow-hidden sm:h-8'
         }
       >
-        {emptyCount > 0 &&
-          Array.from({ length: emptyCount }).map((_, idx) => (
-            <div
-              key={`empty-${idx}`}
-              className={
-                compact
-                  ? 'h-[100%] max-w-[6px] min-w-[3px] flex-1 rounded-sm bg-slate-200 dark:bg-slate-700'
-                  : 'h-[100%] max-w-[6px] min-w-[3px] flex-1 rounded-sm bg-slate-200 dark:bg-slate-700 sm:max-w-[8px] sm:min-w-[4px]'
-              }
-            />
-          ))}
-
-        {displayBars.map(({ day: d, slotKey }) => {
-          const pct = d.uptime_pct;
-
-          return (
-            <button
-              key={slotKey}
-              type="button"
-              aria-label={`${t('uptime.aria_prefix')} ${formatDay(d.day_start_at, timeZone, locale)}`}
-              className={`${
-                compact
-                  ? 'max-w-[6px] min-w-[3px] flex-1'
-                  : 'max-w-[6px] min-w-[3px] flex-1 sm:max-w-[8px] sm:min-w-[4px]'
-              } rounded-sm transition-all duration-150
-                ${getUptimeColorClasses(pct, ratingLevel)}
-                ${compact ? 'hover:scale-y-105' : 'hover:scale-y-110'} hover:shadow-md ${tooltip?.slotKey === slotKey ? getUptimeGlow(pct, ratingLevel) : ''}`}
-              style={{ height: '100%' }}
-              onMouseEnter={(e) => handleMouseEnter(d, slotKey, e)}
-              onMouseLeave={() => setTooltip(null)}
-              onClick={(e) => {
-                e.stopPropagation();
-                onDayClick?.(d.day_start_at);
-              }}
-            />
-          );
-        })}
+        <div
+          data-bar-chart
+          className="relative h-full w-full rounded-md bg-slate-200 dark:bg-slate-700"
+          style={{
+            backgroundImage,
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: '100% 100%',
+          }}
+        />
+        {slotCount > 0 && (
+          <div
+            className="absolute inset-0 grid"
+            style={{ gridTemplateColumns: `repeat(${slotCount}, minmax(0, 1fr))` }}
+          >
+            {slots.map((slot, index) => {
+              const day = slot.day;
+              return day ? (
+                <button
+                  key={day.day_start_at}
+                  type="button"
+                  aria-label={`${t('uptime.aria_prefix')}: ${formatDay(day.day_start_at, timeZone, locale)}`}
+                  className="h-full w-full bg-transparent focus:outline-none"
+                  onMouseEnter={(event) => showTooltip(day, index, event.currentTarget)}
+                  onFocus={(event) => showTooltip(day, index, event.currentTarget)}
+                  onBlur={() => setTooltip((current) => (current?.index === index ? null : current))}
+                  onMouseLeave={() =>
+                    setTooltip((current) => (current?.index === index ? null : current))
+                  }
+                  onClick={(event) => {
+                    if (!onDayClick) return;
+                    event.stopPropagation();
+                    onDayClick(day.day_start_at);
+                  }}
+                />
+              ) : (
+                <span key={`empty-${index}`} aria-hidden="true" />
+              );
+            })}
+          </div>
+        )}
+        {tooltip && (
+          <div
+            className="pointer-events-none absolute inset-y-0 rounded-sm ring-1 ring-white/70 shadow-[0_0_0_1px_rgba(15,23,42,0.08)]"
+            style={{
+              left: `${(tooltip.index / slotCount) * 100}%`,
+              width: `${100 / slotCount}%`,
+            }}
+          />
+        )}
       </div>
 
       {tooltip &&

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -104,6 +104,10 @@ const en = {
   'status_page.failed_load_incident_history': 'Failed to load incident history',
   'status_page.failed_load_maintenance_history': 'Failed to load maintenance history',
   'status_page.failed_load_data': 'Failed to load data',
+  'status_page.partial_bootstrap_loading':
+    '{count} more services are loading. The full list will appear when the refresh completes.',
+  'status_page.partial_bootstrap_error':
+    'Showing a partial service list because the latest refresh did not complete yet.',
   'status_page.incident_prefix': 'Incident: {value}',
   'status_page.maintenance_prefix': 'Maintenance: {value}',
   'status_page.initial_report': 'Initial Report',

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -24,6 +24,20 @@ type PersistedHomepageCache = {
   value: PublicHomepageResponse;
 };
 
+function toHeartbeatStatusCode(status: StatusResponse['monitors'][number]['heartbeats'][number]['status']) {
+  switch (status) {
+    case 'up':
+      return 'u';
+    case 'down':
+      return 'd';
+    case 'maintenance':
+      return 'm';
+    case 'unknown':
+    default:
+      return 'x';
+  }
+}
+
 function readPersistedHomepageCache(): PublicHomepageResponse | null {
   try {
     const raw = localStorage.getItem(LS_PUBLIC_HOMEPAGE_KEY);
@@ -34,6 +48,7 @@ function readPersistedHomepageCache(): PublicHomepageResponse | null {
     const value = (parsed as { value?: unknown }).value;
     if (!value || typeof value !== 'object') return null;
     if (typeof (value as { generated_at?: unknown }).generated_at !== 'number') return null;
+    if ((value as { bootstrap_mode?: unknown }).bootstrap_mode === 'partial') return null;
 
     return value as PublicHomepageResponse;
   } catch {
@@ -61,6 +76,8 @@ function readPersistedStatusCache(): StatusResponse | null {
 }
 
 function writePersistedHomepageCache(value: PublicHomepageResponse): void {
+  if (value.bootstrap_mode === 'partial') return;
+
   try {
     const payload: PersistedHomepageCache = { at: Date.now(), value };
     localStorage.setItem(LS_PUBLIC_HOMEPAGE_KEY, JSON.stringify(payload));
@@ -72,6 +89,8 @@ function writePersistedHomepageCache(value: PublicHomepageResponse): void {
 function homepageFromStatus(status: StatusResponse): PublicHomepageResponse {
   return {
     generated_at: status.generated_at,
+    bootstrap_mode: 'full',
+    monitor_count_total: status.monitors.length,
     site_title: status.site_title,
     site_description: status.site_description,
     site_locale: status.site_locale,
@@ -88,14 +107,22 @@ function homepageFromStatus(status: StatusResponse): PublicHomepageResponse {
       status: monitor.status,
       is_stale: monitor.is_stale,
       last_checked_at: monitor.last_checked_at,
-      heartbeats: monitor.heartbeats,
+      heartbeat_strip: {
+        checked_at: monitor.heartbeats.map((heartbeat) => heartbeat.checked_at),
+        status_codes: monitor.heartbeats
+          .map((heartbeat) => toHeartbeatStatusCode(heartbeat.status))
+          .join(''),
+        latency_ms: monitor.heartbeats.map((heartbeat) => heartbeat.latency_ms),
+      },
       uptime_30d: monitor.uptime_30d ? { uptime_pct: monitor.uptime_30d.uptime_pct } : null,
-      uptime_days: monitor.uptime_days.map((day) => ({
-        day_start_at: day.day_start_at,
-        downtime_sec: day.downtime_sec,
-        unknown_sec: day.unknown_sec,
-        uptime_pct: day.uptime_pct,
-      })),
+      uptime_day_strip: {
+        day_start_at: monitor.uptime_days.map((day) => day.day_start_at),
+        downtime_sec: monitor.uptime_days.map((day) => day.downtime_sec),
+        unknown_sec: monitor.uptime_days.map((day) => day.unknown_sec),
+        uptime_pct_milli: monitor.uptime_days.map((day) =>
+          day.uptime_pct === null ? null : Math.round(day.uptime_pct * 1000),
+        ),
+      },
     })),
     active_incidents: status.active_incidents.map((incident) => ({
       id: incident.id,
@@ -143,7 +170,11 @@ const seedHomepage = initialHomepage ?? persistedHomepage;
 
 if (seedHomepage) {
   const updatedAt =
-    typeof seedHomepage.generated_at === 'number' ? seedHomepage.generated_at * 1000 : Date.now();
+    seedHomepage.bootstrap_mode === 'partial'
+      ? 0
+      : typeof seedHomepage.generated_at === 'number'
+        ? seedHomepage.generated_at * 1000
+        : Date.now();
 
   queryClient.setQueryData<PublicHomepageResponse>(['homepage'], seedHomepage, { updatedAt });
   writePersistedHomepageCache(seedHomepage);

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -369,7 +369,8 @@ export function StatusPage() {
   const homepageQuery = useQuery({
     queryKey: ['homepage'],
     queryFn: fetchHomepage,
-    refetchInterval: 30_000,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
   });
 
   const derivedTitle = homepageQuery.data?.site_title || 'Uptimer';
@@ -468,6 +469,8 @@ export function StatusPage() {
   const data = homepageQuery.data;
   const bannerConfig = getBannerConfig(data.banner.status, t);
   const activeIncidents = data.active_incidents;
+  const hiddenMonitorCount = Math.max(0, data.monitor_count_total - data.monitors.length);
+  const hasPartialBootstrap = data.bootstrap_mode === 'partial' && hiddenMonitorCount > 0;
 
   const siteTitle = derivedTitle;
   const timeZone = derivedTimeZone;
@@ -686,6 +689,15 @@ export function StatusPage() {
           {data.monitors.length === 0 && (
             <Card className="p-8 text-center">
               <p className="text-slate-500 dark:text-slate-400">{t('status_page.no_monitors')}</p>
+            </Card>
+          )}
+          {hasPartialBootstrap && (
+            <Card className="mt-3 p-4 text-sm text-slate-600 dark:text-slate-300">
+              {homepageQuery.isError
+                ? t('status_page.partial_bootstrap_error')
+                : t('status_page.partial_bootstrap_loading', {
+                    count: hiddenMonitorCount,
+                  })}
             </Card>
           )}
         </section>

--- a/apps/worker/src/middleware/cache-public.ts
+++ b/apps/worker/src/middleware/cache-public.ts
@@ -4,6 +4,14 @@ function hasAuthorizationHeader(req: { header?(name: string): string | undefined
   return Boolean(req.header?.('Authorization'));
 }
 
+function buildCacheKey(url: string, origin: string | undefined): Request {
+  const cacheUrl = new URL(url);
+  if (origin) {
+    cacheUrl.searchParams.set('__uptimer_origin_cache_key', origin);
+  }
+  return new Request(cacheUrl.toString(), { method: 'GET' });
+}
+
 // Cache public (unauthenticated) GET responses at the edge.
 // This reduces D1 read pressure and greatly improves TTFB on slow networks.
 //
@@ -19,7 +27,7 @@ export function cachePublic(opts: { cacheName: string; maxAgeSeconds: number }):
     }
 
     const cache = await caches.open(opts.cacheName);
-    const cacheKey = new Request(c.req.url, { method: 'GET' });
+    const cacheKey = buildCacheKey(c.req.url, c.req.header('Origin'));
 
     const cached = await cache.match(cacheKey);
     if (cached) return cached;

--- a/apps/worker/src/public/data.ts
+++ b/apps/worker/src/public/data.ts
@@ -960,11 +960,11 @@ export async function readPublicSiteSettings(db: D1Database) {
 
 export function buildPublicStatusBanner(opts: {
   counts: PublicStatusResponse['summary'];
-  monitors: PublicStatusResponse['monitors'];
+  monitorCount: number;
   activeIncidents: FilteredIncidentEntry[];
   activeMaintenanceWindows: FilteredMaintenanceWindowEntry[];
 }): Banner {
-  const { counts, monitors, activeIncidents, activeMaintenanceWindows } = opts;
+  const { counts, monitorCount, activeIncidents, activeMaintenanceWindows } = opts;
   const incidents = activeIncidents.map((entry) => entry.row);
   if (incidents.length > 0) {
     const impactRank = (impact: PublicStatusResponse['active_incidents'][number]['impact']) => {
@@ -1015,7 +1015,7 @@ export function buildPublicStatusBanner(opts: {
     };
   }
 
-  const total = monitors.length;
+  const total = monitorCount;
   const downRatio = total === 0 ? 0 : counts.down / total;
 
   if (counts.down > 0) {

--- a/apps/worker/src/public/homepage.ts
+++ b/apps/worker/src/public/homepage.ts
@@ -1,34 +1,71 @@
 import type { PublicHomepageResponse } from '../schemas/public-homepage';
 
 import {
-  buildPublicMonitorCards,
   buildPublicStatusBanner,
+  computeTodayPartialUptimeBatch,
   listIncidentMonitorIdsByIncidentId,
   listMaintenanceWindowMonitorIdsByWindowId,
-  listVisibleActiveIncidents,
-  listVisibleMaintenanceWindows,
   readPublicSiteSettings,
+  STATUS_ACTIVE_INCIDENT_LIMIT,
+  STATUS_ACTIVE_MAINTENANCE_LIMIT,
+  STATUS_UPCOMING_MAINTENANCE_LIMIT,
   toIncidentImpact,
   toIncidentStatus,
+  toMonitorStatus,
+  utcDayStart,
+  type FilteredIncidentEntry,
+  type FilteredMaintenanceWindowEntry,
   type IncidentRow,
   type MaintenanceWindowRow,
+  type UptimeWindowTotals,
 } from './data';
 import {
+  buildNumberedPlaceholders,
+  chunkPositiveIntegerIds,
   filterStatusPageScopedMonitorIds,
   incidentStatusPageVisibilityPredicate,
-  listStatusPageVisibleMonitorIds,
   maintenanceWindowStatusPageVisibilityPredicate,
+  monitorVisibilityPredicate,
   shouldIncludeStatusPageScopedItem,
 } from './visibility';
 
 const PREVIEW_BATCH_LIMIT = 50;
+const UPTIME_DAYS = 30;
+const HEARTBEAT_POINTS = 60;
 
 type IncidentSummary = PublicHomepageResponse['active_incidents'][number];
 type MaintenancePreview = NonNullable<PublicHomepageResponse['maintenance_history_preview']>;
+type HomepageMonitorCard = PublicHomepageResponse['monitors'][number];
+type HomepageMonitorStatus = HomepageMonitorCard['status'];
 
-function toHeartbeatStatusCode(
-  status: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number]['heartbeats'][number]['status'],
-): string {
+type HomepageMonitorRow = {
+  id: number;
+  name: string;
+  type: string;
+  group_name: string | null;
+  interval_sec: number;
+  created_at: number;
+  state_status: string | null;
+  last_checked_at: number | null;
+};
+
+type HomepageHeartbeatRow = {
+  monitor_id: number;
+  checked_at: number;
+  status: string;
+  latency_ms: number | null;
+};
+
+type HomepageRollupRow = {
+  monitor_id: number;
+  day_start_at: number;
+  total_sec: number;
+  downtime_sec: number;
+  unknown_sec: number;
+  uptime_sec: number;
+};
+
+function toHeartbeatStatusCode(status: string | null | undefined): string {
   switch (status) {
     case 'up':
       return 'u';
@@ -40,6 +77,13 @@ function toHeartbeatStatusCode(
     default:
       return 'x';
   }
+}
+
+function toUptimePctMilli(totalSec: number, uptimeSec: number): number | null {
+  if (!Number.isFinite(totalSec) || totalSec <= 0) return null;
+  if (!Number.isFinite(uptimeSec)) return null;
+
+  return Math.max(0, Math.min(100_000, Math.round((uptimeSec / totalSec) * 100_000)));
 }
 
 function toIncidentSummary(row: IncidentRow): IncidentSummary {
@@ -68,75 +112,298 @@ function toMaintenancePreview(
   };
 }
 
-function toHomepageHeartbeatStrip(
-  heartbeats: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number]['heartbeats'],
-): PublicHomepageResponse['monitors'][number]['heartbeat_strip'] {
-  const count = heartbeats.length;
-  const checkedAt = new Array<number>(count);
-  const latencyMs = new Array<number | null>(count);
-  let statusCodes = '';
+async function listHomepageMaintenanceMonitorIds(
+  db: D1Database,
+  at: number,
+  monitorIds: number[],
+): Promise<Set<number>> {
+  const activeMonitorIds = new Set<number>();
 
-  for (let index = 0; index < count; index += 1) {
-    const heartbeat = heartbeats[index];
-    if (!heartbeat) continue;
+  for (const ids of chunkPositiveIntegerIds(monitorIds)) {
+    const placeholders = buildNumberedPlaceholders(ids.length, 2);
+    const sql = `
+      SELECT DISTINCT mwm.monitor_id
+      FROM maintenance_window_monitors mwm
+      JOIN maintenance_windows mw ON mw.id = mwm.maintenance_window_id
+      WHERE mw.starts_at <= ?1 AND mw.ends_at > ?1
+        AND mwm.monitor_id IN (${placeholders})
+    `;
 
-    checkedAt[index] = heartbeat.checked_at;
-    latencyMs[index] = heartbeat.latency_ms;
-    statusCodes += toHeartbeatStatusCode(heartbeat.status);
+    const { results } = await db
+      .prepare(sql)
+      .bind(at, ...ids)
+      .all<{ monitor_id: number }>();
+    for (const row of results ?? []) {
+      activeMonitorIds.add(row.monitor_id);
+    }
   }
 
-  return {
-    checked_at: checkedAt,
-    status_codes: statusCodes,
-    latency_ms: latencyMs,
-  };
+  return activeMonitorIds;
 }
 
-function toHomepageUptimeDayStrip(
-  days: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number]['uptime_days'],
-): PublicHomepageResponse['monitors'][number]['uptime_day_strip'] {
-  const count = days.length;
-  const dayStartAt = new Array<number>(count);
-  const downtimeSec = new Array<number>(count);
-  const unknownSec = new Array<number>(count);
-  const uptimePctMilli = new Array<number | null>(count);
+function computeOverallStatus(summary: PublicHomepageResponse['summary']): HomepageMonitorStatus {
+  if (summary.down > 0) return 'down';
+  if (summary.unknown > 0) return 'unknown';
+  if (summary.maintenance > 0) return 'maintenance';
+  if (summary.up > 0) return 'up';
+  if (summary.paused > 0) return 'paused';
+  return 'unknown';
+}
 
-  for (let index = 0; index < count; index += 1) {
-    const day = days[index];
-    if (!day) continue;
-
-    dayStartAt[index] = day.day_start_at;
-    downtimeSec[index] = day.downtime_sec;
-    unknownSec[index] = day.unknown_sec;
-    uptimePctMilli[index] = day.uptime_pct === null ? null : Math.round(day.uptime_pct * 1000);
-  }
-
-  return {
-    day_start_at: dayStartAt,
-    downtime_sec: downtimeSec,
-    unknown_sec: unknownSec,
-    uptime_pct_milli: uptimePctMilli,
-  };
+function toHomepageMonitorType(value: string): HomepageMonitorCard['type'] {
+  return value === 'tcp' ? 'tcp' : 'http';
 }
 
 function toHomepageMonitorCard(
-  monitor: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number],
-): PublicHomepageResponse['monitors'][number] {
+  row: HomepageMonitorRow,
+  now: number,
+  maintenanceMonitorIds: ReadonlySet<number>,
+): HomepageMonitorCard {
+  const isInMaintenance = maintenanceMonitorIds.has(row.id);
+  const stateStatus = toMonitorStatus(row.state_status);
+  const isStale =
+    isInMaintenance || stateStatus === 'paused' || stateStatus === 'maintenance'
+      ? false
+      : row.last_checked_at === null
+        ? true
+        : now - row.last_checked_at > row.interval_sec * 2;
+
   return {
-    id: monitor.id,
-    name: monitor.name,
-    type: monitor.type,
-    group_name: monitor.group_name,
-    status: monitor.status,
-    is_stale: monitor.is_stale,
-    last_checked_at: monitor.last_checked_at,
-    heartbeat_strip: toHomepageHeartbeatStrip(monitor.heartbeats),
-    uptime_30d: monitor.uptime_30d
-      ? {
-          uptime_pct: monitor.uptime_30d.uptime_pct,
-        }
-      : null,
-    uptime_day_strip: toHomepageUptimeDayStrip(monitor.uptime_days),
+    id: row.id,
+    name: row.name,
+    type: toHomepageMonitorType(row.type),
+    group_name: row.group_name?.trim() ? row.group_name.trim() : null,
+    status: isInMaintenance ? 'maintenance' : isStale ? 'unknown' : stateStatus,
+    is_stale: isStale,
+    last_checked_at: row.last_checked_at,
+    heartbeat_strip: {
+      checked_at: [],
+      status_codes: '',
+      latency_ms: [],
+    },
+    uptime_30d: null,
+    uptime_day_strip: {
+      day_start_at: [],
+      downtime_sec: [],
+      unknown_sec: [],
+      uptime_pct_milli: [],
+    },
+  };
+}
+
+function addUptimeDay(
+  monitor: HomepageMonitorCard,
+  totals: { totalSec: number; uptimeSec: number },
+  dayStartAt: number,
+  uptime: Pick<UptimeWindowTotals, 'total_sec' | 'downtime_sec' | 'unknown_sec' | 'uptime_sec'>,
+): void {
+  monitor.uptime_day_strip.day_start_at.push(dayStartAt);
+  monitor.uptime_day_strip.downtime_sec.push(uptime.downtime_sec);
+  monitor.uptime_day_strip.unknown_sec.push(uptime.unknown_sec);
+  monitor.uptime_day_strip.uptime_pct_milli.push(
+    toUptimePctMilli(uptime.total_sec, uptime.uptime_sec),
+  );
+  totals.totalSec += uptime.total_sec;
+  totals.uptimeSec += uptime.uptime_sec;
+}
+
+async function buildHomepageMonitorData(
+  db: D1Database,
+  now: number,
+  includeHiddenMonitors: boolean,
+): Promise<{
+  monitors: HomepageMonitorCard[];
+  summary: PublicHomepageResponse['summary'];
+  overallStatus: HomepageMonitorStatus;
+  visibleMonitorIds: Set<number>;
+}> {
+  const rangeEndFullDays = utcDayStart(now);
+  const rangeEnd = now;
+  const { results } = await db
+    .prepare(
+      `
+      SELECT
+        m.id,
+        m.name,
+        m.type,
+        m.group_name,
+        m.interval_sec,
+        m.created_at,
+        s.status AS state_status,
+        s.last_checked_at
+      FROM monitors m
+      LEFT JOIN monitor_state s ON s.monitor_id = m.id
+      WHERE m.is_active = 1
+        AND ${monitorVisibilityPredicate(includeHiddenMonitors, 'm')}
+      ORDER BY
+        m.group_sort_order ASC,
+        lower(
+          CASE
+            WHEN m.group_name IS NULL OR trim(m.group_name) = '' THEN 'Ungrouped'
+            ELSE trim(m.group_name)
+          END
+        ) ASC,
+        m.sort_order ASC,
+        m.id ASC
+    `,
+    )
+    .all<HomepageMonitorRow>();
+
+  const rawMonitors = results ?? [];
+  const ids = rawMonitors.map((monitor) => monitor.id);
+  const earliestCreatedAt = rawMonitors.reduce(
+    (acc, monitor) => Math.min(acc, monitor.created_at),
+    Number.POSITIVE_INFINITY,
+  );
+  const rangeStart = Number.isFinite(earliestCreatedAt)
+    ? Math.max(rangeEnd - UPTIME_DAYS * 86400, earliestCreatedAt)
+    : rangeEnd - UPTIME_DAYS * 86400;
+
+  const maintenanceMonitorIds = await listHomepageMaintenanceMonitorIds(db, now, ids);
+
+  const summary: PublicHomepageResponse['summary'] = {
+    up: 0,
+    down: 0,
+    maintenance: 0,
+    paused: 0,
+    unknown: 0,
+  };
+
+  const monitors = new Array<HomepageMonitorCard>(rawMonitors.length);
+  const monitorIndexById = new Map<number, number>();
+  for (let index = 0; index < rawMonitors.length; index += 1) {
+    const monitor = toHomepageMonitorCard(rawMonitors[index], now, maintenanceMonitorIds);
+    monitors[index] = monitor;
+    monitorIndexById.set(monitor.id, index);
+    summary[monitor.status] += 1;
+  }
+
+  if (ids.length === 0) {
+    return {
+      monitors,
+      summary,
+      overallStatus: computeOverallStatus(summary),
+      visibleMonitorIds: new Set<number>(),
+    };
+  }
+
+  const placeholders = buildNumberedPlaceholders(ids.length);
+  const todayStartAt = utcDayStart(now);
+  const needsToday = rangeEnd > rangeEndFullDays && todayStartAt >= rangeStart;
+
+  const heartbeatRowsPromise = db
+    .prepare(
+      `
+      SELECT monitor_id, checked_at, status, latency_ms
+      FROM (
+        SELECT
+          id,
+          monitor_id,
+          checked_at,
+          status,
+          latency_ms,
+          ROW_NUMBER() OVER (
+            PARTITION BY monitor_id
+            ORDER BY checked_at DESC, id DESC
+          ) AS rn
+        FROM check_results
+        WHERE monitor_id IN (${placeholders})
+      )
+      WHERE rn <= ?${ids.length + 1}
+      ORDER BY monitor_id, checked_at DESC, id DESC
+    `,
+    )
+    .bind(...ids, HEARTBEAT_POINTS)
+    .all<HomepageHeartbeatRow>()
+    .then(({ results: rows }) => rows ?? []);
+
+  const rollupRowsPromise = db
+    .prepare(
+      `
+      SELECT monitor_id, day_start_at, total_sec, downtime_sec, unknown_sec, uptime_sec
+      FROM monitor_daily_rollups
+      WHERE monitor_id IN (${placeholders})
+        AND day_start_at >= ?${ids.length + 1}
+        AND day_start_at < ?${ids.length + 2}
+      ORDER BY monitor_id, day_start_at
+    `,
+    )
+    .bind(...ids, rangeStart, rangeEndFullDays)
+    .all<HomepageRollupRow>()
+    .then(({ results: rows }) => rows ?? []);
+
+  const todayByMonitorIdPromise: Promise<Map<number, UptimeWindowTotals>> = needsToday
+    ? computeTodayPartialUptimeBatch(
+        db,
+        rawMonitors.map((monitor) => ({
+          id: monitor.id,
+          interval_sec: monitor.interval_sec,
+          created_at: monitor.created_at,
+          last_checked_at: monitor.last_checked_at,
+        })),
+        Math.max(todayStartAt, rangeStart),
+        rangeEnd,
+      )
+    : Promise.resolve(new Map<number, UptimeWindowTotals>());
+
+  const [heartbeatRows, rollupRows, todayByMonitorId] = await Promise.all([
+    heartbeatRowsPromise,
+    rollupRowsPromise,
+    todayByMonitorIdPromise,
+  ]);
+
+  const heartbeatStatusCodes = Array.from({ length: monitors.length }, () => [] as string[]);
+  for (const row of heartbeatRows) {
+    const index = monitorIndexById.get(row.monitor_id);
+    if (index === undefined) continue;
+
+    const monitor = monitors[index];
+    monitor.heartbeat_strip.checked_at.push(row.checked_at);
+    monitor.heartbeat_strip.latency_ms.push(row.latency_ms);
+    heartbeatStatusCodes[index].push(toHeartbeatStatusCode(row.status));
+  }
+
+  const totalsByMonitor = Array.from({ length: monitors.length }, () => ({
+    totalSec: 0,
+    uptimeSec: 0,
+  }));
+  for (const row of rollupRows) {
+    const index = monitorIndexById.get(row.monitor_id);
+    if (index === undefined) continue;
+
+    addUptimeDay(monitors[index], totalsByMonitor[index], row.day_start_at, {
+      total_sec: row.total_sec ?? 0,
+      downtime_sec: row.downtime_sec ?? 0,
+      unknown_sec: row.unknown_sec ?? 0,
+      uptime_sec: row.uptime_sec ?? 0,
+    });
+  }
+
+  if (needsToday) {
+    for (const [monitorId, today] of todayByMonitorId) {
+      const index = monitorIndexById.get(monitorId);
+      if (index === undefined) continue;
+      addUptimeDay(monitors[index], totalsByMonitor[index], todayStartAt, today);
+    }
+  }
+
+  for (let index = 0; index < monitors.length; index += 1) {
+    monitors[index].heartbeat_strip.status_codes = heartbeatStatusCodes[index].join('');
+
+    const totals = totalsByMonitor[index];
+    monitors[index].uptime_30d =
+      totals.totalSec === 0
+        ? null
+        : {
+            uptime_pct: (totals.uptimeSec / totals.totalSec) * 100,
+          };
+  }
+
+  return {
+    monitors,
+    summary,
+    overallStatus: computeOverallStatus(summary),
+    visibleMonitorIds: new Set<number>(ids),
   };
 }
 
@@ -301,20 +568,13 @@ export async function computePublicHomepagePayload(
     resolvedIncidentPreview,
     maintenanceHistoryPreview,
   ] = await Promise.all([
-    buildPublicMonitorCards(db, now, { includeHiddenMonitors }),
+    buildHomepageMonitorData(db, now, includeHiddenMonitors),
     listVisibleActiveIncidents(db, includeHiddenMonitors),
     listVisibleMaintenanceWindows(db, now, includeHiddenMonitors),
     readPublicSiteSettings(db),
     findLatestVisibleResolvedIncident(db, includeHiddenMonitors),
     findLatestVisibleHistoricalMaintenanceWindow(db, now, includeHiddenMonitors),
   ]);
-
-  const monitors = new Array<PublicHomepageResponse['monitors'][number]>(monitorData.monitors.length);
-  for (let index = 0; index < monitorData.monitors.length; index += 1) {
-    const monitor = monitorData.monitors[index];
-    if (!monitor) continue;
-    monitors[index] = toHomepageMonitorCard(monitor);
-  }
 
   const activeIncidentSummaries = new Array<IncidentSummary>(activeIncidents.length);
   for (let index = 0; index < activeIncidents.length; index += 1) {
@@ -351,12 +611,12 @@ export async function computePublicHomepagePayload(
     overall_status: monitorData.overallStatus,
     banner: buildPublicStatusBanner({
       counts: monitorData.summary,
-      monitors: monitorData.monitors,
+      monitorCount: monitorData.monitors.length,
       activeIncidents,
       activeMaintenanceWindows: maintenanceWindows.active,
     }),
     summary: monitorData.summary,
-    monitors,
+    monitors: monitorData.monitors,
     active_incidents: activeIncidentSummaries,
     maintenance_windows: {
       active: activeMaintenancePreview,

--- a/apps/worker/src/public/homepage.ts
+++ b/apps/worker/src/public/homepage.ts
@@ -1,4 +1,5 @@
 import type { PublicHomepageResponse } from '../schemas/public-homepage';
+import type { PublicStatusResponse } from '../schemas/public-status';
 
 import {
   buildPublicStatusBanner,
@@ -64,6 +65,11 @@ type HomepageRollupRow = {
   uptime_sec: number;
 };
 
+type HomepageMonitorDataOptions = {
+  cardLimit?: number;
+  uptimeRatingLevel?: 1 | 2 | 3 | 4 | 5;
+};
+
 function toHeartbeatStatusCode(status: string | null | undefined): string {
   switch (status) {
     case 'up':
@@ -90,6 +96,20 @@ function toIncidentSummary(row: IncidentRow): IncidentSummary {
   };
 }
 
+function incidentSummaryFromStatusIncident(
+  incident: PublicStatusResponse['active_incidents'][number],
+): IncidentSummary {
+  return {
+    id: incident.id,
+    title: incident.title,
+    status: incident.status,
+    impact: incident.impact,
+    message: incident.message,
+    started_at: incident.started_at,
+    resolved_at: incident.resolved_at,
+  };
+}
+
 function toMaintenancePreview(
   row: MaintenanceWindowRow,
   monitorIds: number[],
@@ -101,6 +121,19 @@ function toMaintenancePreview(
     starts_at: row.starts_at,
     ends_at: row.ends_at,
     monitor_ids: monitorIds,
+  };
+}
+
+function maintenancePreviewFromStatusWindow(
+  window: PublicStatusResponse['maintenance_windows']['active'][number],
+): MaintenancePreview {
+  return {
+    id: window.id,
+    title: window.title,
+    message: window.message,
+    starts_at: window.starts_at,
+    ends_at: window.ends_at,
+    monitor_ids: window.monitor_ids,
   };
 }
 
@@ -160,11 +193,11 @@ function toHomepageMonitorType(value: string): HomepageMonitorCard['type'] {
   return value === 'tcp' ? 'tcp' : 'http';
 }
 
-function toHomepageMonitorCard(
-  row: HomepageMonitorRow,
+function computeHomepageMonitorPresentation(
+  row: Pick<HomepageMonitorRow, 'id' | 'interval_sec' | 'last_checked_at' | 'state_status'>,
   now: number,
   maintenanceMonitorIds: ReadonlySet<number>,
-): HomepageMonitorCard {
+): Pick<HomepageMonitorCard, 'status' | 'is_stale'> {
   const isInMaintenance = maintenanceMonitorIds.has(row.id);
   const stateStatus = toMonitorStatus(row.state_status);
   const isStale =
@@ -175,12 +208,25 @@ function toHomepageMonitorCard(
         : now - row.last_checked_at > row.interval_sec * 2;
 
   return {
+    status: isInMaintenance ? 'maintenance' : isStale ? 'unknown' : stateStatus,
+    is_stale: isStale,
+  };
+}
+
+function toHomepageMonitorCard(
+  row: HomepageMonitorRow,
+  now: number,
+  maintenanceMonitorIds: ReadonlySet<number>,
+): HomepageMonitorCard {
+  const presentation = computeHomepageMonitorPresentation(row, now, maintenanceMonitorIds);
+
+  return {
     id: row.id,
     name: row.name,
     type: toHomepageMonitorType(row.type),
     group_name: row.group_name?.trim() ? row.group_name.trim() : null,
-    status: isInMaintenance ? 'maintenance' : isStale ? 'unknown' : stateStatus,
-    is_stale: isStale,
+    status: presentation.status,
+    is_stale: presentation.is_stale,
     last_checked_at: row.last_checked_at,
     heartbeat_strip: {
       checked_at: [],
@@ -213,21 +259,14 @@ function addUptimeDay(
   totals.uptimeSec += uptime.uptime_sec;
 }
 
-async function buildHomepageMonitorData(
+async function listHomepageMonitorRows(
   db: D1Database,
-  now: number,
   includeHiddenMonitors: boolean,
-): Promise<{
-  monitors: HomepageMonitorCard[];
-  summary: PublicHomepageResponse['summary'];
-  overallStatus: HomepageMonitorStatus;
-  uptimeRatingLevel: 1 | 2 | 3 | 4 | 5;
-}> {
-  const rangeEndFullDays = utcDayStart(now);
-  const rangeEnd = now;
-  const { results } = await db
-    .prepare(
-      `
+  limit?: number,
+): Promise<HomepageMonitorRow[]> {
+  const limitClause = limit === undefined ? '' : '\n      LIMIT ?1';
+  const stmt = db.prepare(
+    `
       SELECT
         m.id,
         m.name,
@@ -250,58 +289,164 @@ async function buildHomepageMonitorData(
           END
         ) ASC,
         m.sort_order ASC,
-        m.id ASC
+        m.id ASC${limitClause}
+    `,
+  );
+
+  const result =
+    limit === undefined
+      ? await stmt.all<HomepageMonitorRow>()
+      : await stmt.bind(limit).all<HomepageMonitorRow>();
+
+  return result.results ?? [];
+}
+
+async function readHomepageMonitorSummary(
+  db: D1Database,
+  now: number,
+  includeHiddenMonitors: boolean,
+): Promise<{
+  monitorCountTotal: number;
+  summary: PublicHomepageResponse['summary'];
+  overallStatus: HomepageMonitorStatus;
+}> {
+  const row = await db
+    .prepare(
+      `
+      WITH active_maintenance AS (
+        SELECT DISTINCT mwm.monitor_id
+        FROM maintenance_window_monitors mwm
+        JOIN maintenance_windows mw ON mw.id = mwm.maintenance_window_id
+        WHERE mw.starts_at <= ?1 AND mw.ends_at > ?1
+      ),
+      visible_monitors AS (
+        SELECT
+          m.interval_sec,
+          COALESCE(s.status, 'unknown') AS normalized_status,
+          s.last_checked_at,
+          CASE WHEN am.monitor_id IS NULL THEN 0 ELSE 1 END AS in_maintenance
+        FROM monitors m
+        LEFT JOIN monitor_state s ON s.monitor_id = m.id
+        LEFT JOIN active_maintenance am ON am.monitor_id = m.id
+        WHERE m.is_active = 1
+          AND ${monitorVisibilityPredicate(includeHiddenMonitors, 'm')}
+      )
+      SELECT
+        COUNT(*) AS monitor_count_total,
+        SUM(
+          CASE
+            WHEN in_maintenance = 1 OR normalized_status = 'maintenance' THEN 1
+            ELSE 0
+          END
+        ) AS maintenance,
+        SUM(
+          CASE
+            WHEN in_maintenance = 0 AND normalized_status = 'paused' THEN 1
+            ELSE 0
+          END
+        ) AS paused,
+        SUM(
+          CASE
+            WHEN
+              in_maintenance = 0
+              AND normalized_status = 'down'
+              AND last_checked_at IS NOT NULL
+              AND ?1 - last_checked_at <= interval_sec * 2
+            THEN 1
+            ELSE 0
+          END
+        ) AS down,
+        SUM(
+          CASE
+            WHEN
+              in_maintenance = 0
+              AND normalized_status = 'up'
+              AND last_checked_at IS NOT NULL
+              AND ?1 - last_checked_at <= interval_sec * 2
+            THEN 1
+            ELSE 0
+          END
+        ) AS up,
+        SUM(
+          CASE
+            WHEN
+              in_maintenance = 1
+              OR normalized_status = 'maintenance'
+              OR (in_maintenance = 0 AND normalized_status = 'paused')
+              OR (
+                in_maintenance = 0
+                AND normalized_status = 'down'
+                AND last_checked_at IS NOT NULL
+                AND ?1 - last_checked_at <= interval_sec * 2
+              )
+              OR (
+                in_maintenance = 0
+                AND normalized_status = 'up'
+                AND last_checked_at IS NOT NULL
+                AND ?1 - last_checked_at <= interval_sec * 2
+              )
+            THEN 0
+            ELSE 1
+          END
+        ) AS unknown
+      FROM visible_monitors
     `,
     )
-    .all<HomepageMonitorRow>();
+    .bind(now)
+    .first<{
+      monitor_count_total: number | null;
+      up: number | null;
+      down: number | null;
+      maintenance: number | null;
+      paused: number | null;
+      unknown: number | null;
+    }>();
 
-  const rawMonitors = results ?? [];
-  const ids = rawMonitors.map((monitor) => monitor.id);
-  const earliestCreatedAt = rawMonitors.reduce(
+  const summary: PublicHomepageResponse['summary'] = {
+    up: row?.up ?? 0,
+    down: row?.down ?? 0,
+    maintenance: row?.maintenance ?? 0,
+    paused: row?.paused ?? 0,
+    unknown: row?.unknown ?? 0,
+  };
+
+  return {
+    monitorCountTotal: row?.monitor_count_total ?? 0,
+    summary,
+    overallStatus: computeOverallStatus(summary),
+  };
+}
+
+async function buildHomepageMonitorCardsFromRows(
+  db: D1Database,
+  now: number,
+  rows: HomepageMonitorRow[],
+  maintenanceMonitorIds: ReadonlySet<number>,
+): Promise<HomepageMonitorCard[]> {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const earliestCreatedAt = rows.reduce(
     (acc, monitor) => Math.min(acc, monitor.created_at),
     Number.POSITIVE_INFINITY,
   );
+  const rangeEndFullDays = utcDayStart(now);
+  const rangeEnd = now;
   const rangeStart = Number.isFinite(earliestCreatedAt)
     ? Math.max(rangeEnd - UPTIME_DAYS * 86400, earliestCreatedAt)
     : rangeEnd - UPTIME_DAYS * 86400;
-
-  const [maintenanceMonitorIds, uptimeRatingLevel] = await Promise.all([
-    listHomepageMaintenanceMonitorIds(db, now, ids),
-    readHomepageUptimeRatingLevel(db),
-  ]);
-
-  const summary: PublicHomepageResponse['summary'] = {
-    up: 0,
-    down: 0,
-    maintenance: 0,
-    paused: 0,
-    unknown: 0,
-  };
-
-  const monitors = new Array<HomepageMonitorCard>(rawMonitors.length);
-  const monitorIndexById = new Map<number, number>();
-  for (let index = 0; index < rawMonitors.length; index += 1) {
-    const row = rawMonitors[index];
-    if (!row) continue;
-
-    const monitor = toHomepageMonitorCard(row, now, maintenanceMonitorIds);
-    monitors[index] = monitor;
-    monitorIndexById.set(monitor.id, index);
-    summary[monitor.status] += 1;
-  }
-
-  if (ids.length === 0) {
-    return {
-      monitors,
-      summary,
-      overallStatus: computeOverallStatus(summary),
-      uptimeRatingLevel,
-    };
-  }
-
-  const placeholders = buildNumberedPlaceholders(ids.length);
+  const selectedIds = rows.map((monitor) => monitor.id);
+  const placeholders = buildNumberedPlaceholders(selectedIds.length);
   const todayStartAt = utcDayStart(now);
   const needsToday = rangeEnd > rangeEndFullDays && todayStartAt >= rangeStart;
+  const monitors = rows.map((row) => toHomepageMonitorCard(row, now, maintenanceMonitorIds));
+  const monitorIndexById = new Map<number, number>();
+  for (let index = 0; index < monitors.length; index += 1) {
+    const monitor = monitors[index];
+    if (!monitor) continue;
+    monitorIndexById.set(monitor.id, index);
+  }
 
   const heartbeatRowsPromise = db
     .prepare(
@@ -321,13 +466,13 @@ async function buildHomepageMonitorData(
         FROM check_results
         WHERE monitor_id IN (${placeholders})
       )
-      WHERE rn <= ?${ids.length + 1}
+      WHERE rn <= ?${selectedIds.length + 1}
       ORDER BY monitor_id, checked_at DESC, id DESC
     `,
     )
-    .bind(...ids, HEARTBEAT_POINTS)
+    .bind(...selectedIds, HEARTBEAT_POINTS)
     .all<HomepageHeartbeatRow>()
-    .then(({ results: rows }) => rows ?? []);
+    .then(({ results }) => results ?? []);
 
   const rollupRowsPromise = db
     .prepare(
@@ -335,19 +480,19 @@ async function buildHomepageMonitorData(
       SELECT monitor_id, day_start_at, total_sec, downtime_sec, unknown_sec, uptime_sec
       FROM monitor_daily_rollups
       WHERE monitor_id IN (${placeholders})
-        AND day_start_at >= ?${ids.length + 1}
-        AND day_start_at < ?${ids.length + 2}
+        AND day_start_at >= ?${selectedIds.length + 1}
+        AND day_start_at < ?${selectedIds.length + 2}
       ORDER BY monitor_id, day_start_at
     `,
     )
-    .bind(...ids, rangeStart, rangeEndFullDays)
+    .bind(...selectedIds, rangeStart, rangeEndFullDays)
     .all<HomepageRollupRow>()
-    .then(({ results: rows }) => rows ?? []);
+    .then(({ results }) => results ?? []);
 
   const todayByMonitorIdPromise: Promise<Map<number, UptimeWindowTotals>> = needsToday
     ? computeTodayPartialUptimeBatch(
         db,
-        rawMonitors.map((monitor) => ({
+        rows.map((monitor) => ({
           id: monitor.id,
           interval_sec: monitor.interval_sec,
           created_at: monitor.created_at,
@@ -425,8 +570,70 @@ async function buildHomepageMonitorData(
           };
   }
 
+  return monitors;
+}
+
+async function buildHomepageMonitorData(
+  db: D1Database,
+  now: number,
+  includeHiddenMonitors: boolean,
+  opts: HomepageMonitorDataOptions = {},
+): Promise<{
+  monitors: HomepageMonitorCard[];
+  monitorCountTotal: number;
+  summary: PublicHomepageResponse['summary'];
+  overallStatus: HomepageMonitorStatus;
+  uptimeRatingLevel: 1 | 2 | 3 | 4 | 5;
+}> {
+  const rawMonitors = await listHomepageMonitorRows(db, includeHiddenMonitors);
+  const monitorCountTotal = rawMonitors.length;
+  const ids = rawMonitors.map((monitor) => monitor.id);
+  const selectedRows =
+    opts.cardLimit === undefined ? rawMonitors : rawMonitors.slice(0, Math.max(0, opts.cardLimit));
+
+  const [maintenanceMonitorIds, uptimeRatingLevel] = await Promise.all([
+    listHomepageMaintenanceMonitorIds(db, now, ids),
+    opts.uptimeRatingLevel === undefined
+      ? readHomepageUptimeRatingLevel(db)
+      : Promise.resolve(opts.uptimeRatingLevel),
+  ]);
+
+  const summary: PublicHomepageResponse['summary'] = {
+    up: 0,
+    down: 0,
+    maintenance: 0,
+    paused: 0,
+    unknown: 0,
+  };
+
+  for (let index = 0; index < rawMonitors.length; index += 1) {
+    const row = rawMonitors[index];
+    if (!row) continue;
+
+    const presentation = computeHomepageMonitorPresentation(row, now, maintenanceMonitorIds);
+    summary[presentation.status] += 1;
+  }
+
+  if (selectedRows.length === 0) {
+    return {
+      monitors: [],
+      monitorCountTotal,
+      summary,
+      overallStatus: computeOverallStatus(summary),
+      uptimeRatingLevel,
+    };
+  }
+
+  const monitors = await buildHomepageMonitorCardsFromRows(
+    db,
+    now,
+    selectedRows,
+    maintenanceMonitorIds,
+  );
+
   return {
     monitors,
+    monitorCountTotal,
     summary,
     overallStatus: computeOverallStatus(summary),
     uptimeRatingLevel,
@@ -580,26 +787,106 @@ async function findLatestVisibleHistoricalMaintenanceWindow(
   }
 }
 
+export async function readHomepageHistoryPreviews(
+  db: D1Database,
+  now: number,
+): Promise<{
+  resolvedIncidentPreview: IncidentSummary | null;
+  maintenanceHistoryPreview: MaintenancePreview | null;
+}> {
+  const includeHiddenMonitors = false;
+  const [resolvedIncidentPreview, maintenanceHistoryPreview] = await Promise.all([
+    findLatestVisibleResolvedIncident(db, includeHiddenMonitors),
+    findLatestVisibleHistoricalMaintenanceWindow(db, now, includeHiddenMonitors),
+  ]);
+
+  return {
+    resolvedIncidentPreview: resolvedIncidentPreview
+      ? toIncidentSummary(resolvedIncidentPreview)
+      : null,
+    maintenanceHistoryPreview: maintenanceHistoryPreview
+      ? toMaintenancePreview(maintenanceHistoryPreview.row, maintenanceHistoryPreview.monitorIds)
+      : null,
+  };
+}
+
+export function homepageFromStatusPayload(
+  status: PublicStatusResponse,
+  previews: {
+    resolvedIncidentPreview?: IncidentSummary | null;
+    maintenanceHistoryPreview?: MaintenancePreview | null;
+  } = {},
+): PublicHomepageResponse {
+  return {
+    generated_at: status.generated_at,
+    bootstrap_mode: 'full',
+    monitor_count_total: status.monitors.length,
+    site_title: status.site_title,
+    site_description: status.site_description,
+    site_locale: status.site_locale,
+    site_timezone: status.site_timezone,
+    uptime_rating_level: status.uptime_rating_level,
+    overall_status: status.overall_status,
+    banner: status.banner,
+    summary: status.summary,
+    monitors: status.monitors.map((monitor) => ({
+      id: monitor.id,
+      name: monitor.name,
+      type: monitor.type,
+      group_name: monitor.group_name,
+      status: monitor.status,
+      is_stale: monitor.is_stale,
+      last_checked_at: monitor.last_checked_at,
+      heartbeat_strip: {
+        checked_at: monitor.heartbeats.map((heartbeat) => heartbeat.checked_at),
+        status_codes: monitor.heartbeats
+          .map((heartbeat) => toHeartbeatStatusCode(heartbeat.status))
+          .join(''),
+        latency_ms: monitor.heartbeats.map((heartbeat) => heartbeat.latency_ms),
+      },
+      uptime_30d: monitor.uptime_30d ? { uptime_pct: monitor.uptime_30d.uptime_pct } : null,
+      uptime_day_strip: {
+        day_start_at: monitor.uptime_days.map((day) => day.day_start_at),
+        downtime_sec: monitor.uptime_days.map((day) => day.downtime_sec),
+        unknown_sec: monitor.uptime_days.map((day) => day.unknown_sec),
+        uptime_pct_milli: monitor.uptime_days.map((day) =>
+          day.uptime_pct === null ? null : Math.round(day.uptime_pct * 1000),
+        ),
+      },
+    })),
+    active_incidents: status.active_incidents.map(incidentSummaryFromStatusIncident),
+    maintenance_windows: {
+      active: status.maintenance_windows.active.map(maintenancePreviewFromStatusWindow),
+      upcoming: status.maintenance_windows.upcoming.map(maintenancePreviewFromStatusWindow),
+    },
+    resolved_incident_preview: previews.resolvedIncidentPreview ?? null,
+    maintenance_history_preview: previews.maintenanceHistoryPreview ?? null,
+  };
+}
+
 export async function computePublicHomepagePayload(
   db: D1Database,
   now: number,
 ): Promise<PublicHomepageResponse> {
   const includeHiddenMonitors = false;
+  const settingsPromise = readPublicSiteSettings(db);
 
   const [
+    settings,
     monitorData,
     activeIncidents,
     maintenanceWindows,
-    settings,
-    resolvedIncidentPreview,
-    maintenanceHistoryPreview,
+    historyPreviews,
   ] = await Promise.all([
-    buildHomepageMonitorData(db, now, includeHiddenMonitors),
+    settingsPromise,
+    settingsPromise.then((settings) =>
+      buildHomepageMonitorData(db, now, includeHiddenMonitors, {
+        uptimeRatingLevel: settings.uptime_rating_level,
+      }),
+    ),
     listVisibleActiveIncidents(db, includeHiddenMonitors),
     listVisibleMaintenanceWindows(db, now, includeHiddenMonitors),
-    readPublicSiteSettings(db),
-    findLatestVisibleResolvedIncident(db, includeHiddenMonitors),
-    findLatestVisibleHistoricalMaintenanceWindow(db, now, includeHiddenMonitors),
+    readHomepageHistoryPreviews(db, now),
   ]);
 
   const activeIncidentSummaries = new Array<IncidentSummary>(activeIncidents.length);
@@ -628,7 +915,7 @@ export async function computePublicHomepagePayload(
   return {
     generated_at: now,
     bootstrap_mode: 'full',
-    monitor_count_total: monitorData.monitors.length,
+    monitor_count_total: monitorData.monitorCountTotal,
     site_title: settings.site_title,
     site_description: settings.site_description,
     site_locale: settings.site_locale,
@@ -648,11 +935,67 @@ export async function computePublicHomepagePayload(
       active: activeMaintenancePreview,
       upcoming: upcomingMaintenancePreview,
     },
-    resolved_incident_preview: resolvedIncidentPreview
-      ? toIncidentSummary(resolvedIncidentPreview)
-      : null,
-    maintenance_history_preview: maintenanceHistoryPreview
-      ? toMaintenancePreview(maintenanceHistoryPreview.row, maintenanceHistoryPreview.monitorIds)
-      : null,
+    resolved_incident_preview: historyPreviews.resolvedIncidentPreview,
+    maintenance_history_preview: historyPreviews.maintenanceHistoryPreview,
+  };
+}
+
+export async function computePublicHomepageArtifactPayload(
+  db: D1Database,
+  now: number,
+): Promise<PublicHomepageResponse> {
+  const includeHiddenMonitors = false;
+  const settingsPromise = readPublicSiteSettings(db);
+  const bootstrapRowsPromise = listHomepageMonitorRows(db, includeHiddenMonitors, 12);
+  const [settings, summaryData, bootstrapRows, activeIncidents, maintenanceWindows, historyPreviews] =
+    await Promise.all([
+      settingsPromise,
+      readHomepageMonitorSummary(db, now, includeHiddenMonitors),
+      bootstrapRowsPromise,
+      listVisibleActiveIncidents(db, includeHiddenMonitors),
+      listVisibleMaintenanceWindows(db, now, includeHiddenMonitors),
+      readHomepageHistoryPreviews(db, now),
+    ]);
+  const maintenanceMonitorIds = await listHomepageMaintenanceMonitorIds(
+    db,
+    now,
+    bootstrapRows.map((row) => row.id),
+  );
+  const monitors = await buildHomepageMonitorCardsFromRows(
+    db,
+    now,
+    bootstrapRows,
+    maintenanceMonitorIds,
+  );
+
+  return {
+    generated_at: now,
+    bootstrap_mode: summaryData.monitorCountTotal > monitors.length ? 'partial' : 'full',
+    monitor_count_total: summaryData.monitorCountTotal,
+    site_title: settings.site_title,
+    site_description: settings.site_description,
+    site_locale: settings.site_locale,
+    site_timezone: settings.site_timezone,
+    uptime_rating_level: settings.uptime_rating_level,
+    overall_status: summaryData.overallStatus,
+    banner: buildPublicStatusBanner({
+      counts: summaryData.summary,
+      monitorCount: summaryData.monitorCountTotal,
+      activeIncidents,
+      activeMaintenanceWindows: maintenanceWindows.active,
+    }),
+    summary: summaryData.summary,
+    monitors,
+    active_incidents: activeIncidents.map(({ row }) => toIncidentSummary(row)),
+    maintenance_windows: {
+      active: maintenanceWindows.active.map(({ row, monitorIds }) =>
+        toMaintenancePreview(row, monitorIds),
+      ),
+      upcoming: maintenanceWindows.upcoming.map(({ row, monitorIds }) =>
+        toMaintenancePreview(row, monitorIds),
+      ),
+    },
+    resolved_incident_preview: historyPreviews.resolvedIncidentPreview,
+    maintenance_history_preview: historyPreviews.maintenanceHistoryPreview,
   };
 }

--- a/apps/worker/src/public/homepage.ts
+++ b/apps/worker/src/public/homepage.ts
@@ -5,16 +5,14 @@ import {
   computeTodayPartialUptimeBatch,
   listIncidentMonitorIdsByIncidentId,
   listMaintenanceWindowMonitorIdsByWindowId,
+  listVisibleActiveIncidents,
+  listVisibleMaintenanceWindows,
   readPublicSiteSettings,
-  STATUS_ACTIVE_INCIDENT_LIMIT,
-  STATUS_ACTIVE_MAINTENANCE_LIMIT,
-  STATUS_UPCOMING_MAINTENANCE_LIMIT,
   toIncidentImpact,
   toIncidentStatus,
   toMonitorStatus,
+  toUptimePct,
   utcDayStart,
-  type FilteredIncidentEntry,
-  type FilteredMaintenanceWindowEntry,
   type IncidentRow,
   type MaintenanceWindowRow,
   type UptimeWindowTotals,
@@ -24,6 +22,7 @@ import {
   chunkPositiveIntegerIds,
   filterStatusPageScopedMonitorIds,
   incidentStatusPageVisibilityPredicate,
+  listStatusPageVisibleMonitorIds,
   maintenanceWindowStatusPageVisibilityPredicate,
   monitorVisibilityPredicate,
   shouldIncludeStatusPageScopedItem,
@@ -79,13 +78,6 @@ function toHeartbeatStatusCode(status: string | null | undefined): string {
   }
 }
 
-function toUptimePctMilli(totalSec: number, uptimeSec: number): number | null {
-  if (!Number.isFinite(totalSec) || totalSec <= 0) return null;
-  if (!Number.isFinite(uptimeSec)) return null;
-
-  return Math.max(0, Math.min(100_000, Math.round((uptimeSec / totalSec) * 100_000)));
-}
-
 function toIncidentSummary(row: IncidentRow): IncidentSummary {
   return {
     id: row.id,
@@ -110,6 +102,20 @@ function toMaintenancePreview(
     ends_at: row.ends_at,
     monitor_ids: monitorIds,
   };
+}
+
+async function readHomepageUptimeRatingLevel(db: D1Database): Promise<1 | 2 | 3 | 4 | 5> {
+  const row = await db
+    .prepare('SELECT value FROM settings WHERE key = ?1')
+    .bind('uptime_rating_level')
+    .first<{ value: string }>();
+
+  const raw = row?.value ?? '';
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 5) {
+    return parsed as 1 | 2 | 3 | 4 | 5;
+  }
+  return 3;
 }
 
 async function listHomepageMaintenanceMonitorIds(
@@ -195,13 +201,13 @@ function addUptimeDay(
   monitor: HomepageMonitorCard,
   totals: { totalSec: number; uptimeSec: number },
   dayStartAt: number,
-  uptime: Pick<UptimeWindowTotals, 'total_sec' | 'downtime_sec' | 'unknown_sec' | 'uptime_sec'>,
+  uptime: UptimeWindowTotals,
 ): void {
   monitor.uptime_day_strip.day_start_at.push(dayStartAt);
   monitor.uptime_day_strip.downtime_sec.push(uptime.downtime_sec);
   monitor.uptime_day_strip.unknown_sec.push(uptime.unknown_sec);
   monitor.uptime_day_strip.uptime_pct_milli.push(
-    toUptimePctMilli(uptime.total_sec, uptime.uptime_sec),
+    uptime.uptime_pct === null ? null : Math.round(uptime.uptime_pct * 1000),
   );
   totals.totalSec += uptime.total_sec;
   totals.uptimeSec += uptime.uptime_sec;
@@ -215,7 +221,7 @@ async function buildHomepageMonitorData(
   monitors: HomepageMonitorCard[];
   summary: PublicHomepageResponse['summary'];
   overallStatus: HomepageMonitorStatus;
-  visibleMonitorIds: Set<number>;
+  uptimeRatingLevel: 1 | 2 | 3 | 4 | 5;
 }> {
   const rangeEndFullDays = utcDayStart(now);
   const rangeEnd = now;
@@ -259,7 +265,10 @@ async function buildHomepageMonitorData(
     ? Math.max(rangeEnd - UPTIME_DAYS * 86400, earliestCreatedAt)
     : rangeEnd - UPTIME_DAYS * 86400;
 
-  const maintenanceMonitorIds = await listHomepageMaintenanceMonitorIds(db, now, ids);
+  const [maintenanceMonitorIds, uptimeRatingLevel] = await Promise.all([
+    listHomepageMaintenanceMonitorIds(db, now, ids),
+    readHomepageUptimeRatingLevel(db),
+  ]);
 
   const summary: PublicHomepageResponse['summary'] = {
     up: 0,
@@ -283,7 +292,7 @@ async function buildHomepageMonitorData(
       monitors,
       summary,
       overallStatus: computeOverallStatus(summary),
-      visibleMonitorIds: new Set<number>(),
+      uptimeRatingLevel,
     };
   }
 
@@ -403,7 +412,7 @@ async function buildHomepageMonitorData(
     monitors,
     summary,
     overallStatus: computeOverallStatus(summary),
-    visibleMonitorIds: new Set<number>(ids),
+    uptimeRatingLevel,
   };
 }
 

--- a/apps/worker/src/public/homepage.ts
+++ b/apps/worker/src/public/homepage.ts
@@ -26,6 +26,22 @@ const PREVIEW_BATCH_LIMIT = 50;
 type IncidentSummary = PublicHomepageResponse['active_incidents'][number];
 type MaintenancePreview = NonNullable<PublicHomepageResponse['maintenance_history_preview']>;
 
+function toHeartbeatStatusCode(
+  status: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number]['heartbeats'][number]['status'],
+): string {
+  switch (status) {
+    case 'up':
+      return 'u';
+    case 'down':
+      return 'd';
+    case 'maintenance':
+      return 'm';
+    case 'unknown':
+    default:
+      return 'x';
+  }
+}
+
 function toIncidentSummary(row: IncidentRow): IncidentSummary {
   return {
     id: row.id,
@@ -52,6 +68,57 @@ function toMaintenancePreview(
   };
 }
 
+function toHomepageHeartbeatStrip(
+  heartbeats: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number]['heartbeats'],
+): PublicHomepageResponse['monitors'][number]['heartbeat_strip'] {
+  const count = heartbeats.length;
+  const checkedAt = new Array<number>(count);
+  const latencyMs = new Array<number | null>(count);
+  let statusCodes = '';
+
+  for (let index = 0; index < count; index += 1) {
+    const heartbeat = heartbeats[index];
+    if (!heartbeat) continue;
+
+    checkedAt[index] = heartbeat.checked_at;
+    latencyMs[index] = heartbeat.latency_ms;
+    statusCodes += toHeartbeatStatusCode(heartbeat.status);
+  }
+
+  return {
+    checked_at: checkedAt,
+    status_codes: statusCodes,
+    latency_ms: latencyMs,
+  };
+}
+
+function toHomepageUptimeDayStrip(
+  days: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number]['uptime_days'],
+): PublicHomepageResponse['monitors'][number]['uptime_day_strip'] {
+  const count = days.length;
+  const dayStartAt = new Array<number>(count);
+  const downtimeSec = new Array<number>(count);
+  const unknownSec = new Array<number>(count);
+  const uptimePctMilli = new Array<number | null>(count);
+
+  for (let index = 0; index < count; index += 1) {
+    const day = days[index];
+    if (!day) continue;
+
+    dayStartAt[index] = day.day_start_at;
+    downtimeSec[index] = day.downtime_sec;
+    unknownSec[index] = day.unknown_sec;
+    uptimePctMilli[index] = day.uptime_pct === null ? null : Math.round(day.uptime_pct * 1000);
+  }
+
+  return {
+    day_start_at: dayStartAt,
+    downtime_sec: downtimeSec,
+    unknown_sec: unknownSec,
+    uptime_pct_milli: uptimePctMilli,
+  };
+}
+
 function toHomepageMonitorCard(
   monitor: Awaited<ReturnType<typeof buildPublicMonitorCards>>['monitors'][number],
 ): PublicHomepageResponse['monitors'][number] {
@@ -63,18 +130,13 @@ function toHomepageMonitorCard(
     status: monitor.status,
     is_stale: monitor.is_stale,
     last_checked_at: monitor.last_checked_at,
-    heartbeats: monitor.heartbeats,
+    heartbeat_strip: toHomepageHeartbeatStrip(monitor.heartbeats),
     uptime_30d: monitor.uptime_30d
       ? {
           uptime_pct: monitor.uptime_30d.uptime_pct,
         }
       : null,
-    uptime_days: monitor.uptime_days.map((day) => ({
-      day_start_at: day.day_start_at,
-      downtime_sec: day.downtime_sec,
-      unknown_sec: day.unknown_sec,
-      uptime_pct: day.uptime_pct,
-    })),
+    uptime_day_strip: toHomepageUptimeDayStrip(monitor.uptime_days),
   };
 }
 
@@ -247,8 +309,40 @@ export async function computePublicHomepagePayload(
     findLatestVisibleHistoricalMaintenanceWindow(db, now, includeHiddenMonitors),
   ]);
 
+  const monitors = new Array<PublicHomepageResponse['monitors'][number]>(monitorData.monitors.length);
+  for (let index = 0; index < monitorData.monitors.length; index += 1) {
+    const monitor = monitorData.monitors[index];
+    if (!monitor) continue;
+    monitors[index] = toHomepageMonitorCard(monitor);
+  }
+
+  const activeIncidentSummaries = new Array<IncidentSummary>(activeIncidents.length);
+  for (let index = 0; index < activeIncidents.length; index += 1) {
+    const incident = activeIncidents[index];
+    if (!incident) continue;
+    activeIncidentSummaries[index] = toIncidentSummary(incident.row);
+  }
+
+  const activeMaintenancePreview = new Array<MaintenancePreview>(maintenanceWindows.active.length);
+  for (let index = 0; index < maintenanceWindows.active.length; index += 1) {
+    const window = maintenanceWindows.active[index];
+    if (!window) continue;
+    activeMaintenancePreview[index] = toMaintenancePreview(window.row, window.monitorIds);
+  }
+
+  const upcomingMaintenancePreview = new Array<MaintenancePreview>(
+    maintenanceWindows.upcoming.length,
+  );
+  for (let index = 0; index < maintenanceWindows.upcoming.length; index += 1) {
+    const window = maintenanceWindows.upcoming[index];
+    if (!window) continue;
+    upcomingMaintenancePreview[index] = toMaintenancePreview(window.row, window.monitorIds);
+  }
+
   return {
     generated_at: now,
+    bootstrap_mode: 'full',
+    monitor_count_total: monitorData.monitors.length,
     site_title: settings.site_title,
     site_description: settings.site_description,
     site_locale: settings.site_locale,
@@ -262,15 +356,11 @@ export async function computePublicHomepagePayload(
       activeMaintenanceWindows: maintenanceWindows.active,
     }),
     summary: monitorData.summary,
-    monitors: monitorData.monitors.map(toHomepageMonitorCard),
-    active_incidents: activeIncidents.map(({ row }) => toIncidentSummary(row)),
+    monitors,
+    active_incidents: activeIncidentSummaries,
     maintenance_windows: {
-      active: maintenanceWindows.active.map(({ row, monitorIds }) =>
-        toMaintenancePreview(row, monitorIds),
-      ),
-      upcoming: maintenanceWindows.upcoming.map(({ row, monitorIds }) =>
-        toMaintenancePreview(row, monitorIds),
-      ),
+      active: activeMaintenancePreview,
+      upcoming: upcomingMaintenancePreview,
     },
     resolved_incident_preview: resolvedIncidentPreview
       ? toIncidentSummary(resolvedIncidentPreview)

--- a/apps/worker/src/public/homepage.ts
+++ b/apps/worker/src/public/homepage.ts
@@ -281,7 +281,10 @@ async function buildHomepageMonitorData(
   const monitors = new Array<HomepageMonitorCard>(rawMonitors.length);
   const monitorIndexById = new Map<number, number>();
   for (let index = 0; index < rawMonitors.length; index += 1) {
-    const monitor = toHomepageMonitorCard(rawMonitors[index], now, maintenanceMonitorIds);
+    const row = rawMonitors[index];
+    if (!row) continue;
+
+    const monitor = toHomepageMonitorCard(row, now, maintenanceMonitorIds);
     monitors[index] = monitor;
     monitorIndexById.set(monitor.id, index);
     summary[monitor.status] += 1;
@@ -367,9 +370,12 @@ async function buildHomepageMonitorData(
     if (index === undefined) continue;
 
     const monitor = monitors[index];
+    const statusCodes = heartbeatStatusCodes[index];
+    if (!monitor || !statusCodes) continue;
+
     monitor.heartbeat_strip.checked_at.push(row.checked_at);
     monitor.heartbeat_strip.latency_ms.push(row.latency_ms);
-    heartbeatStatusCodes[index].push(toHeartbeatStatusCode(row.status));
+    statusCodes.push(toHeartbeatStatusCode(row.status));
   }
 
   const totalsByMonitor = Array.from({ length: monitors.length }, () => ({
@@ -380,11 +386,16 @@ async function buildHomepageMonitorData(
     const index = monitorIndexById.get(row.monitor_id);
     if (index === undefined) continue;
 
-    addUptimeDay(monitors[index], totalsByMonitor[index], row.day_start_at, {
+    const monitor = monitors[index];
+    const totals = totalsByMonitor[index];
+    if (!monitor || !totals) continue;
+
+    addUptimeDay(monitor, totals, row.day_start_at, {
       total_sec: row.total_sec ?? 0,
       downtime_sec: row.downtime_sec ?? 0,
       unknown_sec: row.unknown_sec ?? 0,
       uptime_sec: row.uptime_sec ?? 0,
+      uptime_pct: toUptimePct(row.total_sec ?? 0, row.uptime_sec ?? 0),
     });
   }
 
@@ -392,15 +403,21 @@ async function buildHomepageMonitorData(
     for (const [monitorId, today] of todayByMonitorId) {
       const index = monitorIndexById.get(monitorId);
       if (index === undefined) continue;
-      addUptimeDay(monitors[index], totalsByMonitor[index], todayStartAt, today);
+      const monitor = monitors[index];
+      const totals = totalsByMonitor[index];
+      if (!monitor || !totals) continue;
+      addUptimeDay(monitor, totals, todayStartAt, today);
     }
   }
 
   for (let index = 0; index < monitors.length; index += 1) {
-    monitors[index].heartbeat_strip.status_codes = heartbeatStatusCodes[index].join('');
-
+    const monitor = monitors[index];
+    const statusCodes = heartbeatStatusCodes[index];
     const totals = totalsByMonitor[index];
-    monitors[index].uptime_30d =
+    if (!monitor || !statusCodes || !totals) continue;
+
+    monitor.heartbeat_strip.status_codes = statusCodes.join('');
+    monitor.uptime_30d =
       totals.totalSec === 0
         ? null
         : {

--- a/apps/worker/src/public/status.ts
+++ b/apps/worker/src/public/status.ts
@@ -40,7 +40,7 @@ export async function computePublicStatusPayload(
     overall_status: monitorData.overallStatus,
     banner: buildPublicStatusBanner({
       counts: monitorData.summary,
-      monitors: monitorData.monitors,
+      monitorCount: monitorData.monitors.length,
       activeIncidents,
       activeMaintenanceWindows: maintenanceWindows.active,
     }),

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -5,6 +5,10 @@ import { getDb, monitors } from '@uptimer/db';
 
 import type { Env } from '../env';
 import { hasValidAdminTokenRequest } from '../middleware/auth';
+import {
+  homepageFromStatusPayload,
+  readHomepageHistoryPreviews,
+} from '../public/homepage';
 import { computePublicStatusPayload } from '../public/status';
 import {
   buildNumberedPlaceholders,
@@ -22,8 +26,8 @@ import {
   readHomepageSnapshotArtifactJson,
   readHomepageSnapshotJson,
   readStatusSnapshot,
+  readStaleHomepageSnapshot,
   readStaleHomepageSnapshotArtifactJson,
-  readStaleHomepageSnapshotJson,
   toSnapshotPayload,
   writeStatusSnapshot,
 } from '../snapshots';
@@ -539,41 +543,85 @@ publicRoutes.get('/homepage', async (c) => {
   const now = Math.floor(Date.now() / 1000);
   const snapshot = await readHomepageSnapshotJson(c.env.DB, now);
   if (snapshot) {
-    const res = new Response(snapshot.bodyJson, {
-      headers: { 'Content-Type': 'application/json; charset=utf-8' },
-    });
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
     return res;
   }
 
-  const stale = await readStaleHomepageSnapshotJson(c.env.DB, now);
-  if (stale) {
-    const res = new Response(stale.bodyJson, {
-      headers: { 'Content-Type': 'application/json; charset=utf-8' },
-    });
-    applyHomepageCacheHeaders(res, Math.min(60, stale.age));
+  const historyPreviewsPromise = readHomepageHistoryPreviews(c.env.DB, now).catch((err) => {
+    console.warn('public homepage: preview read failed', err);
+    return {
+      resolvedIncidentPreview: null,
+      maintenanceHistoryPreview: null,
+    };
+  });
+  const statusSnapshot = await readStatusSnapshot(c.env.DB, now);
+  if (statusSnapshot) {
+    const payload = homepageFromStatusPayload(
+      statusSnapshot.data,
+      await historyPreviewsPromise,
+    );
+    const res = c.json(payload);
+    applyHomepageCacheHeaders(res, statusSnapshot.age);
     return res;
   }
 
-  throw new AppError(503, 'UNAVAILABLE', 'Homepage snapshot unavailable');
+  try {
+    const statusPayload = await computePublicStatusPayload(c.env.DB, now);
+    const payload = homepageFromStatusPayload(statusPayload, await historyPreviewsPromise);
+    const res = c.json(payload);
+    applyHomepageCacheHeaders(res, 0);
+
+    c.executionCtx.waitUntil(
+      writeStatusSnapshot(c.env.DB, now, statusPayload).catch((err) => {
+        console.warn('public snapshot: write failed', err);
+      }),
+    );
+
+    return res;
+  } catch (err) {
+    console.warn('public homepage: secondary status compute failed', err);
+
+    const staleHomepage = await readStaleHomepageSnapshot(c.env.DB, now);
+    if (staleHomepage) {
+      const res = c.json(staleHomepage.data);
+      applyHomepageCacheHeaders(res, Math.min(60, staleHomepage.age));
+      return res;
+    }
+
+    const staleStatus = await readStaleStatusSnapshot(c.env.DB, now, 10 * 60);
+    if (staleStatus) {
+      const payload = homepageFromStatusPayload(
+        toSnapshotPayload(staleStatus.data),
+        await historyPreviewsPromise.catch(() => ({
+          resolvedIncidentPreview: null,
+          maintenanceHistoryPreview: null,
+        })),
+      );
+      const res = c.json(payload);
+      applyHomepageCacheHeaders(res, Math.min(60, staleStatus.age));
+      return res;
+    }
+
+    throw new AppError(503, 'UNAVAILABLE', 'Homepage unavailable');
+  }
 });
 
 publicRoutes.get('/homepage-artifact', async (c) => {
   const now = Math.floor(Date.now() / 1000);
   const snapshot = await readHomepageSnapshotArtifactJson(c.env.DB, now);
   if (snapshot) {
-    const res = new Response(snapshot.bodyJson, {
-      headers: { 'Content-Type': 'application/json; charset=utf-8' },
-    });
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
     return res;
   }
 
   const stale = await readStaleHomepageSnapshotArtifactJson(c.env.DB, now);
   if (stale) {
-    const res = new Response(stale.bodyJson, {
-      headers: { 'Content-Type': 'application/json; charset=utf-8' },
-    });
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(stale.bodyJson);
     applyHomepageCacheHeaders(res, Math.min(60, stale.age));
     return res;
   }

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -20,8 +20,10 @@ import {
   applyHomepageCacheHeaders,
   applyStatusCacheHeaders,
   readHomepageSnapshot,
+  readHomepageSnapshotArtifact,
   readStatusSnapshot,
   readStaleHomepageSnapshot,
+  readStaleHomepageSnapshotArtifact,
   toSnapshotPayload,
   writeStatusSnapshot,
 } from '../snapshots';
@@ -550,6 +552,25 @@ publicRoutes.get('/homepage', async (c) => {
   }
 
   throw new AppError(503, 'UNAVAILABLE', 'Homepage snapshot unavailable');
+});
+
+publicRoutes.get('/homepage-artifact', async (c) => {
+  const now = Math.floor(Date.now() / 1000);
+  const snapshot = await readHomepageSnapshotArtifact(c.env.DB, now);
+  if (snapshot) {
+    const res = c.json(snapshot.data);
+    applyHomepageCacheHeaders(res, snapshot.age);
+    return res;
+  }
+
+  const stale = await readStaleHomepageSnapshotArtifact(c.env.DB, now);
+  if (stale) {
+    const res = c.json(stale.data);
+    applyHomepageCacheHeaders(res, Math.min(60, stale.age));
+    return res;
+  }
+
+  throw new AppError(503, 'UNAVAILABLE', 'Homepage artifact unavailable');
 });
 
 publicRoutes.get('/incidents', async (c) => {

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -19,11 +19,11 @@ import {
 import {
   applyHomepageCacheHeaders,
   applyStatusCacheHeaders,
-  readHomepageSnapshot,
-  readHomepageSnapshotArtifact,
+  readHomepageSnapshotArtifactJson,
+  readHomepageSnapshotJson,
   readStatusSnapshot,
-  readStaleHomepageSnapshot,
-  readStaleHomepageSnapshotArtifact,
+  readStaleHomepageSnapshotArtifactJson,
+  readStaleHomepageSnapshotJson,
   toSnapshotPayload,
   writeStatusSnapshot,
 } from '../snapshots';
@@ -537,16 +537,20 @@ publicRoutes.get('/status', async (c) => {
 
 publicRoutes.get('/homepage', async (c) => {
   const now = Math.floor(Date.now() / 1000);
-  const snapshot = await readHomepageSnapshot(c.env.DB, now);
+  const snapshot = await readHomepageSnapshotJson(c.env.DB, now);
   if (snapshot) {
-    const res = c.json(snapshot.data);
+    const res = new Response(snapshot.bodyJson, {
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
     applyHomepageCacheHeaders(res, snapshot.age);
     return res;
   }
 
-  const stale = await readStaleHomepageSnapshot(c.env.DB, now);
+  const stale = await readStaleHomepageSnapshotJson(c.env.DB, now);
   if (stale) {
-    const res = c.json(stale.data);
+    const res = new Response(stale.bodyJson, {
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
     applyHomepageCacheHeaders(res, Math.min(60, stale.age));
     return res;
   }
@@ -556,16 +560,20 @@ publicRoutes.get('/homepage', async (c) => {
 
 publicRoutes.get('/homepage-artifact', async (c) => {
   const now = Math.floor(Date.now() / 1000);
-  const snapshot = await readHomepageSnapshotArtifact(c.env.DB, now);
+  const snapshot = await readHomepageSnapshotArtifactJson(c.env.DB, now);
   if (snapshot) {
-    const res = c.json(snapshot.data);
+    const res = new Response(snapshot.bodyJson, {
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
     applyHomepageCacheHeaders(res, snapshot.age);
     return res;
   }
 
-  const stale = await readStaleHomepageSnapshotArtifact(c.env.DB, now);
+  const stale = await readStaleHomepageSnapshotArtifactJson(c.env.DB, now);
   if (stale) {
-    const res = c.json(stale.data);
+    const res = new Response(stale.bodyJson, {
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
     applyHomepageCacheHeaders(res, Math.min(60, stale.age));
     return res;
   }

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -21,8 +21,8 @@ import {
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
-import { computePublicHomepagePayload } from '../public/homepage';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../snapshots';
+import { computePublicHomepageArtifactPayload } from '../public/homepage';
+import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -592,10 +592,10 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
   const queueHomepageRefresh = () =>
-    refreshPublicHomepageSnapshotIfNeeded({
+    refreshPublicHomepageArtifactSnapshotIfNeeded({
       db: env.DB,
       now,
-      compute: () => computePublicHomepagePayload(env.DB, Math.floor(Date.now() / 1000)),
+      compute: () => computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     });

--- a/apps/worker/src/schemas/public-homepage.ts
+++ b/apps/worker/src/schemas/public-homepage.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 const monitorStatusSchema = z.enum(['up', 'down', 'maintenance', 'paused', 'unknown']);
-const checkStatusSchema = z.enum(['up', 'down', 'maintenance', 'unknown']);
 const uptimeRatingLevelSchema = z.number().int().min(1).max(5);
 const incidentStatusSchema = z.enum(['investigating', 'identified', 'monitoring', 'resolved']);
 const incidentImpactSchema = z.enum(['none', 'minor', 'major', 'critical']);
@@ -41,21 +40,21 @@ const bannerSchema = z.discriminatedUnion('source', [
   }),
 ]);
 
-const heartbeatSchema = z.object({
-  checked_at: z.number().int().nonnegative(),
-  status: checkStatusSchema,
-  latency_ms: z.number().int().nonnegative().nullable(),
-});
-
 const uptimeSummaryPreviewSchema = z.object({
   uptime_pct: z.number().min(0).max(100),
 });
 
-const uptimeDayPreviewSchema = z.object({
-  day_start_at: z.number().int().nonnegative(),
-  downtime_sec: z.number().int().nonnegative(),
-  unknown_sec: z.number().int().nonnegative(),
-  uptime_pct: z.number().min(0).max(100).nullable(),
+const homepageHeartbeatStripSchema = z.object({
+  checked_at: z.array(z.number().int().nonnegative()),
+  status_codes: z.string().regex(/^[udmx]*$/),
+  latency_ms: z.array(z.number().int().nonnegative().nullable()),
+});
+
+const homepageUptimeDayStripSchema = z.object({
+  day_start_at: z.array(z.number().int().nonnegative()),
+  downtime_sec: z.array(z.number().int().nonnegative()),
+  unknown_sec: z.array(z.number().int().nonnegative()),
+  uptime_pct_milli: z.array(z.number().int().min(0).max(100_000).nullable()),
 });
 
 export const homepageMonitorCardSchema = z.object({
@@ -66,9 +65,9 @@ export const homepageMonitorCardSchema = z.object({
   status: monitorStatusSchema,
   is_stale: z.boolean(),
   last_checked_at: z.number().int().nonnegative().nullable(),
-  heartbeats: z.array(heartbeatSchema),
+  heartbeat_strip: homepageHeartbeatStripSchema,
   uptime_30d: uptimeSummaryPreviewSchema.nullable(),
-  uptime_days: z.array(uptimeDayPreviewSchema),
+  uptime_day_strip: homepageUptimeDayStripSchema,
 });
 
 const incidentSummarySchema = z.object({
@@ -92,6 +91,8 @@ const maintenanceWindowPreviewSchema = z.object({
 
 export const publicHomepageResponseSchema = z.object({
   generated_at: z.number().int().nonnegative(),
+  bootstrap_mode: z.enum(['full', 'partial']).default('full'),
+  monitor_count_total: z.number().int().nonnegative(),
   site_title: z.string().default('Uptimer'),
   site_description: z.string().default(''),
   site_locale: z.enum(['auto', 'en', 'zh-CN', 'zh-TW', 'ja', 'es']).default('auto'),

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -10,13 +10,12 @@ const SNAPSHOT_KEY = 'homepage';
 const MAX_AGE_SECONDS = 60;
 const MAX_STALE_SECONDS = 10 * 60;
 const REFRESH_LOCK_NAME = 'snapshot:homepage:refresh';
-const MAX_BOOTSTRAP_MONITORS = 24;
+const MAX_BOOTSTRAP_MONITORS = 12;
 
 const homepageRenderArtifactSchema = z.object({
   generated_at: z.number().int().nonnegative(),
-  style_tag: z.string(),
   preload_html: z.string(),
-  bootstrap_script: z.string(),
+  snapshot: publicHomepageResponseSchema,
   meta_title: z.string(),
   meta_description: z.string(),
 });
@@ -41,10 +40,6 @@ const storedHomepageSnapshotRenderSchema = z.object({
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
-}
-
-function safeJsonForInlineScript(value: unknown): string {
-  return JSON.stringify(value).replace(/</g, '\\u003c');
 }
 
 function normalizeSnapshotText(value: unknown, fallback: string): string {
@@ -160,63 +155,6 @@ function buildHeartbeatStripSvg(
   }
   return `<svg class="usv" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-hidden="true">${rects}</svg>`;
 }
-
-const HOMEPAGE_PRELOAD_STYLE_TAG = `<style id="uptimer-preload-style">
-#uptimer-preload{min-height:100vh;background:#f8fafc;color:#0f172a;font:400 14px/1.45 ui-sans-serif,system-ui,sans-serif}
-#uptimer-preload *{box-sizing:border-box}
-#uptimer-preload .uw{max-width:80rem;margin:0 auto;padding:0 16px}
-#uptimer-preload .uh{position:sticky;top:0;z-index:20;background:rgba(255,255,255,.95);backdrop-filter:blur(12px);border-bottom:1px solid rgba(226,232,240,.8)}
-#uptimer-preload .uhw{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:16px 0}
-#uptimer-preload .ut{min-width:0}
-#uptimer-preload .un{font-size:20px;font-weight:700;line-height:1.1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-#uptimer-preload .ud{margin-top:4px;color:#64748b;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-#uptimer-preload .sb{display:inline-flex;align-items:center;border-radius:999px;padding:4px 10px;font-size:12px;font-weight:600;border:1px solid transparent}
-#uptimer-preload .sb-up{background:#ecfdf5;color:#047857;border-color:#a7f3d0}
-#uptimer-preload .sb-down{background:#fef2f2;color:#b91c1c;border-color:#fecaca}
-#uptimer-preload .sb-maintenance{background:#eff6ff;color:#1d4ed8;border-color:#bfdbfe}
-#uptimer-preload .sb-paused{background:#fffbeb;color:#b45309;border-color:#fde68a}
-#uptimer-preload .sb-unknown{background:#f8fafc;color:#475569;border-color:#cbd5e1}
-#uptimer-preload .um{padding:24px 0 40px}
-#uptimer-preload .bn{margin:0 0 24px;border:1px solid #e2e8f0;border-radius:18px;padding:20px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.04)}
-#uptimer-preload .bt{color:#475569}
-#uptimer-preload .bu{margin-top:4px;font-size:12px;color:#94a3b8}
-#uptimer-preload .sec{margin-top:24px}
-#uptimer-preload .sh{margin:0 0 12px;font-size:16px;font-weight:700}
-#uptimer-preload .st{display:grid;gap:12px}
-#uptimer-preload .sg{margin-top:20px}
-#uptimer-preload .sgh{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
-#uptimer-preload .sgt{font-size:13px;font-weight:700;color:#475569}
-#uptimer-preload .sgc{font-size:12px;color:#94a3b8}
-#uptimer-preload .grid{display:grid;gap:12px}
-#uptimer-preload .card{border:1px solid rgba(226,232,240,.9);border-radius:16px;padding:14px;background:#fff}
-#uptimer-preload .row{display:flex;align-items:flex-start;justify-content:space-between;gap:10px}
-#uptimer-preload .lhs{min-width:0;display:flex;align-items:flex-start;gap:10px}
-#uptimer-preload .dot{display:block;width:10px;height:10px;border-radius:999px;margin-top:5px}
-#uptimer-preload .dot-up{background:#10b981}
-#uptimer-preload .dot-down{background:#ef4444}
-#uptimer-preload .dot-maintenance{background:#3b82f6}
-#uptimer-preload .dot-paused{background:#f59e0b}
-#uptimer-preload .dot-unknown{background:#94a3b8}
-#uptimer-preload .mn{font-size:15px;font-weight:700;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-#uptimer-preload .mt{margin-top:3px;font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:.08em}
-#uptimer-preload .rhs{display:flex;align-items:center;gap:8px;white-space:nowrap}
-#uptimer-preload .up{font-size:12px;color:#94a3b8}
-#uptimer-preload .lbl{margin:12px 0 6px;font-size:11px;color:#94a3b8}
-#uptimer-preload .strip{height:20px;border-radius:8px;background:#e2e8f0;overflow:hidden}
-#uptimer-preload .usv{display:block;width:100%;height:100%}
-#uptimer-preload .ft{margin-top:12px;font-size:11px;color:#94a3b8}
-#uptimer-preload .ih{padding-top:24px;border-top:1px solid #e2e8f0}
-@media (min-width:640px){#uptimer-preload .grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
-html.dark #uptimer-preload{background:#0f172a;color:#f8fafc}
-html.dark #uptimer-preload .uh{background:rgba(15,23,42,.95);border-bottom-color:rgba(51,65,85,.9)}
-html.dark #uptimer-preload .ud,#uptimer-preload .sgt{color:#cbd5e1}
-html.dark #uptimer-preload .bn,html.dark #uptimer-preload .card{background:#1e293b;border-color:rgba(51,65,85,.95);box-shadow:none}
-html.dark #uptimer-preload .bt{color:#cbd5e1}
-html.dark #uptimer-preload .bu,#uptimer-preload .sgc,#uptimer-preload .up,#uptimer-preload .lbl,#uptimer-preload .ft{color:#94a3b8}
-html.dark #uptimer-preload .mt{color:#94a3b8}
-html.dark #uptimer-preload .strip{background:#334155}
-html.dark #uptimer-preload .ih{border-top-color:#334155}
-</style>`;
 
 function renderIncidentCard(
   incident: PublicHomepageResponse['active_incidents'][number],
@@ -388,9 +326,8 @@ export function buildHomepageRenderArtifact(
 
   return {
     generated_at: snapshot.generated_at,
-    style_tag: HOMEPAGE_PRELOAD_STYLE_TAG,
     preload_html: `<div id="uptimer-preload">${renderPreload(bootstrapSnapshot, allMonitorNames)}</div>`,
-    bootstrap_script: `<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${safeJsonForInlineScript(bootstrapSnapshot)};</script>`,
+    snapshot: bootstrapSnapshot,
     meta_title: metaTitle,
     meta_description: metaDescription,
   };

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -290,7 +290,7 @@ export function buildHomepageRenderArtifact(
     allMonitorNames.set(monitor.id, monitor.name);
   }
   const bootstrapSnapshot =
-    snapshot.monitors.length > MAX_BOOTSTRAP_MONITORS
+    snapshot.bootstrap_mode === 'partial' || snapshot.monitors.length > MAX_BOOTSTRAP_MONITORS
       ? {
           ...snapshot,
           bootstrap_mode: 'partial' as const,
@@ -692,6 +692,34 @@ export async function readHomepageSnapshotGeneratedAt(
   return row?.generated_at ?? null;
 }
 
+export async function readHomepageArtifactSnapshotGeneratedAt(
+  db: D1Database,
+): Promise<number | null> {
+  const row = await readHomepageArtifactSnapshotRow(db);
+  return row?.generated_at ?? null;
+}
+
+function homepageSnapshotUpsertStatement(
+  db: D1Database,
+  key: string,
+  generatedAt: number,
+  bodyJson: string,
+  now: number,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `
+      INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
+      VALUES (?1, ?2, ?3, ?4)
+      ON CONFLICT(key) DO UPDATE SET
+        generated_at = excluded.generated_at,
+        body_json = excluded.body_json,
+        updated_at = excluded.updated_at
+    `,
+    )
+    .bind(key, generatedAt, bodyJson, now);
+}
+
 export async function writeHomepageSnapshot(
   db: D1Database,
   now: number,
@@ -701,19 +729,33 @@ export async function writeHomepageSnapshot(
   const dataBodyJson = JSON.stringify(payload);
   const renderBodyJson = JSON.stringify(render);
 
-  const upsertSql = `
-    INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
-    VALUES (?1, ?2, ?3, ?4)
-    ON CONFLICT(key) DO UPDATE SET
-      generated_at = excluded.generated_at,
-      body_json = excluded.body_json,
-      updated_at = excluded.updated_at
-  `;
-
   await db.batch([
-    db.prepare(upsertSql).bind(SNAPSHOT_KEY, payload.generated_at, dataBodyJson, now),
-    db.prepare(upsertSql).bind(SNAPSHOT_ARTIFACT_KEY, render.generated_at, renderBodyJson, now),
+    homepageSnapshotUpsertStatement(db, SNAPSHOT_KEY, payload.generated_at, dataBodyJson, now),
+    homepageSnapshotUpsertStatement(
+      db,
+      SNAPSHOT_ARTIFACT_KEY,
+      render.generated_at,
+      renderBodyJson,
+      now,
+    ),
   ]);
+}
+
+export async function writeHomepageArtifactSnapshot(
+  db: D1Database,
+  now: number,
+  payload: PublicHomepageResponse,
+): Promise<void> {
+  const render = buildHomepageRenderArtifact(payload);
+  const renderBodyJson = JSON.stringify(render);
+
+  await homepageSnapshotUpsertStatement(
+    db,
+    SNAPSHOT_ARTIFACT_KEY,
+    render.generated_at,
+    renderBodyJson,
+    now,
+  ).run();
 }
 
 export function applyHomepageCacheHeaders(res: Response, ageSeconds: number): void {
@@ -744,6 +786,15 @@ export async function refreshPublicHomepageSnapshot(opts: {
   await writeHomepageSnapshot(opts.db, opts.now, payload);
 }
 
+export async function refreshPublicHomepageArtifactSnapshot(opts: {
+  db: D1Database;
+  now: number;
+  compute: () => Promise<unknown>;
+}): Promise<void> {
+  const payload = toHomepageSnapshotPayload(await opts.compute());
+  await writeHomepageArtifactSnapshot(opts.db, opts.now, payload);
+}
+
 export async function refreshPublicHomepageSnapshotIfNeeded(opts: {
   db: D1Database;
   now: number;
@@ -765,5 +816,29 @@ export async function refreshPublicHomepageSnapshotIfNeeded(opts: {
   }
 
   await refreshPublicHomepageSnapshot(opts);
+  return true;
+}
+
+export async function refreshPublicHomepageArtifactSnapshotIfNeeded(opts: {
+  db: D1Database;
+  now: number;
+  compute: () => Promise<unknown>;
+}): Promise<boolean> {
+  const generatedAt = await readHomepageArtifactSnapshotGeneratedAt(opts.db);
+  if (generatedAt !== null && isSameMinute(generatedAt, opts.now)) {
+    return false;
+  }
+
+  const acquired = await acquireLease(opts.db, REFRESH_LOCK_NAME, opts.now, 55);
+  if (!acquired) {
+    return false;
+  }
+
+  const latestGeneratedAt = await readHomepageArtifactSnapshotGeneratedAt(opts.db);
+  if (latestGeneratedAt !== null && isSameMinute(latestGeneratedAt, opts.now)) {
+    return false;
+  }
+
+  await refreshPublicHomepageArtifactSnapshot(opts);
   return true;
 }

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -355,6 +355,25 @@ function looksLikeHomepageArtifact(value: unknown): value is PublicHomepageRende
   );
 }
 
+function looksLikeSerializedHomepagePayload(text: string): boolean {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith('{"generated_at":') &&
+    trimmed.includes('"bootstrap_mode"') &&
+    trimmed.includes('"monitor_count_total"')
+  );
+}
+
+function looksLikeSerializedHomepageArtifact(text: string): boolean {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith('{"generated_at":') &&
+    trimmed.includes('"preload_html"') &&
+    trimmed.includes('"meta_title"') &&
+    trimmed.includes('"snapshot"')
+  );
+}
+
 function readStoredHomepageSnapshotData(value: unknown): PublicHomepageResponse | null {
   if (!isRecord(value)) return null;
 
@@ -380,6 +399,10 @@ function readStoredHomepageSnapshotData(value: unknown): PublicHomepageResponse 
 }
 
 function readStoredHomepageSnapshotRender(value: unknown): PublicHomepageRenderArtifact | null {
+  if (looksLikeHomepageArtifact(value)) {
+    return value;
+  }
+
   if (!isRecord(value)) return null;
   const version = value.version;
   if (version !== SPLIT_SNAPSHOT_VERSION && version !== LEGACY_COMBINED_SNAPSHOT_VERSION) {
@@ -469,6 +492,38 @@ export async function readHomepageSnapshot(
   };
 }
 
+export async function readHomepageSnapshotJson(
+  db: D1Database,
+  now: number,
+): Promise<{ bodyJson: string; age: number } | null> {
+  const row = await readHomepageSnapshotRow(db);
+  if (!row) return null;
+
+  const age = Math.max(0, now - row.generated_at);
+  if (age > MAX_AGE_SECONDS) return null;
+
+  if (looksLikeSerializedHomepagePayload(row.body_json)) {
+    return {
+      bodyJson: row.body_json,
+      age,
+    };
+  }
+
+  const parsed = safeJsonParse(row.body_json);
+  if (parsed === null) return null;
+
+  const data = readStoredHomepageSnapshotData(parsed);
+  if (!data) {
+    console.warn('homepage snapshot: invalid payload');
+    return null;
+  }
+
+  return {
+    bodyJson: JSON.stringify(data),
+    age,
+  };
+}
+
 export async function readStaleHomepageSnapshot(
   db: D1Database,
   now: number,
@@ -490,6 +545,38 @@ export async function readStaleHomepageSnapshot(
 
   return {
     data,
+    age,
+  };
+}
+
+export async function readStaleHomepageSnapshotJson(
+  db: D1Database,
+  now: number,
+): Promise<{ bodyJson: string; age: number } | null> {
+  const row = await readHomepageSnapshotRow(db);
+  if (!row) return null;
+
+  const age = Math.max(0, now - row.generated_at);
+  if (age > MAX_STALE_SECONDS) return null;
+
+  if (looksLikeSerializedHomepagePayload(row.body_json)) {
+    return {
+      bodyJson: row.body_json,
+      age,
+    };
+  }
+
+  const parsed = safeJsonParse(row.body_json);
+  if (parsed === null) return null;
+
+  const data = readStoredHomepageSnapshotData(parsed);
+  if (!data) {
+    console.warn('homepage snapshot: invalid stale payload');
+    return null;
+  }
+
+  return {
+    bodyJson: JSON.stringify(data),
     age,
   };
 }
@@ -519,6 +606,38 @@ export async function readHomepageSnapshotArtifact(
   };
 }
 
+export async function readHomepageSnapshotArtifactJson(
+  db: D1Database,
+  now: number,
+): Promise<{ bodyJson: string; age: number } | null> {
+  const row = (await readHomepageArtifactSnapshotRow(db)) ?? (await readHomepageSnapshotRow(db));
+  if (!row) return null;
+
+  const age = Math.max(0, now - row.generated_at);
+  if (age > MAX_AGE_SECONDS) return null;
+
+  if (looksLikeSerializedHomepageArtifact(row.body_json)) {
+    return {
+      bodyJson: row.body_json,
+      age,
+    };
+  }
+
+  const parsed = safeJsonParse(row.body_json);
+  if (parsed === null) return null;
+
+  const render = readStoredHomepageSnapshotRender(parsed);
+  if (!render) {
+    console.warn('homepage snapshot: invalid render payload');
+    return null;
+  }
+
+  return {
+    bodyJson: JSON.stringify(render),
+    age,
+  };
+}
+
 export async function readStaleHomepageSnapshotArtifact(
   db: D1Database,
   now: number,
@@ -544,6 +663,38 @@ export async function readStaleHomepageSnapshotArtifact(
   };
 }
 
+export async function readStaleHomepageSnapshotArtifactJson(
+  db: D1Database,
+  now: number,
+): Promise<{ bodyJson: string; age: number } | null> {
+  const row = (await readHomepageArtifactSnapshotRow(db)) ?? (await readHomepageSnapshotRow(db));
+  if (!row) return null;
+
+  const age = Math.max(0, now - row.generated_at);
+  if (age > MAX_STALE_SECONDS) return null;
+
+  if (looksLikeSerializedHomepageArtifact(row.body_json)) {
+    return {
+      bodyJson: row.body_json,
+      age,
+    };
+  }
+
+  const parsed = safeJsonParse(row.body_json);
+  if (parsed === null) return null;
+
+  const render = readStoredHomepageSnapshotRender(parsed);
+  if (!render) {
+    console.warn('homepage snapshot: invalid stale render payload');
+    return null;
+  }
+
+  return {
+    bodyJson: JSON.stringify(render),
+    age,
+  };
+}
+
 export async function readHomepageSnapshotGeneratedAt(
   db: D1Database,
 ): Promise<number | null> {
@@ -557,14 +708,8 @@ export async function writeHomepageSnapshot(
   payload: PublicHomepageResponse,
 ): Promise<void> {
   const render = buildHomepageRenderArtifact(payload);
-  const dataBodyJson = JSON.stringify({
-    version: SPLIT_SNAPSHOT_VERSION,
-    data: payload,
-  } satisfies StoredHomepageDataSnapshot);
-  const renderBodyJson = JSON.stringify({
-    version: SPLIT_SNAPSHOT_VERSION,
-    render,
-  } satisfies StoredHomepageRenderSnapshot);
+  const dataBodyJson = JSON.stringify(payload);
+  const renderBodyJson = JSON.stringify(render);
 
   const upsertSql = `
     INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -23,16 +23,6 @@ export type PublicHomepageRenderArtifact = {
   meta_description: string;
 };
 
-type StoredHomepageDataSnapshot = {
-  version: typeof SPLIT_SNAPSHOT_VERSION;
-  data: PublicHomepageResponse;
-};
-
-type StoredHomepageRenderSnapshot = {
-  version: typeof SPLIT_SNAPSHOT_VERSION;
-  render: PublicHomepageRenderArtifact;
-};
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -4,11 +4,440 @@ import {
   publicHomepageResponseSchema,
   type PublicHomepageResponse,
 } from '../schemas/public-homepage';
+import { z } from 'zod';
 
 const SNAPSHOT_KEY = 'homepage';
 const MAX_AGE_SECONDS = 60;
 const MAX_STALE_SECONDS = 10 * 60;
 const REFRESH_LOCK_NAME = 'snapshot:homepage:refresh';
+const MAX_BOOTSTRAP_MONITORS = 24;
+
+const homepageRenderArtifactSchema = z.object({
+  generated_at: z.number().int().nonnegative(),
+  style_tag: z.string(),
+  preload_html: z.string(),
+  bootstrap_script: z.string(),
+  meta_title: z.string(),
+  meta_description: z.string(),
+});
+
+export type PublicHomepageRenderArtifact = z.infer<typeof homepageRenderArtifactSchema>;
+
+type StoredHomepageSnapshot = {
+  version: 2;
+  data: PublicHomepageResponse;
+  render: PublicHomepageRenderArtifact;
+};
+
+const storedHomepageSnapshotDataSchema = z.object({
+  version: z.literal(2),
+  data: publicHomepageResponseSchema,
+});
+
+const storedHomepageSnapshotRenderSchema = z.object({
+  version: z.literal(2),
+  render: homepageRenderArtifactSchema,
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function safeJsonForInlineScript(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function normalizeSnapshotText(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatTime(tsSec: number, cache?: Map<number, string>): string {
+  if (cache?.has(tsSec)) {
+    return cache.get(tsSec) ?? '';
+  }
+
+  let formatted = '';
+  try {
+    formatted = new Date(tsSec * 1000).toLocaleString();
+  } catch {
+    formatted = '';
+  }
+
+  cache?.set(tsSec, formatted);
+  return formatted;
+}
+
+function monitorGroupLabel(value: string | null | undefined): string {
+  const trimmed = value?.trim() ?? '';
+  return trimmed.length > 0 ? trimmed : 'Ungrouped';
+}
+
+function uptimeFillFromMilli(uptimePctMilli: number | null | undefined): string {
+  if (typeof uptimePctMilli !== 'number') return '#cbd5e1';
+  if (uptimePctMilli >= 99_950) return '#10b981';
+  if (uptimePctMilli >= 99_000) return '#84cc16';
+  if (uptimePctMilli >= 95_000) return '#f59e0b';
+  return '#ef4444';
+}
+
+function heartbeatFillFromCode(code: string | undefined): string {
+  switch (code) {
+    case 'u':
+      return '#10b981';
+    case 'd':
+      return '#ef4444';
+    case 'm':
+      return '#3b82f6';
+    case 'x':
+    default:
+      return '#cbd5e1';
+  }
+}
+
+function heartbeatHeightPct(
+  code: string | undefined,
+  latencyMs: number | null | undefined,
+): number {
+  if (code === 'd') return 100;
+  if (code === 'm') return 62;
+  if (code !== 'u') return 48;
+  if (typeof latencyMs !== 'number' || !Number.isFinite(latencyMs)) return 74;
+  return 36 + Math.min(64, Math.max(0, latencyMs / 12));
+}
+
+function buildUptimeStripSvg(
+  strip: PublicHomepageResponse['monitors'][number]['uptime_day_strip'],
+): string {
+  const count = Math.min(
+    strip.day_start_at.length,
+    strip.downtime_sec.length,
+    strip.unknown_sec.length,
+    strip.uptime_pct_milli.length,
+  );
+  const barWidth = 4;
+  const gap = 2;
+  const height = 20;
+  const width = count <= 0 ? barWidth : count * barWidth + Math.max(0, count - 1) * gap;
+  let rects = '';
+  for (let index = 0; index < count; index += 1) {
+    const x = index * (barWidth + gap);
+    const fill = uptimeFillFromMilli(strip.uptime_pct_milli[index]);
+    rects += `<rect x="${x}" width="${barWidth}" height="${height}" rx="1" fill="${fill}"/>`;
+  }
+  return `<svg class="usv" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-hidden="true">${rects}</svg>`;
+}
+
+function buildHeartbeatStripSvg(
+  strip: PublicHomepageResponse['monitors'][number]['heartbeat_strip'],
+): string {
+  const count = Math.min(
+    strip.checked_at.length,
+    strip.latency_ms.length,
+    strip.status_codes.length,
+  );
+  const barWidth = 4;
+  const gap = 2;
+  const height = 20;
+  const width = count <= 0 ? barWidth : count * barWidth + Math.max(0, count - 1) * gap;
+  let rects = '';
+  for (let index = 0; index < count; index += 1) {
+    const x = index * (barWidth + gap);
+    const barHeight =
+      (height * heartbeatHeightPct(strip.status_codes[index], strip.latency_ms[index])) / 100;
+    const y = height - barHeight;
+    rects += `<rect x="${x}" y="${y.toFixed(2)}" width="${barWidth}" height="${barHeight.toFixed(2)}" rx="1" fill="${heartbeatFillFromCode(strip.status_codes[index])}"/>`;
+  }
+  return `<svg class="usv" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-hidden="true">${rects}</svg>`;
+}
+
+const HOMEPAGE_PRELOAD_STYLE_TAG = `<style id="uptimer-preload-style">
+#uptimer-preload{min-height:100vh;background:#f8fafc;color:#0f172a;font:400 14px/1.45 ui-sans-serif,system-ui,sans-serif}
+#uptimer-preload *{box-sizing:border-box}
+#uptimer-preload .uw{max-width:80rem;margin:0 auto;padding:0 16px}
+#uptimer-preload .uh{position:sticky;top:0;z-index:20;background:rgba(255,255,255,.95);backdrop-filter:blur(12px);border-bottom:1px solid rgba(226,232,240,.8)}
+#uptimer-preload .uhw{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:16px 0}
+#uptimer-preload .ut{min-width:0}
+#uptimer-preload .un{font-size:20px;font-weight:700;line-height:1.1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#uptimer-preload .ud{margin-top:4px;color:#64748b;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#uptimer-preload .sb{display:inline-flex;align-items:center;border-radius:999px;padding:4px 10px;font-size:12px;font-weight:600;border:1px solid transparent}
+#uptimer-preload .sb-up{background:#ecfdf5;color:#047857;border-color:#a7f3d0}
+#uptimer-preload .sb-down{background:#fef2f2;color:#b91c1c;border-color:#fecaca}
+#uptimer-preload .sb-maintenance{background:#eff6ff;color:#1d4ed8;border-color:#bfdbfe}
+#uptimer-preload .sb-paused{background:#fffbeb;color:#b45309;border-color:#fde68a}
+#uptimer-preload .sb-unknown{background:#f8fafc;color:#475569;border-color:#cbd5e1}
+#uptimer-preload .um{padding:24px 0 40px}
+#uptimer-preload .bn{margin:0 0 24px;border:1px solid #e2e8f0;border-radius:18px;padding:20px;background:#fff;box-shadow:0 10px 30px rgba(15,23,42,.04)}
+#uptimer-preload .bt{color:#475569}
+#uptimer-preload .bu{margin-top:4px;font-size:12px;color:#94a3b8}
+#uptimer-preload .sec{margin-top:24px}
+#uptimer-preload .sh{margin:0 0 12px;font-size:16px;font-weight:700}
+#uptimer-preload .st{display:grid;gap:12px}
+#uptimer-preload .sg{margin-top:20px}
+#uptimer-preload .sgh{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
+#uptimer-preload .sgt{font-size:13px;font-weight:700;color:#475569}
+#uptimer-preload .sgc{font-size:12px;color:#94a3b8}
+#uptimer-preload .grid{display:grid;gap:12px}
+#uptimer-preload .card{border:1px solid rgba(226,232,240,.9);border-radius:16px;padding:14px;background:#fff}
+#uptimer-preload .row{display:flex;align-items:flex-start;justify-content:space-between;gap:10px}
+#uptimer-preload .lhs{min-width:0;display:flex;align-items:flex-start;gap:10px}
+#uptimer-preload .dot{display:block;width:10px;height:10px;border-radius:999px;margin-top:5px}
+#uptimer-preload .dot-up{background:#10b981}
+#uptimer-preload .dot-down{background:#ef4444}
+#uptimer-preload .dot-maintenance{background:#3b82f6}
+#uptimer-preload .dot-paused{background:#f59e0b}
+#uptimer-preload .dot-unknown{background:#94a3b8}
+#uptimer-preload .mn{font-size:15px;font-weight:700;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#uptimer-preload .mt{margin-top:3px;font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:.08em}
+#uptimer-preload .rhs{display:flex;align-items:center;gap:8px;white-space:nowrap}
+#uptimer-preload .up{font-size:12px;color:#94a3b8}
+#uptimer-preload .lbl{margin:12px 0 6px;font-size:11px;color:#94a3b8}
+#uptimer-preload .strip{height:20px;border-radius:8px;background:#e2e8f0;overflow:hidden}
+#uptimer-preload .usv{display:block;width:100%;height:100%}
+#uptimer-preload .ft{margin-top:12px;font-size:11px;color:#94a3b8}
+#uptimer-preload .ih{padding-top:24px;border-top:1px solid #e2e8f0}
+@media (min-width:640px){#uptimer-preload .grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+html.dark #uptimer-preload{background:#0f172a;color:#f8fafc}
+html.dark #uptimer-preload .uh{background:rgba(15,23,42,.95);border-bottom-color:rgba(51,65,85,.9)}
+html.dark #uptimer-preload .ud,#uptimer-preload .sgt{color:#cbd5e1}
+html.dark #uptimer-preload .bn,html.dark #uptimer-preload .card{background:#1e293b;border-color:rgba(51,65,85,.95);box-shadow:none}
+html.dark #uptimer-preload .bt{color:#cbd5e1}
+html.dark #uptimer-preload .bu,#uptimer-preload .sgc,#uptimer-preload .up,#uptimer-preload .lbl,#uptimer-preload .ft{color:#94a3b8}
+html.dark #uptimer-preload .mt{color:#94a3b8}
+html.dark #uptimer-preload .strip{background:#334155}
+html.dark #uptimer-preload .ih{border-top-color:#334155}
+</style>`;
+
+function renderIncidentCard(
+  incident: PublicHomepageResponse['active_incidents'][number],
+  formatTimestamp: (tsSec: number) => string,
+): string {
+  const impactVariant =
+    incident.impact === 'major' || incident.impact === 'critical' ? 'down' : 'paused';
+
+  let html = `<article class="card"><div class="row"><h4 class="mn">${escapeHtml(incident.title)}</h4><span class="sb sb-${impactVariant}">${escapeHtml(incident.impact)}</span></div><div class="ft">${formatTimestamp(incident.started_at)}</div>`;
+  if (incident.message) {
+    html += `<p class="bt">${escapeHtml(incident.message)}</p>`;
+  }
+  html += '</article>';
+  return html;
+}
+
+function renderMaintenanceCard(
+  window: NonNullable<PublicHomepageResponse['maintenance_history_preview']>,
+  monitorNames: Map<number, string>,
+  formatTimestamp: (tsSec: number) => string,
+): string {
+  let affected = '';
+  for (let index = 0; index < window.monitor_ids.length; index += 1) {
+    const monitorId = window.monitor_ids[index];
+    if (typeof monitorId !== 'number') {
+      continue;
+    }
+    if (index > 0) {
+      affected += ', ';
+    }
+    affected += escapeHtml(monitorNames.get(monitorId) || `#${monitorId}`);
+  }
+
+  let html = `<article class="card"><div><h4 class="mn">${escapeHtml(window.title)}</h4><div class="ft">${formatTimestamp(window.starts_at)} - ${formatTimestamp(window.ends_at)}</div></div>`;
+  if (affected) {
+    html += `<div class="bt">Affected: ${affected}</div>`;
+  }
+  if (window.message) {
+    html += `<p class="bt">${escapeHtml(window.message)}</p>`;
+  }
+  html += '</article>';
+  return html;
+}
+
+function renderPreload(
+  snapshot: PublicHomepageResponse,
+  monitorNameById?: ReadonlyMap<number, string>,
+): string {
+  const overall = snapshot.overall_status;
+  const siteTitle = snapshot.site_title;
+  const siteDescription = snapshot.site_description;
+  const bannerTitle = snapshot.banner.title;
+  const generatedAt = snapshot.generated_at;
+  const timeCache = new Map<number, string>();
+  const formatTimestamp = (tsSec: number) => escapeHtml(formatTime(tsSec, timeCache));
+  const needsMonitorNames =
+    snapshot.maintenance_windows.active.length > 0 ||
+    snapshot.maintenance_windows.upcoming.length > 0 ||
+    snapshot.maintenance_history_preview !== null;
+  const monitorNames = new Map<number, string>();
+  if (needsMonitorNames) {
+    if (monitorNameById) {
+      for (const [monitorId, monitorName] of monitorNameById.entries()) {
+        monitorNames.set(monitorId, monitorName);
+      }
+    } else {
+      for (const monitor of snapshot.monitors) {
+        monitorNames.set(monitor.id, monitor.name);
+      }
+    }
+  }
+  const groups = new Map<string, PublicHomepageResponse['monitors']>();
+  for (const monitor of snapshot.monitors) {
+    const key = monitorGroupLabel(monitor.group_name);
+    const existing = groups.get(key) ?? [];
+    existing.push(monitor);
+    groups.set(key, existing);
+  }
+
+  let groupedMonitors = '';
+  for (const [groupName, groupMonitors] of groups.entries()) {
+    let monitorCards = '';
+    for (const monitor of groupMonitors) {
+      const uptimePct =
+        typeof monitor.uptime_30d?.uptime_pct === 'number'
+          ? `${monitor.uptime_30d.uptime_pct.toFixed(3)}%`
+          : '-';
+      const status = monitor.status;
+      const statusLabel = escapeHtml(status);
+      const lastCheckedLabel = monitor.last_checked_at
+        ? `Last checked: ${formatTimestamp(monitor.last_checked_at)}`
+        : 'Never checked';
+
+      monitorCards += `<article class="card"><div class="row"><div class="lhs"><span class="dot dot-${status}"></span><div class="ut"><div class="mn">${escapeHtml(monitor.name)}</div><div class="mt">${escapeHtml(monitor.type)}</div></div></div><div class="rhs"><span class="up">${escapeHtml(uptimePct)}</span><span class="sb sb-${status}">${statusLabel}</span></div></div><div><div class="lbl">Availability (30d)</div><div class="strip">${buildUptimeStripSvg(monitor.uptime_day_strip)}</div></div><div><div class="lbl">Recent checks</div><div class="strip">${buildHeartbeatStripSvg(monitor.heartbeat_strip)}</div></div><div class="ft">${lastCheckedLabel}</div></article>`;
+    }
+
+    groupedMonitors += `<section class="sg"><div class="sgh"><h4 class="sgt">${escapeHtml(groupName)}</h4><span class="sgc">${groupMonitors.length}</span></div><div class="grid">${monitorCards}</div></section>`;
+  }
+
+  const activeMaintenance = snapshot.maintenance_windows.active;
+  const upcomingMaintenance = snapshot.maintenance_windows.upcoming;
+  const hiddenMonitorCount = Math.max(0, snapshot.monitor_count_total - snapshot.monitors.length);
+  let maintenanceSection = '';
+  if (activeMaintenance.length > 0 || upcomingMaintenance.length > 0) {
+    let activeCards = '';
+    for (const window of activeMaintenance) {
+      activeCards += renderMaintenanceCard(window, monitorNames, formatTimestamp);
+    }
+    let upcomingCards = '';
+    for (const window of upcomingMaintenance) {
+      upcomingCards += renderMaintenanceCard(window, monitorNames, formatTimestamp);
+    }
+
+    maintenanceSection = `<section class="sec"><h3 class="sh">Scheduled Maintenance</h3>${activeCards ? `<div class="st">${activeCards}</div>` : ''}${upcomingCards ? `<div class="st">${upcomingCards}</div>` : ''}</section>`;
+  }
+
+  let incidentSection = '';
+  if (snapshot.active_incidents.length > 0) {
+    let incidentCards = '';
+    for (const incident of snapshot.active_incidents) {
+      incidentCards += renderIncidentCard(incident, formatTimestamp);
+    }
+    incidentSection = `<section class="sec"><h3 class="sh">Active Incidents</h3><div class="st">${incidentCards}</div></section>`;
+  }
+
+  const incidentHistory = snapshot.resolved_incident_preview
+    ? renderIncidentCard(snapshot.resolved_incident_preview, formatTimestamp)
+    : '<div class="card">No past incidents</div>';
+  const maintenanceHistory = snapshot.maintenance_history_preview
+    ? renderMaintenanceCard(snapshot.maintenance_history_preview, monitorNames, formatTimestamp)
+    : '<div class="card">No past maintenance</div>';
+  const descriptionHtml = siteDescription
+    ? `<div class="ud">${escapeHtml(siteDescription)}</div>`
+    : '';
+  const hiddenMonitorMessage =
+    hiddenMonitorCount > 0
+      ? `<div class="card ft">${hiddenMonitorCount} more services will appear after the app finishes loading.</div>`
+      : '';
+
+  return `<div class="hp"><header class="uh"><div class="uw uhw"><div class="ut"><div class="un">${escapeHtml(siteTitle)}</div>${descriptionHtml}</div><span class="sb sb-${overall}">${escapeHtml(overall)}</span></div></header><main class="uw um"><section class="bn"><div class="bt">${escapeHtml(bannerTitle)}</div><div class="bu">Updated: ${formatTimestamp(generatedAt)}</div></section>${maintenanceSection}${incidentSection}<section class="sec"><h3 class="sh">Services</h3>${groupedMonitors}${hiddenMonitorMessage}</section><section class="sec ih"><div><h3 class="sh">Incident History</h3>${incidentHistory}</div><div><h3 class="sh">Maintenance History</h3>${maintenanceHistory}</div></section></main></div>`;
+}
+
+export function buildHomepageRenderArtifact(
+  snapshot: PublicHomepageResponse,
+): PublicHomepageRenderArtifact {
+  const allMonitorNames = new Map<number, string>();
+  for (const monitor of snapshot.monitors) {
+    allMonitorNames.set(monitor.id, monitor.name);
+  }
+  const bootstrapSnapshot =
+    snapshot.monitors.length > MAX_BOOTSTRAP_MONITORS
+      ? {
+          ...snapshot,
+          bootstrap_mode: 'partial' as const,
+          monitors: snapshot.monitors.slice(0, MAX_BOOTSTRAP_MONITORS),
+        }
+      : {
+          ...snapshot,
+          bootstrap_mode: 'full' as const,
+        };
+  const metaTitle = normalizeSnapshotText(snapshot.site_title, 'Uptimer');
+  const fallbackDescription = normalizeSnapshotText(
+    snapshot.banner.title,
+    'Real-time status and incident updates.',
+  );
+  const metaDescription = normalizeSnapshotText(snapshot.site_description, fallbackDescription)
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return {
+    generated_at: snapshot.generated_at,
+    style_tag: HOMEPAGE_PRELOAD_STYLE_TAG,
+    preload_html: `<div id="uptimer-preload">${renderPreload(bootstrapSnapshot, allMonitorNames)}</div>`,
+    bootstrap_script: `<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${safeJsonForInlineScript(bootstrapSnapshot)};</script>`,
+    meta_title: metaTitle,
+    meta_description: metaDescription,
+  };
+}
+
+function looksLikeHomepagePayload(value: unknown): value is PublicHomepageResponse {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.generated_at === 'number' &&
+    typeof value.site_title === 'string' &&
+    Array.isArray(value.monitors) &&
+    Array.isArray(value.active_incidents)
+  );
+}
+
+function readStoredHomepageSnapshotData(value: unknown): PublicHomepageResponse | null {
+  if (!isRecord(value)) return null;
+
+  const version = value.version;
+  if (version === 2) {
+    const parsed = storedHomepageSnapshotDataSchema.safeParse(value);
+    return parsed.success ? parsed.data.data : null;
+  }
+
+  if (!looksLikeHomepagePayload(value)) {
+    return null;
+  }
+
+  const parsed = publicHomepageResponseSchema.safeParse({
+    ...value,
+    bootstrap_mode: 'full',
+    monitor_count_total: Array.isArray(value.monitors) ? value.monitors.length : 0,
+  });
+  if (!parsed.success) {
+    return null;
+  }
+
+  return parsed.data;
+}
+
+function readStoredHomepageSnapshotRender(value: unknown): PublicHomepageRenderArtifact | null {
+  if (!isRecord(value)) return null;
+  if (value.version !== 2) return null;
+
+  const parsed = storedHomepageSnapshotRenderSchema.safeParse(value);
+  return parsed.success ? parsed.data.render : null;
+}
 
 function safeJsonParse(text: string): unknown | null {
   const trimmed = text.trim();
@@ -69,15 +498,16 @@ export async function readHomepageSnapshot(
   const parsed = safeJsonParse(row.body_json);
   if (parsed === null) return null;
 
-  try {
-    return {
-      data: publicHomepageResponseSchema.parse(parsed),
-      age,
-    };
-  } catch (err) {
-    console.warn('homepage snapshot: invalid payload', err);
+  const data = readStoredHomepageSnapshotData(parsed);
+  if (!data) {
+    console.warn('homepage snapshot: invalid payload');
     return null;
   }
+
+  return {
+    data,
+    age,
+  };
 }
 
 export async function readStaleHomepageSnapshot(
@@ -93,15 +523,66 @@ export async function readStaleHomepageSnapshot(
   const parsed = safeJsonParse(row.body_json);
   if (parsed === null) return null;
 
-  try {
-    return {
-      data: publicHomepageResponseSchema.parse(parsed),
-      age,
-    };
-  } catch (err) {
-    console.warn('homepage snapshot: invalid stale payload', err);
+  const data = readStoredHomepageSnapshotData(parsed);
+  if (!data) {
+    console.warn('homepage snapshot: invalid stale payload');
     return null;
   }
+
+  return {
+    data,
+    age,
+  };
+}
+
+export async function readHomepageSnapshotArtifact(
+  db: D1Database,
+  now: number,
+): Promise<{ data: PublicHomepageRenderArtifact; age: number } | null> {
+  const row = await readHomepageSnapshotRow(db);
+  if (!row) return null;
+
+  const age = Math.max(0, now - row.generated_at);
+  if (age > MAX_AGE_SECONDS) return null;
+
+  const parsed = safeJsonParse(row.body_json);
+  if (parsed === null) return null;
+
+  const render = readStoredHomepageSnapshotRender(parsed);
+  if (!render) {
+    console.warn('homepage snapshot: invalid render payload');
+    return null;
+  }
+
+  return {
+    data: render,
+    age,
+  };
+}
+
+export async function readStaleHomepageSnapshotArtifact(
+  db: D1Database,
+  now: number,
+): Promise<{ data: PublicHomepageRenderArtifact; age: number } | null> {
+  const row = await readHomepageSnapshotRow(db);
+  if (!row) return null;
+
+  const age = Math.max(0, now - row.generated_at);
+  if (age > MAX_STALE_SECONDS) return null;
+
+  const parsed = safeJsonParse(row.body_json);
+  if (parsed === null) return null;
+
+  const render = readStoredHomepageSnapshotRender(parsed);
+  if (!render) {
+    console.warn('homepage snapshot: invalid stale render payload');
+    return null;
+  }
+
+  return {
+    data: render,
+    age,
+  };
 }
 
 export async function readHomepageSnapshotGeneratedAt(
@@ -116,7 +597,11 @@ export async function writeHomepageSnapshot(
   now: number,
   payload: PublicHomepageResponse,
 ): Promise<void> {
-  const bodyJson = JSON.stringify(payload);
+  const bodyJson = JSON.stringify({
+    version: 2,
+    data: payload,
+    render: buildHomepageRenderArtifact(payload),
+  } satisfies StoredHomepageSnapshot);
   await db
     .prepare(
       `

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -4,39 +4,34 @@ import {
   publicHomepageResponseSchema,
   type PublicHomepageResponse,
 } from '../schemas/public-homepage';
-import { z } from 'zod';
 
 const SNAPSHOT_KEY = 'homepage';
+const SNAPSHOT_ARTIFACT_KEY = 'homepage:artifact';
 const MAX_AGE_SECONDS = 60;
 const MAX_STALE_SECONDS = 10 * 60;
 const REFRESH_LOCK_NAME = 'snapshot:homepage:refresh';
 const MAX_BOOTSTRAP_MONITORS = 12;
 
-const homepageRenderArtifactSchema = z.object({
-  generated_at: z.number().int().nonnegative(),
-  preload_html: z.string(),
-  snapshot: publicHomepageResponseSchema,
-  meta_title: z.string(),
-  meta_description: z.string(),
-});
+const SPLIT_SNAPSHOT_VERSION = 3;
+const LEGACY_COMBINED_SNAPSHOT_VERSION = 2;
 
-export type PublicHomepageRenderArtifact = z.infer<typeof homepageRenderArtifactSchema>;
-
-type StoredHomepageSnapshot = {
-  version: 2;
-  data: PublicHomepageResponse;
-  render: PublicHomepageRenderArtifact;
+export type PublicHomepageRenderArtifact = {
+  generated_at: number;
+  preload_html: string;
+  snapshot: PublicHomepageResponse;
+  meta_title: string;
+  meta_description: string;
 };
 
-const storedHomepageSnapshotDataSchema = z.object({
-  version: z.literal(2),
-  data: publicHomepageResponseSchema,
-});
+type StoredHomepageDataSnapshot = {
+  version: typeof SPLIT_SNAPSHOT_VERSION;
+  data: PublicHomepageResponse;
+};
 
-const storedHomepageSnapshotRenderSchema = z.object({
-  version: z.literal(2),
-  render: homepageRenderArtifactSchema,
-});
+type StoredHomepageRenderSnapshot = {
+  version: typeof SPLIT_SNAPSHOT_VERSION;
+  render: PublicHomepageRenderArtifact;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -337,9 +332,26 @@ function looksLikeHomepagePayload(value: unknown): value is PublicHomepageRespon
   if (!isRecord(value)) return false;
   return (
     typeof value.generated_at === 'number' &&
+    (value.bootstrap_mode === 'full' || value.bootstrap_mode === 'partial') &&
+    typeof value.monitor_count_total === 'number' &&
     typeof value.site_title === 'string' &&
     Array.isArray(value.monitors) &&
-    Array.isArray(value.active_incidents)
+    Array.isArray(value.active_incidents) &&
+    isRecord(value.summary) &&
+    isRecord(value.banner) &&
+    isRecord(value.maintenance_windows)
+  );
+}
+
+function looksLikeHomepageArtifact(value: unknown): value is PublicHomepageRenderArtifact {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.generated_at === 'number' &&
+    typeof value.preload_html === 'string' &&
+    typeof value.meta_title === 'string' &&
+    typeof value.meta_description === 'string' &&
+    looksLikeHomepagePayload(value.snapshot)
   );
 }
 
@@ -347,13 +359,12 @@ function readStoredHomepageSnapshotData(value: unknown): PublicHomepageResponse 
   if (!isRecord(value)) return null;
 
   const version = value.version;
-  if (version === 2) {
-    const parsed = storedHomepageSnapshotDataSchema.safeParse(value);
-    return parsed.success ? parsed.data.data : null;
+  if (version === SPLIT_SNAPSHOT_VERSION) {
+    return looksLikeHomepagePayload(value.data) ? value.data : null;
   }
 
-  if (!looksLikeHomepagePayload(value)) {
-    return null;
+  if (version === LEGACY_COMBINED_SNAPSHOT_VERSION) {
+    return looksLikeHomepagePayload(value.data) ? value.data : null;
   }
 
   const parsed = publicHomepageResponseSchema.safeParse({
@@ -370,10 +381,12 @@ function readStoredHomepageSnapshotData(value: unknown): PublicHomepageResponse 
 
 function readStoredHomepageSnapshotRender(value: unknown): PublicHomepageRenderArtifact | null {
   if (!isRecord(value)) return null;
-  if (value.version !== 2) return null;
+  const version = value.version;
+  if (version !== SPLIT_SNAPSHOT_VERSION && version !== LEGACY_COMBINED_SNAPSHOT_VERSION) {
+    return null;
+  }
 
-  const parsed = storedHomepageSnapshotRenderSchema.safeParse(value);
-  return parsed.success ? parsed.data.render : null;
+  return looksLikeHomepageArtifact(value.render) ? value.render : null;
 }
 
 function safeJsonParse(text: string): unknown | null {
@@ -386,8 +399,9 @@ function safeJsonParse(text: string): unknown | null {
   }
 }
 
-async function readHomepageSnapshotRow(
+async function readSnapshotRow(
   db: D1Database,
+  key: string,
 ): Promise<{ generated_at: number; body_json: string } | null> {
   try {
     return await db
@@ -398,12 +412,20 @@ async function readHomepageSnapshotRow(
         WHERE key = ?1
       `,
       )
-      .bind(SNAPSHOT_KEY)
+      .bind(key)
       .first<{ generated_at: number; body_json: string }>();
   } catch (err) {
     console.warn('homepage snapshot: read failed', err);
     return null;
   }
+}
+
+async function readHomepageSnapshotRow(db: D1Database) {
+  return readSnapshotRow(db, SNAPSHOT_KEY);
+}
+
+async function readHomepageArtifactSnapshotRow(db: D1Database) {
+  return readSnapshotRow(db, SNAPSHOT_ARTIFACT_KEY);
 }
 
 function isSameMinute(a: number, b: number): boolean {
@@ -476,7 +498,7 @@ export async function readHomepageSnapshotArtifact(
   db: D1Database,
   now: number,
 ): Promise<{ data: PublicHomepageRenderArtifact; age: number } | null> {
-  const row = await readHomepageSnapshotRow(db);
+  const row = (await readHomepageArtifactSnapshotRow(db)) ?? (await readHomepageSnapshotRow(db));
   if (!row) return null;
 
   const age = Math.max(0, now - row.generated_at);
@@ -501,7 +523,7 @@ export async function readStaleHomepageSnapshotArtifact(
   db: D1Database,
   now: number,
 ): Promise<{ data: PublicHomepageRenderArtifact; age: number } | null> {
-  const row = await readHomepageSnapshotRow(db);
+  const row = (await readHomepageArtifactSnapshotRow(db)) ?? (await readHomepageSnapshotRow(db));
   if (!row) return null;
 
   const age = Math.max(0, now - row.generated_at);
@@ -534,24 +556,29 @@ export async function writeHomepageSnapshot(
   now: number,
   payload: PublicHomepageResponse,
 ): Promise<void> {
-  const bodyJson = JSON.stringify({
-    version: 2,
+  const render = buildHomepageRenderArtifact(payload);
+  const dataBodyJson = JSON.stringify({
+    version: SPLIT_SNAPSHOT_VERSION,
     data: payload,
-    render: buildHomepageRenderArtifact(payload),
-  } satisfies StoredHomepageSnapshot);
-  await db
-    .prepare(
-      `
-      INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
-      VALUES (?1, ?2, ?3, ?4)
-      ON CONFLICT(key) DO UPDATE SET
-        generated_at = excluded.generated_at,
-        body_json = excluded.body_json,
-        updated_at = excluded.updated_at
-    `,
-    )
-    .bind(SNAPSHOT_KEY, payload.generated_at, bodyJson, now)
-    .run();
+  } satisfies StoredHomepageDataSnapshot);
+  const renderBodyJson = JSON.stringify({
+    version: SPLIT_SNAPSHOT_VERSION,
+    render,
+  } satisfies StoredHomepageRenderSnapshot);
+
+  const upsertSql = `
+    INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
+    VALUES (?1, ?2, ?3, ?4)
+    ON CONFLICT(key) DO UPDATE SET
+      generated_at = excluded.generated_at,
+      body_json = excluded.body_json,
+      updated_at = excluded.updated_at
+  `;
+
+  await db.batch([
+    db.prepare(upsertSql).bind(SNAPSHOT_KEY, payload.generated_at, dataBodyJson, now),
+    db.prepare(upsertSql).bind(SNAPSHOT_ARTIFACT_KEY, render.generated_at, renderBodyJson, now),
+  ]);
 }
 
 export function applyHomepageCacheHeaders(res: Response, ageSeconds: number): void {

--- a/apps/worker/test/homepage-snapshot.bench.ts
+++ b/apps/worker/test/homepage-snapshot.bench.ts
@@ -3,7 +3,9 @@ import { writeFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 
 import { computePublicHomepagePayload } from '../src/public/homepage';
+import { buildHomepageRenderArtifact } from '../src/snapshots/public-homepage';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
+import pageWorker from '../../web/public/_worker.js';
 
 type Scenario = {
   name: string;
@@ -19,12 +21,30 @@ type Sample = {
   rollupRows: number;
 };
 
+type RootMissScenario = {
+  name: string;
+  monitorCount: number;
+};
+
+type RootMissSample = {
+  elapsedMs: number;
+  artifactKB: number;
+  preloadKB: number;
+  snapshotKB: number;
+};
+
 const BENCH_LABEL = process.env.HOMEPAGE_BENCH_LABEL ?? 'current-working-tree';
 const OUTPUT_PATH = process.env.HOMEPAGE_BENCH_OUTPUT ?? null;
 
 const SCENARIOS: Scenario[] = [
   { name: '1000 monitors / 30 heartbeats / 14 uptime days', monitorCount: 1000, heartbeatPoints: 30, uptimeDays: 14 },
   { name: '5000 monitors / 30 heartbeats / 14 uptime days', monitorCount: 5000, heartbeatPoints: 30, uptimeDays: 14 },
+];
+
+const ROOT_MISS_SCENARIOS: RootMissScenario[] = [
+  { name: '50 monitors', monitorCount: 50 },
+  { name: '100 monitors', monitorCount: 100 },
+  { name: '250 monitors', monitorCount: 250 },
 ];
 
 function parsePositiveIntEnv(name: string, fallback: number): number {
@@ -182,9 +202,154 @@ function summarize(scenario: Scenario, samples: Sample[]) {
   };
 }
 
+function buildSyntheticHomepagePayload(
+  monitorCount: number,
+  heartbeatPoints: number,
+  uptimeDays: number,
+  now: number,
+) {
+  return {
+    generated_at: now,
+    bootstrap_mode: 'full' as const,
+    monitor_count_total: monitorCount,
+    site_title: 'Status Hub',
+    site_description: 'Production services',
+    site_locale: 'en' as const,
+    site_timezone: 'UTC',
+    uptime_rating_level: 3 as const,
+    overall_status: 'up' as const,
+    banner: {
+      source: 'monitors' as const,
+      status: 'operational' as const,
+      title: 'All Systems Operational',
+      down_ratio: null,
+    },
+    summary: {
+      up: monitorCount,
+      down: 0,
+      maintenance: 0,
+      paused: 0,
+      unknown: 0,
+    },
+    monitors: Array.from({ length: monitorCount }, (_, monitorIndex) => ({
+      id: monitorIndex + 1,
+      name: `Monitor ${monitorIndex + 1}`,
+      type: 'http' as const,
+      group_name: monitorIndex % 2 === 0 ? 'Core' : 'Edge',
+      status: 'up' as const,
+      is_stale: false,
+      last_checked_at: now - 30,
+      heartbeat_strip: {
+        checked_at: Array.from({ length: heartbeatPoints }, (_, pointIndex) => now - (pointIndex + 1) * 60),
+        status_codes: 'u'.repeat(heartbeatPoints),
+        latency_ms: Array.from(
+          { length: heartbeatPoints },
+          (_, pointIndex) => 40 + ((monitorIndex + pointIndex) % 50),
+        ),
+      },
+      uptime_30d: { uptime_pct: 100 },
+      uptime_day_strip: {
+        day_start_at: Array.from(
+          { length: uptimeDays },
+          (_, dayIndex) => now - (uptimeDays - dayIndex) * 86_400,
+        ),
+        downtime_sec: Array.from({ length: uptimeDays }, () => 0),
+        unknown_sec: Array.from({ length: uptimeDays }, () => 0),
+        uptime_pct_milli: Array.from({ length: uptimeDays }, () => 100_000),
+      },
+    })),
+    active_incidents: [],
+    maintenance_windows: {
+      active: [],
+      upcoming: [],
+    },
+    resolved_incident_preview: null,
+    maintenance_history_preview: null,
+  };
+}
+
+async function runOneRootMiss(scenario: RootMissScenario): Promise<RootMissSample> {
+  const now = 1_728_000_000;
+  const artifact = buildHomepageRenderArtifact(
+    buildSyntheticHomepagePayload(scenario.monitorCount, 30, 14, now),
+  );
+
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: {
+      default: {
+        match: async () => null,
+        put: async () => undefined,
+      },
+    },
+  });
+
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(artifact), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof fetch;
+
+  try {
+    const started = performance.now();
+    const response = await pageWorker.fetch(
+      new Request('https://status.example.com/', {
+        headers: { Accept: 'text/html' },
+      }),
+      {
+        UPTIMER_API_ORIGIN: 'https://api.example.com',
+        ASSETS: {
+          fetch: async () =>
+            new Response('<!doctype html><html><head><title>Uptimer</title></head><body><div id="root"></div></body></html>', {
+              status: 200,
+              headers: { 'Content-Type': 'text/html; charset=utf-8' },
+            }),
+        },
+      },
+      { waitUntil: () => undefined } as ExecutionContext,
+    );
+    await response.text();
+    const elapsedMs = performance.now() - started;
+
+    return {
+      elapsedMs,
+      artifactKB: Number((JSON.stringify(artifact).length / 1024).toFixed(1)),
+      preloadKB: Number((artifact.preload_html.length / 1024).toFixed(1)),
+      snapshotKB: Number((JSON.stringify(artifact.snapshot).length / 1024).toFixed(1)),
+    };
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: originalCaches,
+    });
+  }
+}
+
+function summarizeRootMiss(scenario: RootMissScenario, samples: RootMissSample[]) {
+  const elapsed = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const totalElapsed = elapsed.reduce((sum, value) => sum + value, 0);
+  const first = samples[0];
+
+  return {
+    scenario: scenario.name,
+    runs: samples.length,
+    meanMs: Number((totalElapsed / samples.length).toFixed(3)),
+    medianMs: Number(percentile(elapsed, 0.5).toFixed(3)),
+    p95Ms: Number(percentile(elapsed, 0.95).toFixed(3)),
+    artifactKB: first?.artifactKB ?? 0,
+    preloadKB: first?.preloadKB ?? 0,
+    snapshotKB: first?.snapshotKB ?? 0,
+  };
+}
+
 describe('homepage snapshot benchmark', () => {
   it('measures homepage snapshot compute cost', async () => {
     const rows = [];
+    const rootMissRows = [];
 
     for (const scenario of SCENARIOS) {
       for (let index = 0; index < WARMUP_RUNS; index += 1) {
@@ -199,6 +364,19 @@ describe('homepage snapshot benchmark', () => {
       rows.push(summarize(scenario, samples));
     }
 
+    for (const scenario of ROOT_MISS_SCENARIOS) {
+      for (let index = 0; index < WARMUP_RUNS; index += 1) {
+        await runOneRootMiss(scenario);
+      }
+
+      const samples: RootMissSample[] = [];
+      for (let index = 0; index < MEASURE_RUNS; index += 1) {
+        samples.push(await runOneRootMiss(scenario));
+      }
+
+      rootMissRows.push(summarizeRootMiss(scenario, samples));
+    }
+
     console.log('Homepage snapshot benchmark');
     console.log(`Label: ${BENCH_LABEL}`);
     if (process.env.HOMEPAGE_BENCH_RUNS || process.env.HOMEPAGE_BENCH_WARMUPS) {
@@ -208,9 +386,16 @@ describe('homepage snapshot benchmark', () => {
     }
     console.log('');
     console.table(rows);
+    console.log('');
+    console.log('Pages homepage root miss benchmark');
+    console.table(rootMissRows);
 
     if (OUTPUT_PATH) {
-      await writeFile(OUTPUT_PATH, JSON.stringify(rows, null, 2), 'utf8');
+      await writeFile(
+        OUTPUT_PATH,
+        JSON.stringify({ snapshotCompute: rows, rootMiss: rootMissRows }, null, 2),
+        'utf8',
+      );
       console.log(`Wrote raw benchmark data to ${OUTPUT_PATH}`);
     }
   });

--- a/apps/worker/test/homepage-snapshot.bench.ts
+++ b/apps/worker/test/homepage-snapshot.bench.ts
@@ -3,7 +3,10 @@ import { writeFile } from 'node:fs/promises';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
-import { computePublicHomepagePayload } from '../src/public/homepage';
+import {
+  computePublicHomepageArtifactPayload,
+  computePublicHomepagePayload,
+} from '../src/public/homepage';
 import type { Env } from '../src/env';
 import { handleError, handleNotFound } from '../src/middleware/errors';
 import { publicRoutes } from '../src/routes/public';
@@ -139,7 +142,21 @@ function createDbForScenario(scenario: Scenario, now: number) {
   const handlers: FakeD1QueryHandler[] = [
     {
       match: 'from monitors m',
-      all: () => rows.monitors,
+      all: (args, normalizedSql) =>
+        normalizedSql.includes('limit ?1')
+          ? rows.monitors.slice(0, Number(args[0] ?? rows.monitors.length))
+          : rows.monitors,
+    },
+    {
+      match: 'with active_maintenance',
+      first: () => ({
+        monitor_count_total: rows.monitors.length,
+        up: rows.monitors.length,
+        down: 0,
+        maintenance: 0,
+        paused: 0,
+        unknown: 0,
+      }),
     },
     {
       match: 'select distinct mwm.monitor_id',
@@ -195,6 +212,23 @@ async function runOne(scenario: Scenario): Promise<Sample> {
   const elapsedMs = performance.now() - started;
 
   expect(payload.monitors).toHaveLength(scenario.monitorCount);
+
+  return {
+    elapsedMs,
+    ...rowCounts,
+  };
+}
+
+async function runOneArtifactCompute(scenario: Scenario): Promise<Sample> {
+  const now = 1_728_000_000;
+  const { db, rowCounts } = createDbForScenario(scenario, now);
+
+  const started = performance.now();
+  const payload = await computePublicHomepageArtifactPayload(db, now);
+  const elapsedMs = performance.now() - started;
+
+  expect(payload.monitors.length).toBeLessThanOrEqual(12);
+  expect(payload.monitor_count_total).toBe(scenario.monitorCount);
 
   return {
     elapsedMs,
@@ -369,7 +403,7 @@ function summarizeRootMiss(scenario: RootMissScenario, samples: RootMissSample[]
 }
 
 async function runOneRouteRead(scenario: RouteReadScenario): Promise<RouteReadSample> {
-  const now = 1_728_000_000;
+  const now = Math.floor(Date.now() / 1000);
   const payload = buildSyntheticHomepagePayload(scenario.monitorCount, 30, 14, now);
   const artifact = buildHomepageRenderArtifact(payload);
   const bodyJson = scenario.endpoint === 'homepage' ? JSON.stringify(payload) : JSON.stringify(artifact);
@@ -414,12 +448,13 @@ async function runOneRouteRead(scenario: RouteReadScenario): Promise<RouteReadSa
       env,
       { waitUntil: () => undefined } as ExecutionContext,
     );
-    await response.text();
+    const responseBody = await response.text();
     const elapsedMs = performance.now() - started;
+    expect(response.ok).toBe(true);
 
     return {
       elapsedMs,
-      bodyKB: Number((bodyJson.length / 1024).toFixed(1)),
+      bodyKB: Number((responseBody.length / 1024).toFixed(1)),
     };
   } finally {
     Object.defineProperty(globalThis, 'caches', {
@@ -447,6 +482,7 @@ function summarizeRouteRead(scenario: RouteReadScenario, samples: RouteReadSampl
 describe('homepage snapshot benchmark', () => {
   it('measures homepage snapshot compute cost', async () => {
     const rows = [];
+    const artifactRows = [];
     const rootMissRows = [];
     const routeReadRows = [];
 
@@ -461,6 +497,19 @@ describe('homepage snapshot benchmark', () => {
       }
 
       rows.push(summarize(scenario, samples));
+    }
+
+    for (const scenario of SCENARIOS) {
+      for (let index = 0; index < WARMUP_RUNS; index += 1) {
+        await runOneArtifactCompute(scenario);
+      }
+
+      const samples: Sample[] = [];
+      for (let index = 0; index < MEASURE_RUNS; index += 1) {
+        samples.push(await runOneArtifactCompute(scenario));
+      }
+
+      artifactRows.push(summarize(scenario, samples));
     }
 
     for (const scenario of ROOT_MISS_SCENARIOS) {
@@ -499,6 +548,9 @@ describe('homepage snapshot benchmark', () => {
     console.log('');
     console.table(rows);
     console.log('');
+    console.log('Homepage artifact bootstrap compute benchmark');
+    console.table(artifactRows);
+    console.log('');
     console.log('Pages homepage root miss benchmark');
     console.table(rootMissRows);
     console.log('');
@@ -508,7 +560,16 @@ describe('homepage snapshot benchmark', () => {
     if (OUTPUT_PATH) {
       await writeFile(
         OUTPUT_PATH,
-        JSON.stringify({ snapshotCompute: rows, rootMiss: rootMissRows, routeRead: routeReadRows }, null, 2),
+        JSON.stringify(
+          {
+            snapshotCompute: rows,
+            artifactCompute: artifactRows,
+            rootMiss: rootMissRows,
+            routeRead: routeReadRows,
+          },
+          null,
+          2,
+        ),
         'utf8',
       );
       console.log(`Wrote raw benchmark data to ${OUTPUT_PATH}`);

--- a/apps/worker/test/homepage-snapshot.bench.ts
+++ b/apps/worker/test/homepage-snapshot.bench.ts
@@ -1,8 +1,12 @@
 import { writeFile } from 'node:fs/promises';
 
+import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
 import { computePublicHomepagePayload } from '../src/public/homepage';
+import type { Env } from '../src/env';
+import { handleError, handleNotFound } from '../src/middleware/errors';
+import { publicRoutes } from '../src/routes/public';
 import { buildHomepageRenderArtifact } from '../src/snapshots/public-homepage';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 import pageWorker from '../../web/public/_worker.js';
@@ -33,6 +37,17 @@ type RootMissSample = {
   snapshotKB: number;
 };
 
+type RouteReadScenario = {
+  name: string;
+  endpoint: 'homepage' | 'homepage-artifact';
+  monitorCount: number;
+};
+
+type RouteReadSample = {
+  elapsedMs: number;
+  bodyKB: number;
+};
+
 const BENCH_LABEL = process.env.HOMEPAGE_BENCH_LABEL ?? 'current-working-tree';
 const OUTPUT_PATH = process.env.HOMEPAGE_BENCH_OUTPUT ?? null;
 
@@ -45,6 +60,13 @@ const ROOT_MISS_SCENARIOS: RootMissScenario[] = [
   { name: '50 monitors', monitorCount: 50 },
   { name: '100 monitors', monitorCount: 100 },
   { name: '250 monitors', monitorCount: 250 },
+];
+
+const ROUTE_READ_SCENARIOS: RouteReadScenario[] = [
+  { name: 'homepage / 250 monitors', endpoint: 'homepage', monitorCount: 250 },
+  { name: 'homepage / 1000 monitors', endpoint: 'homepage', monitorCount: 1000 },
+  { name: 'homepage-artifact / 250 monitors', endpoint: 'homepage-artifact', monitorCount: 250 },
+  { name: 'homepage-artifact / 1000 monitors', endpoint: 'homepage-artifact', monitorCount: 1000 },
 ];
 
 function parsePositiveIntEnv(name: string, fallback: number): number {
@@ -346,10 +368,87 @@ function summarizeRootMiss(scenario: RootMissScenario, samples: RootMissSample[]
   };
 }
 
+async function runOneRouteRead(scenario: RouteReadScenario): Promise<RouteReadSample> {
+  const now = 1_728_000_000;
+  const payload = buildSyntheticHomepagePayload(scenario.monitorCount, 30, 14, now);
+  const artifact = buildHomepageRenderArtifact(payload);
+  const bodyJson = scenario.endpoint === 'homepage' ? JSON.stringify(payload) : JSON.stringify(artifact);
+  const key = scenario.endpoint === 'homepage' ? 'homepage' : 'homepage:artifact';
+  const originalCaches = globalThis.caches;
+
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: {
+      open: async () => ({
+        match: async () => undefined,
+        put: async () => undefined,
+      }),
+    },
+  });
+
+  try {
+    const env = {
+      DB: createFakeD1Database([
+        {
+          match: 'from public_snapshots',
+          first: (args) =>
+            args[0] === key
+              ? {
+                  generated_at: now,
+                  body_json: bodyJson,
+                }
+              : null,
+        },
+      ]),
+      ADMIN_TOKEN: 'test-admin-token',
+    } as unknown as Env;
+
+    const app = new Hono<{ Bindings: Env }>();
+    app.onError(handleError);
+    app.notFound(handleNotFound);
+    app.route('/api/v1/public', publicRoutes);
+
+    const started = performance.now();
+    const response = await app.fetch(
+      new Request(`https://status.example.com/api/v1/public/${scenario.endpoint}`),
+      env,
+      { waitUntil: () => undefined } as ExecutionContext,
+    );
+    await response.text();
+    const elapsedMs = performance.now() - started;
+
+    return {
+      elapsedMs,
+      bodyKB: Number((bodyJson.length / 1024).toFixed(1)),
+    };
+  } finally {
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: originalCaches,
+    });
+  }
+}
+
+function summarizeRouteRead(scenario: RouteReadScenario, samples: RouteReadSample[]) {
+  const elapsed = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const totalElapsed = elapsed.reduce((sum, value) => sum + value, 0);
+  const first = samples[0];
+
+  return {
+    scenario: scenario.name,
+    runs: samples.length,
+    meanMs: Number((totalElapsed / samples.length).toFixed(3)),
+    medianMs: Number(percentile(elapsed, 0.5).toFixed(3)),
+    p95Ms: Number(percentile(elapsed, 0.95).toFixed(3)),
+    bodyKB: first?.bodyKB ?? 0,
+  };
+}
+
 describe('homepage snapshot benchmark', () => {
   it('measures homepage snapshot compute cost', async () => {
     const rows = [];
     const rootMissRows = [];
+    const routeReadRows = [];
 
     for (const scenario of SCENARIOS) {
       for (let index = 0; index < WARMUP_RUNS; index += 1) {
@@ -377,6 +476,19 @@ describe('homepage snapshot benchmark', () => {
       rootMissRows.push(summarizeRootMiss(scenario, samples));
     }
 
+    for (const scenario of ROUTE_READ_SCENARIOS) {
+      for (let index = 0; index < WARMUP_RUNS; index += 1) {
+        await runOneRouteRead(scenario);
+      }
+
+      const samples: RouteReadSample[] = [];
+      for (let index = 0; index < MEASURE_RUNS; index += 1) {
+        samples.push(await runOneRouteRead(scenario));
+      }
+
+      routeReadRows.push(summarizeRouteRead(scenario, samples));
+    }
+
     console.log('Homepage snapshot benchmark');
     console.log(`Label: ${BENCH_LABEL}`);
     if (process.env.HOMEPAGE_BENCH_RUNS || process.env.HOMEPAGE_BENCH_WARMUPS) {
@@ -389,11 +501,14 @@ describe('homepage snapshot benchmark', () => {
     console.log('');
     console.log('Pages homepage root miss benchmark');
     console.table(rootMissRows);
+    console.log('');
+    console.log('Worker homepage route read benchmark');
+    console.table(routeReadRows);
 
     if (OUTPUT_PATH) {
       await writeFile(
         OUTPUT_PATH,
-        JSON.stringify({ snapshotCompute: rows, rootMiss: rootMissRows }, null, 2),
+        JSON.stringify({ snapshotCompute: rows, rootMiss: rootMissRows, routeRead: routeReadRows }, null, 2),
         'utf8',
       );
       console.log(`Wrote raw benchmark data to ${OUTPUT_PATH}`);

--- a/apps/worker/test/pages-homepage-worker.test.ts
+++ b/apps/worker/test/pages-homepage-worker.test.ts
@@ -101,10 +101,8 @@ describe('pages homepage worker', () => {
       new Response(
         JSON.stringify({
           generated_at: 1_728_000_000,
-          style_tag: '<style id="uptimer-preload-style">body{}</style>',
           preload_html: '<div id="uptimer-preload"><main>artifact preload</main></div>',
-          bootstrap_script:
-            '<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__={"site_title":"Status Hub"};</script>',
+          snapshot: { site_title: 'Status Hub' },
           meta_title: 'Status Hub',
           meta_description: 'Production',
         }),

--- a/apps/worker/test/pages-homepage-worker.test.ts
+++ b/apps/worker/test/pages-homepage-worker.test.ts
@@ -94,31 +94,19 @@ describe('pages homepage worker', () => {
     expect(await res.text()).toContain('fallback homepage');
   });
 
-  it('injects homepage bootstrap data and updates both html caches on success', async () => {
+  it('injects the precomputed homepage artifact and updates both html caches on success', async () => {
     const { put } = installDefaultCacheMock(() => undefined);
     const env = makeEnv();
     globalThis.fetch = vi.fn(async () =>
       new Response(
         JSON.stringify({
           generated_at: 1_728_000_000,
-          site_title: 'Status Hub',
-          site_description: 'Production',
-          site_locale: 'auto',
-          site_timezone: 'UTC',
-          uptime_rating_level: 3,
-          overall_status: 'up',
-          banner: {
-            source: 'monitors',
-            status: 'operational',
-            title: 'All Systems Operational',
-            down_ratio: null,
-          },
-          summary: { up: 1, down: 0, maintenance: 0, paused: 0, unknown: 0 },
-          monitors: [],
-          active_incidents: [],
-          maintenance_windows: { active: [], upcoming: [] },
-          resolved_incident_preview: null,
-          maintenance_history_preview: null,
+          style_tag: '<style id="uptimer-preload-style">body{}</style>',
+          preload_html: '<div id="uptimer-preload"><main>artifact preload</main></div>',
+          bootstrap_script:
+            '<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__={"site_title":"Status Hub"};</script>',
+          meta_title: 'Status Hub',
+          meta_description: 'Production',
         }),
         { status: 200 },
       ),
@@ -135,6 +123,7 @@ describe('pages homepage worker', () => {
     const html = await res.text();
     expect(html).toContain('__UPTIMER_INITIAL_HOMEPAGE__');
     expect(html).not.toContain('__UPTIMER_INITIAL_STATUS__');
+    expect(html).toContain('artifact preload');
     expect(put).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/worker/test/public-homepage-compute.test.ts
+++ b/apps/worker/test/public-homepage-compute.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { computePublicHomepagePayload } from '../src/public/homepage';
+import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
+
+describe('computePublicHomepagePayload', () => {
+  it('builds compact homepage monitor cards with the expected strips and uptime summary', async () => {
+    const now = 1_728_000_000;
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: 'from monitors m',
+        all: () => [
+          {
+            id: 1,
+            name: 'API',
+            type: 'http',
+            group_name: 'Core',
+            group_sort_order: 0,
+            sort_order: 0,
+            interval_sec: 60,
+            created_at: now - 40 * 86_400,
+            state_status: 'up',
+            last_checked_at: now - 30,
+          },
+        ],
+      },
+      {
+        match: 'select distinct mwm.monitor_id',
+        all: () => [],
+      },
+      {
+        match: (sql) => sql.startsWith('select value from settings where key = ?1'),
+        first: () => ({ value: '4' }),
+      },
+      {
+        match: 'row_number() over',
+        all: () => [
+          {
+            monitor_id: 1,
+            checked_at: now - 60,
+            status: 'up',
+            latency_ms: 42,
+          },
+          {
+            monitor_id: 1,
+            checked_at: now - 120,
+            status: 'down',
+            latency_ms: null,
+          },
+        ],
+      },
+      {
+        match: 'from monitor_daily_rollups',
+        all: () => [
+          {
+            monitor_id: 1,
+            day_start_at: now - 2 * 86_400,
+            total_sec: 86_400,
+            downtime_sec: 0,
+            unknown_sec: 0,
+            uptime_sec: 86_400,
+          },
+          {
+            monitor_id: 1,
+            day_start_at: now - 86_400,
+            total_sec: 86_400,
+            downtime_sec: 60,
+            unknown_sec: 0,
+            uptime_sec: 86_340,
+          },
+        ],
+      },
+      {
+        match: (sql) => sql.startsWith('select key, value from settings'),
+        all: () => [
+          { key: 'site_title', value: 'Status Hub' },
+          { key: 'site_description', value: 'Production services' },
+          { key: 'site_locale', value: 'en' },
+          { key: 'site_timezone', value: 'UTC' },
+        ],
+      },
+      {
+        match: 'from incidents',
+        all: () => [],
+      },
+      {
+        match: 'from maintenance_windows',
+        all: () => [],
+      },
+    ];
+
+    const payload = await computePublicHomepagePayload(createFakeD1Database(handlers), now);
+
+    expect(payload.generated_at).toBe(now);
+    expect(payload.bootstrap_mode).toBe('full');
+    expect(payload.monitor_count_total).toBe(1);
+    expect(payload.uptime_rating_level).toBe(4);
+    expect(payload.summary).toEqual({
+      up: 1,
+      down: 0,
+      maintenance: 0,
+      paused: 0,
+      unknown: 0,
+    });
+    expect(payload.banner).toEqual({
+      source: 'monitors',
+      status: 'operational',
+      title: 'All Systems Operational',
+    });
+
+    expect(payload.monitors).toHaveLength(1);
+    expect(payload.monitors[0]).toMatchObject({
+      id: 1,
+      name: 'API',
+      type: 'http',
+      group_name: 'Core',
+      status: 'up',
+      is_stale: false,
+      last_checked_at: now - 30,
+      heartbeat_strip: {
+        checked_at: [now - 60, now - 120],
+        status_codes: 'ud',
+        latency_ms: [42, null],
+      },
+      uptime_day_strip: {
+        day_start_at: [now - 2 * 86_400, now - 86_400],
+        downtime_sec: [0, 60],
+        unknown_sec: [0, 0],
+        uptime_pct_milli: [100_000, 99_931],
+      },
+    });
+    expect(payload.monitors[0]?.uptime_30d?.uptime_pct).toBeCloseTo(99.965, 3);
+  });
+});

--- a/apps/worker/test/public-homepage-compute.test.ts
+++ b/apps/worker/test/public-homepage-compute.test.ts
@@ -30,10 +30,6 @@ describe('computePublicHomepagePayload', () => {
         all: () => [],
       },
       {
-        match: (sql) => sql.startsWith('select value from settings where key = ?1'),
-        first: () => ({ value: '4' }),
-      },
-      {
         match: 'row_number() over',
         all: () => [
           {
@@ -78,6 +74,7 @@ describe('computePublicHomepagePayload', () => {
           { key: 'site_description', value: 'Production services' },
           { key: 'site_locale', value: 'en' },
           { key: 'site_timezone', value: 'UTC' },
+          { key: 'uptime_rating_level', value: '4' },
         ],
       },
       {

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -122,9 +122,8 @@ describe('public homepage route', () => {
       data: payload,
       render: {
         generated_at: payload.generated_at,
-        style_tag: '<style id="uptimer-preload-style"></style>',
         preload_html: '<div id="uptimer-preload">hello</div>',
-        bootstrap_script: '<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__={};</script>',
+        snapshot: payload,
         meta_title: 'Uptimer',
         meta_description: 'All Systems Operational',
       },
@@ -149,9 +148,8 @@ describe('public homepage route', () => {
     const payload = samplePayload(190);
     const render = {
       generated_at: payload.generated_at,
-      style_tag: '<style id="uptimer-preload-style"></style>',
       preload_html: '<div id="uptimer-preload">hello</div>',
-      bootstrap_script: '<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__={};</script>',
+      snapshot: payload,
       meta_title: 'Uptimer',
       meta_description: 'All Systems Operational',
     };

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
+vi.mock('../src/monitor/http', () => ({
+  runHttpCheck: vi.fn(),
+}));
+vi.mock('../src/monitor/tcp', () => ({
+  runTcpCheck: vi.fn(),
+}));
+
 import type { Env } from '../src/env';
 import { handleError, handleNotFound } from '../src/middleware/errors';
+import worker from '../src/index';
 import { publicRoutes } from '../src/routes/public';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -56,6 +64,25 @@ async function requestHomepageArtifact(handlers: FakeD1QueryHandler[]) {
 
   return app.fetch(
     new Request('https://status.example.com/api/v1/public/homepage-artifact'),
+    env,
+    { waitUntil: vi.fn() } as unknown as ExecutionContext,
+  );
+}
+
+async function requestHomepageViaApp(
+  path: '/api/v1/public/homepage' | '/api/v1/public/homepage-artifact',
+  handlers: FakeD1QueryHandler[],
+  origin = 'https://status-web.example.com',
+) {
+  const env = {
+    DB: createFakeD1Database(handlers),
+    ADMIN_TOKEN: 'test-admin-token',
+  } as unknown as Env;
+
+  return worker.fetch(
+    new Request(`https://status.example.com${path}`, {
+      headers: { Origin: origin },
+    }),
     env,
     { waitUntil: vi.fn() } as unknown as ExecutionContext,
   );
@@ -196,6 +223,103 @@ describe('public homepage route', () => {
     expect(await res.json()).toEqual(render);
   });
 
+  it('preserves app-level CORS headers for homepage snapshot responses', async () => {
+    const payload = samplePayload(190);
+    vi.spyOn(Date, 'now').mockReturnValue(200_000);
+
+    const res = await requestHomepageViaApp('/api/v1/public/homepage', [
+      {
+        match: 'from public_snapshots',
+        first: (args) =>
+          args[0] === 'homepage'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify(payload),
+              }
+            : null,
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://status-web.example.com',
+    );
+    expect(res.headers.get('Vary')).toContain('Origin');
+  });
+
+  it('preserves app-level CORS headers for homepage artifact responses', async () => {
+    const payload = samplePayload(190);
+    const render = {
+      generated_at: payload.generated_at,
+      preload_html: '<div id="uptimer-preload">hello</div>',
+      snapshot: payload,
+      meta_title: 'Uptimer',
+      meta_description: 'All Systems Operational',
+    };
+    vi.spyOn(Date, 'now').mockReturnValue(200_000);
+
+    const res = await requestHomepageViaApp('/api/v1/public/homepage-artifact', [
+      {
+        match: 'from public_snapshots',
+        first: (args) =>
+          args[0] === 'homepage:artifact'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify(render),
+              }
+            : null,
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://status-web.example.com',
+    );
+    expect(res.headers.get('Vary')).toContain('Origin');
+  });
+
+  it('partitions cached homepage responses by Origin when app-level CORS reflection is enabled', async () => {
+    const payload = samplePayload(190);
+    const dbReads: string[] = [];
+    vi.spyOn(Date, 'now').mockReturnValue(200_000);
+
+    const handlers: FakeD1QueryHandler[] = [
+      {
+        match: 'from public_snapshots',
+        first: (args) => {
+          dbReads.push(String(args[0]));
+          return args[0] === 'homepage'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify(payload),
+              }
+            : null;
+        },
+      },
+    ];
+
+    const first = await requestHomepageViaApp(
+      '/api/v1/public/homepage',
+      handlers,
+      'https://one.example.com',
+    );
+    const second = await requestHomepageViaApp(
+      '/api/v1/public/homepage',
+      handlers,
+      'https://two.example.com',
+    );
+    const third = await requestHomepageViaApp(
+      '/api/v1/public/homepage',
+      handlers,
+      'https://one.example.com',
+    );
+
+    expect(first.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
+    expect(second.headers.get('Access-Control-Allow-Origin')).toBe('https://two.example.com');
+    expect(third.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
+    expect(dbReads).toEqual(['homepage', 'homepage']);
+  });
+
   it('serves a bounded stale homepage snapshot instead of computing in-request', async () => {
     const payload = samplePayload(100);
     vi.spyOn(Date, 'now').mockReturnValue(200_000);
@@ -215,6 +339,110 @@ describe('public homepage route', () => {
     expect(res.headers.get('Cache-Control')).toBe(
       'public, max-age=0, stale-while-revalidate=0, stale-if-error=0',
     );
+  });
+
+  it('falls back to the fresh public status snapshot when the full homepage snapshot is missing', async () => {
+    const now = 200;
+    vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+
+    const res = await requestHomepage([
+      {
+        match: 'from public_snapshots',
+        first: (args) =>
+          args[0] === 'status'
+            ? {
+                generated_at: 190,
+                body_json: JSON.stringify({
+                  generated_at: 190,
+                  site_title: 'Status Hub',
+                  site_description: 'Production services',
+                  site_locale: 'en',
+                  site_timezone: 'UTC',
+                  uptime_rating_level: 4,
+                  overall_status: 'up',
+                  banner: {
+                    source: 'monitors',
+                    status: 'operational',
+                    title: 'All Systems Operational',
+                    down_ratio: null,
+                  },
+                  summary: {
+                    up: 1,
+                    down: 0,
+                    maintenance: 0,
+                    paused: 0,
+                    unknown: 0,
+                  },
+                  monitors: [
+                    {
+                      id: 1,
+                      name: 'API',
+                      type: 'http',
+                      group_name: null,
+                      group_sort_order: 0,
+                      sort_order: 0,
+                      uptime_rating_level: 4,
+                      status: 'up',
+                      is_stale: false,
+                      last_checked_at: 180,
+                      last_latency_ms: 42,
+                      heartbeats: [{ checked_at: 180, status: 'up', latency_ms: 42 }],
+                      uptime_30d: {
+                        range_start_at: 0,
+                        range_end_at: 190,
+                        total_sec: 190,
+                        downtime_sec: 0,
+                        unknown_sec: 0,
+                        uptime_sec: 190,
+                        uptime_pct: 100,
+                      },
+                      uptime_days: [
+                        {
+                          day_start_at: 0,
+                          total_sec: 190,
+                          downtime_sec: 0,
+                          unknown_sec: 0,
+                          uptime_sec: 190,
+                          uptime_pct: 100,
+                        },
+                      ],
+                    },
+                  ],
+                  active_incidents: [],
+                  maintenance_windows: {
+                    active: [],
+                    upcoming: [],
+                  },
+                }),
+              }
+            : null,
+      },
+      {
+        match: 'from incidents',
+        all: () => [],
+      },
+      {
+        match: 'from maintenance_windows',
+        all: () => [],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      generated_at: 190,
+      monitor_count_total: 1,
+      uptime_rating_level: 4,
+      monitors: [
+        {
+          id: 1,
+          heartbeat_strip: {
+            checked_at: [180],
+            status_codes: 'u',
+            latency_ms: [42],
+          },
+        },
+      ],
+    });
   });
 
   it('returns 503 when no homepage snapshot is available', async () => {

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -43,9 +43,29 @@ async function requestHomepage(handlers: FakeD1QueryHandler[]) {
   );
 }
 
+async function requestHomepageArtifact(handlers: FakeD1QueryHandler[]) {
+  const env = {
+    DB: createFakeD1Database(handlers),
+    ADMIN_TOKEN: 'test-admin-token',
+  } as unknown as Env;
+
+  const app = new Hono<{ Bindings: Env }>();
+  app.onError(handleError);
+  app.notFound(handleNotFound);
+  app.route('/api/v1/public', publicRoutes);
+
+  return app.fetch(
+    new Request('https://status.example.com/api/v1/public/homepage-artifact'),
+    env,
+    { waitUntil: vi.fn() } as unknown as ExecutionContext,
+  );
+}
+
 function samplePayload(now = 1_728_000_000) {
   return {
     generated_at: now,
+    bootstrap_mode: 'full',
+    monitor_count_total: 0,
     site_title: 'Uptimer',
     site_description: '',
     site_locale: 'auto',
@@ -97,6 +117,18 @@ describe('public homepage route', () => {
 
   it('serves a fresh homepage snapshot without live compute', async () => {
     const payload = samplePayload(190);
+    const stored = {
+      version: 2,
+      data: payload,
+      render: {
+        generated_at: payload.generated_at,
+        style_tag: '<style id="uptimer-preload-style"></style>',
+        preload_html: '<div id="uptimer-preload">hello</div>',
+        bootstrap_script: '<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__={};</script>',
+        meta_title: 'Uptimer',
+        meta_description: 'All Systems Operational',
+      },
+    };
     vi.spyOn(Date, 'now').mockReturnValue(200_000);
 
     const res = await requestHomepage([
@@ -104,13 +136,43 @@ describe('public homepage route', () => {
         match: 'from public_snapshots',
         first: () => ({
           generated_at: payload.generated_at,
-          body_json: JSON.stringify(payload),
+          body_json: JSON.stringify(stored),
         }),
       },
     ]);
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual(payload);
+  });
+
+  it('serves homepage render artifacts from the same snapshot row', async () => {
+    const payload = samplePayload(190);
+    const render = {
+      generated_at: payload.generated_at,
+      style_tag: '<style id="uptimer-preload-style"></style>',
+      preload_html: '<div id="uptimer-preload">hello</div>',
+      bootstrap_script: '<script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__={};</script>',
+      meta_title: 'Uptimer',
+      meta_description: 'All Systems Operational',
+    };
+    vi.spyOn(Date, 'now').mockReturnValue(200_000);
+
+    const res = await requestHomepageArtifact([
+      {
+        match: 'from public_snapshots',
+        first: () => ({
+          generated_at: payload.generated_at,
+          body_json: JSON.stringify({
+            version: 2,
+            data: payload,
+            render,
+          }),
+        }),
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(render);
   });
 
   it('serves a bounded stale homepage snapshot instead of computing in-request', async () => {

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -118,25 +118,21 @@ describe('public homepage route', () => {
   it('serves a fresh homepage snapshot without live compute', async () => {
     const payload = samplePayload(190);
     const stored = {
-      version: 2,
+      version: 3,
       data: payload,
-      render: {
-        generated_at: payload.generated_at,
-        preload_html: '<div id="uptimer-preload">hello</div>',
-        snapshot: payload,
-        meta_title: 'Uptimer',
-        meta_description: 'All Systems Operational',
-      },
     };
     vi.spyOn(Date, 'now').mockReturnValue(200_000);
 
     const res = await requestHomepage([
       {
         match: 'from public_snapshots',
-        first: () => ({
-          generated_at: payload.generated_at,
-          body_json: JSON.stringify(stored),
-        }),
+        first: (args) =>
+          args[0] === 'homepage'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify(stored),
+              }
+            : null,
       },
     ]);
 
@@ -144,7 +140,7 @@ describe('public homepage route', () => {
     expect(await res.json()).toEqual(payload);
   });
 
-  it('serves homepage render artifacts from the same snapshot row', async () => {
+  it('serves homepage render artifacts from the artifact snapshot row', async () => {
     const payload = samplePayload(190);
     const render = {
       generated_at: payload.generated_at,
@@ -158,14 +154,48 @@ describe('public homepage route', () => {
     const res = await requestHomepageArtifact([
       {
         match: 'from public_snapshots',
-        first: () => ({
-          generated_at: payload.generated_at,
-          body_json: JSON.stringify({
-            version: 2,
-            data: payload,
-            render,
-          }),
-        }),
+        first: (args) =>
+          args[0] === 'homepage:artifact'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify({
+                  version: 3,
+                  render,
+                }),
+              }
+            : null,
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(render);
+  });
+
+  it('falls back to the legacy combined homepage row for artifacts during rollout', async () => {
+    const payload = samplePayload(190);
+    const render = {
+      generated_at: payload.generated_at,
+      preload_html: '<div id="uptimer-preload">hello</div>',
+      snapshot: payload,
+      meta_title: 'Uptimer',
+      meta_description: 'All Systems Operational',
+    };
+    vi.spyOn(Date, 'now').mockReturnValue(200_000);
+
+    const res = await requestHomepageArtifact([
+      {
+        match: 'from public_snapshots',
+        first: (args) =>
+          args[0] === 'homepage'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify({
+                  version: 2,
+                  data: payload,
+                  render,
+                }),
+              }
+            : null,
       },
     ]);
 

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -117,10 +117,6 @@ describe('public homepage route', () => {
 
   it('serves a fresh homepage snapshot without live compute', async () => {
     const payload = samplePayload(190);
-    const stored = {
-      version: 3,
-      data: payload,
-    };
     vi.spyOn(Date, 'now').mockReturnValue(200_000);
 
     const res = await requestHomepage([
@@ -130,7 +126,7 @@ describe('public homepage route', () => {
           args[0] === 'homepage'
             ? {
                 generated_at: payload.generated_at,
-                body_json: JSON.stringify(stored),
+                body_json: JSON.stringify(payload),
               }
             : null,
       },
@@ -158,10 +154,7 @@ describe('public homepage route', () => {
           args[0] === 'homepage:artifact'
             ? {
                 generated_at: payload.generated_at,
-                body_json: JSON.stringify({
-                  version: 3,
-                  render,
-                }),
+                body_json: JSON.stringify(render),
               }
             : null,
       },

--- a/apps/worker/test/scheduled.bench.ts
+++ b/apps/worker/test/scheduled.bench.ts
@@ -55,7 +55,9 @@ function makeDueRows(count: number) {
     name: `Monitor ${index + 1}`,
     type: 'unsupported',
     target: `benchmark-target-${index + 1}`,
+    group_name: index % 2 === 0 ? 'Core' : 'Edge',
     interval_sec: 60,
+    created_at: 1_700_000_000 - 40 * 86_400,
     timeout_ms: 5000,
     http_method: null,
     http_headers_json: null,
@@ -83,6 +85,7 @@ function createEnvForScenario(scenario: Scenario): {
     waitUntilCalls: 0,
   };
   const dueRows = makeDueRows(scenario.monitorCount);
+  let homepageArtifactGeneratedAt = 0;
   const channels = scenario.withChannel
     ? [
         {
@@ -109,11 +112,22 @@ function createEnvForScenario(scenario: Scenario): {
     },
     {
       match: 'select key, value from settings',
-      all: () => [],
+      all: () => [
+        { key: 'site_title', value: 'Status Hub' },
+        { key: 'site_description', value: 'Production services' },
+        { key: 'site_locale', value: 'en' },
+        { key: 'site_timezone', value: 'UTC' },
+        { key: 'uptime_rating_level', value: '3' },
+      ],
     },
     {
       match: 'from monitors m',
-      all: () => dueRows,
+      all: (args, normalizedSql) => {
+        if (normalizedSql.includes('limit ?1')) {
+          return dueRows.slice(0, Number(args[0] ?? dueRows.length));
+        }
+        return dueRows;
+      },
     },
     {
       match: 'select distinct mwm.monitor_id',
@@ -126,6 +140,53 @@ function createEnvForScenario(scenario: Scenario): {
     {
       match: 'from maintenance_window_monitors',
       all: () => [],
+    },
+    {
+      match: 'with active_maintenance',
+      first: () => ({
+        monitor_count_total: dueRows.length,
+        up: dueRows.length,
+        down: 0,
+        maintenance: 0,
+        paused: 0,
+        unknown: 0,
+      }),
+    },
+    {
+      match: 'row_number() over',
+      all: () =>
+        dueRows.slice(0, 12).flatMap((row) =>
+          Array.from({ length: 30 }, (_, index) => ({
+            monitor_id: row.id,
+            checked_at: 1_700_000_000 - (index + 1) * 60,
+            status: 'up',
+            latency_ms: 40 + ((row.id + index) % 50),
+          })),
+        ),
+    },
+    {
+      match: 'from monitor_daily_rollups',
+      all: () =>
+        dueRows.slice(0, 12).flatMap((row) =>
+          Array.from({ length: 14 }, (_, index) => ({
+            monitor_id: row.id,
+            day_start_at: 1_700_000_000 - (14 - index) * 86_400,
+            total_sec: 86_400,
+            downtime_sec: 0,
+            unknown_sec: 0,
+            uptime_sec: 86_400,
+          })),
+        ),
+    },
+    {
+      match: 'from public_snapshots',
+      first: (args) =>
+        args[0] === 'homepage:artifact' && homepageArtifactGeneratedAt > 0
+          ? {
+              generated_at: homepageArtifactGeneratedAt,
+              body_json: '{"generated_at":0}',
+            }
+          : null,
     },
     {
       match: 'insert into check_results',
@@ -142,6 +203,15 @@ function createEnvForScenario(scenario: Scenario): {
     {
       match: 'update outages',
       run: () => ({ meta: { changes: 1 } }),
+    },
+    {
+      match: 'insert into public_snapshots',
+      run: (args) => {
+        if (args[0] === 'homepage:artifact') {
+          homepageArtifactGeneratedAt = Number(args[1]);
+        }
+        return { meta: { changes: 1 } };
+      },
     },
   ];
 
@@ -161,15 +231,19 @@ function createEnvForScenario(scenario: Scenario): {
 
 async function runOne(scenario: Scenario): Promise<Sample> {
   const { env, sampleState } = createEnvForScenario(scenario);
+  const waitUntilPromises: Promise<unknown>[] = [];
   const ctx = {
     waitUntil(promise: Promise<unknown>) {
       sampleState.waitUntilCalls += 1;
-      void promise.catch(() => undefined);
+      waitUntilPromises.push(
+        promise.catch(() => undefined),
+      );
     },
   } as unknown as ExecutionContext;
 
   const started = performance.now();
   await runScheduledTick(env, ctx);
+  await Promise.all(waitUntilPromises);
   const elapsedMs = performance.now() - started;
 
   return {
@@ -181,13 +255,16 @@ async function runOne(scenario: Scenario): Promise<Sample> {
 async function withMutedConsole<T>(fn: () => Promise<T>): Promise<T> {
   const originalLog = console.log;
   const originalError = console.error;
+  const originalWarn = console.warn;
   console.log = () => undefined;
   console.error = () => undefined;
+  console.warn = () => undefined;
   try {
     return await fn();
   } finally {
     console.log = originalLog;
     console.error = originalError;
+    console.warn = originalWarn;
   }
 }
 

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -16,20 +16,20 @@ vi.mock('../src/notify/webhook', () => ({
   dispatchWebhookToChannels: vi.fn(),
 }));
 vi.mock('../src/public/homepage', () => ({
-  computePublicHomepagePayload: vi.fn(),
+  computePublicHomepageArtifactPayload: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
-  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageArtifactSnapshotIfNeeded: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { runHttpCheck } from '../src/monitor/http';
 import { runTcpCheck } from '../src/monitor/tcp';
 import { dispatchWebhookToChannels } from '../src/notify/webhook';
-import { computePublicHomepagePayload } from '../src/public/homepage';
+import { computePublicHomepageArtifactPayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../src/snapshots';
+import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -137,10 +137,10 @@ describe('scheduler/scheduled regression', () => {
       uptime_rating_level: 3,
     });
     vi.mocked(dispatchWebhookToChannels).mockResolvedValue(undefined);
-    vi.mocked(computePublicHomepagePayload).mockResolvedValue({
+    vi.mocked(computePublicHomepageArtifactPayload).mockResolvedValue({
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -183,20 +183,20 @@ describe('scheduler/scheduled regression', () => {
 
     expect(acquireLease).toHaveBeenCalledWith(env.DB, 'scheduler:tick', expectedNow, 55);
     expect(readSettings).toHaveBeenCalledTimes(1);
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
+    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
       compute: expect.any(Function),
     });
-    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
+    const refreshArgs = vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
-    expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(computePublicHomepageArtifactPayload).toHaveBeenCalledWith(env.DB, expectedNow);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockRejectedValueOnce(
+    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockRejectedValueOnce(
       new Error('snapshot refresh failed'),
     );
 
@@ -289,7 +289,7 @@ describe('scheduler/scheduled regression', () => {
     expect(runArgs[stateUpsertIndex]?.[1]).toBe('up');
     expect(runArgs[stateUpsertIndex]?.[2]).toBe(expectedCheckedAt);
 
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -171,19 +171,10 @@ describe('snapshots/public-homepage', () => {
     };
 
     const artifact = buildHomepageRenderArtifact(payload);
-    const match = artifact.bootstrap_script.match(
-      /__UPTIMER_INITIAL_HOMEPAGE__=(.*);<\/script>$/,
-    );
-    expect(match).not.toBeNull();
-
-    const bootstrapped = JSON.parse(match?.[1] ?? '{}') as {
-      bootstrap_mode: string;
-      monitor_count_total: number;
-      monitors: Array<{ id: number }>;
-    };
+    const bootstrapped = artifact.snapshot;
     expect(bootstrapped.bootstrap_mode).toBe('partial');
     expect(bootstrapped.monitor_count_total).toBe(30);
-    expect(bootstrapped.monitors).toHaveLength(24);
+    expect(bootstrapped.monitors).toHaveLength(12);
     expect(artifact.preload_html).toContain('Monitor 30');
     expect(artifact.preload_html).not.toContain('#30');
   });

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -11,12 +11,14 @@ import {
   getHomepageSnapshotKey,
   getHomepageSnapshotMaxAgeSeconds,
   getHomepageSnapshotMaxStaleSeconds,
+  refreshPublicHomepageArtifactSnapshotIfNeeded,
   readHomepageSnapshot,
   readHomepageSnapshotArtifact,
   readStaleHomepageSnapshot,
   readStaleHomepageSnapshotArtifact,
   refreshPublicHomepageSnapshotIfNeeded,
   toHomepageSnapshotPayload,
+  writeHomepageArtifactSnapshot,
   writeHomepageSnapshot,
 } from '../src/snapshots/public-homepage';
 import { createFakeD1Database } from './helpers/fake-d1';
@@ -240,6 +242,36 @@ describe('snapshots/public-homepage', () => {
     ]);
   });
 
+  it('writes artifact-only homepage snapshots without touching the full payload row', async () => {
+    const boundArgs: unknown[][] = [];
+    const db = createFakeD1Database([
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          boundArgs.push(args);
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    const payload = {
+      ...samplePayload(280),
+      bootstrap_mode: 'partial' as const,
+      monitor_count_total: 30,
+      monitors: Array.from({ length: 12 }, (_, index) => ({
+        ...samplePayload(280).monitors[0],
+        id: index + 1,
+        name: `Monitor ${index + 1}`,
+      })),
+    };
+
+    await writeHomepageArtifactSnapshot(db, 300, payload);
+
+    expect(boundArgs).toEqual([
+      ['homepage:artifact', 280, JSON.stringify(buildHomepageRenderArtifact(payload)), 300],
+    ]);
+  });
+
   it('applies bounded cache headers for homepage payloads', () => {
     const fresh = new Response('ok');
     applyHomepageCacheHeaders(fresh, 10);
@@ -326,6 +358,56 @@ describe('snapshots/public-homepage', () => {
     expect(writtenArgs).toEqual([
       ['homepage', now, JSON.stringify(storedData), now],
       ['homepage:artifact', now, JSON.stringify(storedRender), now],
+    ]);
+  });
+
+  it('refreshes only the artifact snapshot when the scheduler path requests it', async () => {
+    vi.mocked(acquireLease).mockResolvedValue(true);
+
+    let artifactGeneratedAt = 1_728_000_001;
+    const writtenArgs: unknown[][] = [];
+    const now = 1_728_000_120;
+    const payload = {
+      ...samplePayload(now),
+      bootstrap_mode: 'partial' as const,
+      monitor_count_total: 30,
+      monitors: Array.from({ length: 12 }, (_, index) => ({
+        ...samplePayload(now).monitors[0],
+        id: index + 1,
+        name: `Monitor ${index + 1}`,
+      })),
+    };
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: (args) => {
+          if (args[0] !== 'homepage:artifact') {
+            return null;
+          }
+          return {
+            generated_at: artifactGeneratedAt,
+            body_json: JSON.stringify(buildHomepageRenderArtifact(samplePayload(artifactGeneratedAt))),
+          };
+        },
+      },
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          writtenArgs.push(args);
+          artifactGeneratedAt = Number(args[1]);
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    const compute = vi.fn(async () => payload);
+    const refreshed = await refreshPublicHomepageArtifactSnapshotIfNeeded({ db, now, compute });
+
+    expect(refreshed).toBe(true);
+    expect(acquireLease).toHaveBeenCalledWith(db, 'snapshot:homepage:refresh', now, 55);
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(writtenArgs).toEqual([
+      ['homepage:artifact', now, JSON.stringify(buildHomepageRenderArtifact(payload)), now],
     ]);
   });
 });

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -7,11 +7,14 @@ vi.mock('../src/scheduler/lock', () => ({
 import { acquireLease } from '../src/scheduler/lock';
 import {
   applyHomepageCacheHeaders,
+  buildHomepageRenderArtifact,
   getHomepageSnapshotKey,
   getHomepageSnapshotMaxAgeSeconds,
   getHomepageSnapshotMaxStaleSeconds,
   readHomepageSnapshot,
+  readHomepageSnapshotArtifact,
   readStaleHomepageSnapshot,
+  readStaleHomepageSnapshotArtifact,
   refreshPublicHomepageSnapshotIfNeeded,
   toHomepageSnapshotPayload,
   writeHomepageSnapshot,
@@ -21,6 +24,8 @@ import { createFakeD1Database } from './helpers/fake-d1';
 function samplePayload(now = 1_728_000_000) {
   return {
     generated_at: now,
+    bootstrap_mode: 'full' as const,
+    monitor_count_total: 1,
     site_title: 'Uptimer',
     site_description: '',
     site_locale: 'auto' as const,
@@ -49,16 +54,18 @@ function samplePayload(now = 1_728_000_000) {
         status: 'up' as const,
         is_stale: false,
         last_checked_at: now - 30,
-        heartbeats: [{ checked_at: now - 60, status: 'up' as const, latency_ms: 42 }],
+        heartbeat_strip: {
+          checked_at: [now - 60],
+          status_codes: 'u',
+          latency_ms: [42],
+        },
         uptime_30d: { uptime_pct: 100 },
-        uptime_days: [
-          {
-            day_start_at: Math.max(0, now - 86_400),
-            downtime_sec: 0,
-            unknown_sec: 0,
-            uptime_pct: 100,
-          },
-        ],
+        uptime_day_strip: {
+          day_start_at: [Math.max(0, now - 86_400)],
+          downtime_sec: [0],
+          unknown_sec: [0],
+          uptime_pct_milli: [100_000],
+        },
       },
     ],
     active_incidents: [],
@@ -84,12 +91,17 @@ describe('snapshots/public-homepage', () => {
 
   it('reads fresh and bounded-stale homepage snapshots without live compute', async () => {
     const payload = samplePayload(190);
+    const stored = {
+      version: 2,
+      data: payload,
+      render: buildHomepageRenderArtifact(payload),
+    };
     const db = createFakeD1Database([
       {
         match: 'from public_snapshots',
         first: () => ({
           generated_at: payload.generated_at,
-          body_json: JSON.stringify(payload),
+          body_json: JSON.stringify(stored),
         }),
       },
     ]);
@@ -98,10 +110,82 @@ describe('snapshots/public-homepage', () => {
       data: payload,
       age: 10,
     });
+    await expect(readHomepageSnapshotArtifact(db, 200)).resolves.toEqual({
+      data: stored.render,
+      age: 10,
+    });
     await expect(readStaleHomepageSnapshot(db, 200)).resolves.toEqual({
       data: payload,
       age: 10,
     });
+    await expect(readStaleHomepageSnapshotArtifact(db, 200)).resolves.toEqual({
+      data: stored.render,
+      age: 10,
+    });
+  });
+
+  it('reads legacy homepage payloads but refuses to synthesize render artifacts on the read path', async () => {
+    const { bootstrap_mode: _ignoredMode, monitor_count_total: _ignoredCount, ...legacyPayload } =
+      samplePayload(190);
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: () => ({
+          generated_at: legacyPayload.generated_at,
+          body_json: JSON.stringify(legacyPayload),
+        }),
+      },
+    ]);
+
+    await expect(readHomepageSnapshot(db, 200)).resolves.toEqual({
+      data: samplePayload(190),
+      age: 10,
+    });
+    await expect(readHomepageSnapshotArtifact(db, 200)).resolves.toBeNull();
+  });
+
+  it('caps bootstrap monitors in render artifacts to keep root misses bounded', () => {
+    const payload = {
+      ...samplePayload(190),
+      monitor_count_total: 30,
+      monitors: Array.from({ length: 30 }, (_, index) => ({
+        ...samplePayload(190).monitors[0],
+        id: index + 1,
+        name: `Monitor ${index + 1}`,
+      })),
+      summary: {
+        up: 30,
+        down: 0,
+        maintenance: 0,
+        paused: 0,
+        unknown: 0,
+      },
+      maintenance_history_preview: {
+        id: 1,
+        title: 'Database patching',
+        message: null,
+        starts_at: 120,
+        ends_at: 180,
+        monitor_ids: [30],
+      },
+    };
+
+    const artifact = buildHomepageRenderArtifact(payload);
+    const match = artifact.bootstrap_script.match(
+      /__UPTIMER_INITIAL_HOMEPAGE__=(.*);<\/script>$/,
+    );
+    expect(match).not.toBeNull();
+
+    const bootstrapped = JSON.parse(match?.[1] ?? '{}') as {
+      bootstrap_mode: string;
+      monitor_count_total: number;
+      monitors: Array<{ id: number }>;
+    };
+    expect(bootstrapped.bootstrap_mode).toBe('partial');
+    expect(bootstrapped.monitor_count_total).toBe(30);
+    expect(bootstrapped.monitors).toHaveLength(24);
+    expect(artifact.preload_html).toContain('Monitor 30');
+    expect(artifact.preload_html).not.toContain('#30');
   });
 
   it('returns null when homepage snapshot is too old or invalid', async () => {
@@ -147,7 +231,13 @@ describe('snapshots/public-homepage', () => {
     const payload = samplePayload(280);
     await writeHomepageSnapshot(db, 300, payload);
 
-    expect(boundArgs).toEqual(['homepage', 280, JSON.stringify(payload), 300]);
+    const stored = {
+      version: 2,
+      data: payload,
+      render: buildHomepageRenderArtifact(payload),
+    };
+
+    expect(boundArgs).toEqual(['homepage', 280, JSON.stringify(stored), 300]);
   });
 
   it('applies bounded cache headers for homepage payloads', () => {
@@ -204,12 +294,20 @@ describe('snapshots/public-homepage', () => {
           if (readCount <= 2) {
             return {
               generated_at: 1_728_000_001,
-              body_json: JSON.stringify(samplePayload(1_728_000_001)),
+              body_json: JSON.stringify({
+                version: 2,
+                data: samplePayload(1_728_000_001),
+                render: buildHomepageRenderArtifact(samplePayload(1_728_000_001)),
+              }),
             };
           }
           return {
             generated_at: now,
-            body_json: JSON.stringify(samplePayload(now)),
+            body_json: JSON.stringify({
+              version: 2,
+              data: samplePayload(now),
+              render: buildHomepageRenderArtifact(samplePayload(now)),
+            }),
           };
         },
       },
@@ -224,10 +322,15 @@ describe('snapshots/public-homepage', () => {
 
     const compute = vi.fn(async () => samplePayload(now));
     const refreshed = await refreshPublicHomepageSnapshotIfNeeded({ db, now, compute });
+    const stored = {
+      version: 2,
+      data: samplePayload(now),
+      render: buildHomepageRenderArtifact(samplePayload(now)),
+    };
 
     expect(refreshed).toBe(true);
     expect(acquireLease).toHaveBeenCalledWith(db, 'snapshot:homepage:refresh', now, 55);
     expect(compute).toHaveBeenCalledTimes(1);
-    expect(writtenArgs).toEqual(['homepage', now, JSON.stringify(samplePayload(now)), now]);
+    expect(writtenArgs).toEqual(['homepage', now, JSON.stringify(stored), now]);
   });
 });

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -91,14 +91,8 @@ describe('snapshots/public-homepage', () => {
 
   it('reads fresh and bounded-stale homepage snapshots without live compute', async () => {
     const payload = samplePayload(190);
-    const storedData = {
-      version: 3,
-      data: payload,
-    };
-    const storedRender = {
-      version: 3,
-      render: buildHomepageRenderArtifact(payload),
-    };
+    const storedData = payload;
+    const storedRender = buildHomepageRenderArtifact(payload);
     const db = createFakeD1Database([
       {
         match: 'from public_snapshots',
@@ -126,7 +120,7 @@ describe('snapshots/public-homepage', () => {
       age: 10,
     });
     await expect(readHomepageSnapshotArtifact(db, 200)).resolves.toEqual({
-      data: storedRender.render,
+      data: storedRender,
       age: 10,
     });
     await expect(readStaleHomepageSnapshot(db, 200)).resolves.toEqual({
@@ -134,7 +128,7 @@ describe('snapshots/public-homepage', () => {
       age: 10,
     });
     await expect(readStaleHomepageSnapshotArtifact(db, 200)).resolves.toEqual({
-      data: storedRender.render,
+      data: storedRender,
       age: 10,
     });
   });
@@ -237,14 +231,8 @@ describe('snapshots/public-homepage', () => {
     const payload = samplePayload(280);
     await writeHomepageSnapshot(db, 300, payload);
 
-    const storedData = {
-      version: 3,
-      data: payload,
-    };
-    const storedRender = {
-      version: 3,
-      render: buildHomepageRenderArtifact(payload),
-    };
+    const storedData = payload;
+    const storedRender = buildHomepageRenderArtifact(payload);
 
     expect(boundArgs).toEqual([
       ['homepage', 280, JSON.stringify(storedData), 300],
@@ -309,18 +297,12 @@ describe('snapshots/public-homepage', () => {
           if (readCount <= 2) {
             return {
               generated_at: 1_728_000_001,
-              body_json: JSON.stringify({
-                version: 3,
-                data: samplePayload(1_728_000_001),
-              }),
+              body_json: JSON.stringify(samplePayload(1_728_000_001)),
             };
           }
           return {
             generated_at: now,
-            body_json: JSON.stringify({
-              version: 3,
-              data: samplePayload(now),
-            }),
+            body_json: JSON.stringify(samplePayload(now)),
           };
         },
       },
@@ -335,14 +317,8 @@ describe('snapshots/public-homepage', () => {
 
     const compute = vi.fn(async () => samplePayload(now));
     const refreshed = await refreshPublicHomepageSnapshotIfNeeded({ db, now, compute });
-    const storedData = {
-      version: 3,
-      data: samplePayload(now),
-    };
-    const storedRender = {
-      version: 3,
-      render: buildHomepageRenderArtifact(samplePayload(now)),
-    };
+    const storedData = samplePayload(now);
+    const storedRender = buildHomepageRenderArtifact(samplePayload(now));
 
     expect(refreshed).toBe(true);
     expect(acquireLease).toHaveBeenCalledWith(db, 'snapshot:homepage:refresh', now, 55);

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -91,18 +91,33 @@ describe('snapshots/public-homepage', () => {
 
   it('reads fresh and bounded-stale homepage snapshots without live compute', async () => {
     const payload = samplePayload(190);
-    const stored = {
-      version: 2,
+    const storedData = {
+      version: 3,
       data: payload,
+    };
+    const storedRender = {
+      version: 3,
       render: buildHomepageRenderArtifact(payload),
     };
     const db = createFakeD1Database([
       {
         match: 'from public_snapshots',
-        first: () => ({
-          generated_at: payload.generated_at,
-          body_json: JSON.stringify(stored),
-        }),
+        first: (args) => {
+          const key = args[0];
+          if (key === 'homepage') {
+            return {
+              generated_at: payload.generated_at,
+              body_json: JSON.stringify(storedData),
+            };
+          }
+          if (key === 'homepage:artifact') {
+            return {
+              generated_at: payload.generated_at,
+              body_json: JSON.stringify(storedRender),
+            };
+          }
+          return null;
+        },
       },
     ]);
 
@@ -111,7 +126,7 @@ describe('snapshots/public-homepage', () => {
       age: 10,
     });
     await expect(readHomepageSnapshotArtifact(db, 200)).resolves.toEqual({
-      data: stored.render,
+      data: storedRender.render,
       age: 10,
     });
     await expect(readStaleHomepageSnapshot(db, 200)).resolves.toEqual({
@@ -119,7 +134,7 @@ describe('snapshots/public-homepage', () => {
       age: 10,
     });
     await expect(readStaleHomepageSnapshotArtifact(db, 200)).resolves.toEqual({
-      data: stored.render,
+      data: storedRender.render,
       age: 10,
     });
   });
@@ -208,12 +223,12 @@ describe('snapshots/public-homepage', () => {
   });
 
   it('writes normalized homepage snapshots with upsert semantics', async () => {
-    let boundArgs = null as unknown[] | null;
+    const boundArgs: unknown[][] = [];
     const db = createFakeD1Database([
       {
         match: 'insert into public_snapshots',
         run: (args) => {
-          boundArgs = args;
+          boundArgs.push(args);
           return { meta: { changes: 1 } };
         },
       },
@@ -222,13 +237,19 @@ describe('snapshots/public-homepage', () => {
     const payload = samplePayload(280);
     await writeHomepageSnapshot(db, 300, payload);
 
-    const stored = {
-      version: 2,
+    const storedData = {
+      version: 3,
       data: payload,
+    };
+    const storedRender = {
+      version: 3,
       render: buildHomepageRenderArtifact(payload),
     };
 
-    expect(boundArgs).toEqual(['homepage', 280, JSON.stringify(stored), 300]);
+    expect(boundArgs).toEqual([
+      ['homepage', 280, JSON.stringify(storedData), 300],
+      ['homepage:artifact', 280, JSON.stringify(storedRender), 300],
+    ]);
   });
 
   it('applies bounded cache headers for homepage payloads', () => {
@@ -275,29 +296,30 @@ describe('snapshots/public-homepage', () => {
     vi.mocked(acquireLease).mockResolvedValue(true);
 
     let readCount = 0;
-    let writtenArgs = null as unknown[] | null;
+    const writtenArgs: unknown[][] = [];
     const now = 1_728_000_120;
     const db = createFakeD1Database([
       {
         match: 'from public_snapshots',
-        first: () => {
+        first: (args) => {
+          if (args[0] !== 'homepage') {
+            return null;
+          }
           readCount += 1;
           if (readCount <= 2) {
             return {
               generated_at: 1_728_000_001,
               body_json: JSON.stringify({
-                version: 2,
+                version: 3,
                 data: samplePayload(1_728_000_001),
-                render: buildHomepageRenderArtifact(samplePayload(1_728_000_001)),
               }),
             };
           }
           return {
             generated_at: now,
             body_json: JSON.stringify({
-              version: 2,
+              version: 3,
               data: samplePayload(now),
-              render: buildHomepageRenderArtifact(samplePayload(now)),
             }),
           };
         },
@@ -305,7 +327,7 @@ describe('snapshots/public-homepage', () => {
       {
         match: 'insert into public_snapshots',
         run: (args) => {
-          writtenArgs = args;
+          writtenArgs.push(args);
           return { meta: { changes: 1 } };
         },
       },
@@ -313,15 +335,21 @@ describe('snapshots/public-homepage', () => {
 
     const compute = vi.fn(async () => samplePayload(now));
     const refreshed = await refreshPublicHomepageSnapshotIfNeeded({ db, now, compute });
-    const stored = {
-      version: 2,
+    const storedData = {
+      version: 3,
       data: samplePayload(now),
+    };
+    const storedRender = {
+      version: 3,
       render: buildHomepageRenderArtifact(samplePayload(now)),
     };
 
     expect(refreshed).toBe(true);
     expect(acquireLease).toHaveBeenCalledWith(db, 'snapshot:homepage:refresh', now, 55);
     expect(compute).toHaveBeenCalledTimes(1);
-    expect(writtenArgs).toEqual(['homepage', now, JSON.stringify(stored), now]);
+    expect(writtenArgs).toEqual([
+      ['homepage', now, JSON.stringify(storedData), now],
+      ['homepage:artifact', now, JSON.stringify(storedRender), now],
+    ]);
   });
 });


### PR DESCRIPTION
What
- replaces the homepage snapshot artifact from full prebuilt HTML/script blobs to a lighter payload: pre-rendered `preload_html` plus a bounded bootstrap snapshot
- keeps `/` fast and data-rich by injecting homepage preload HTML plus `__UPTIMER_INITIAL_HOMEPAGE__`, while handling partial bootstrap state explicitly in the web app
- adds a dedicated root-miss benchmark so Pages Worker homepage injection is measured alongside homepage snapshot compute

Why
- Cloudflare request CPU on `/` needed to stay comfortably below the free-plan 10ms ceiling without falling back to live status compute
- the previous full artifact approach improved `/` but pushed too much work and payload size onto scheduled/admin snapshot refreshes
- this version keeps the UX goal (immediate populated homepage, no live compute on entry) while cutting snapshot row size and write-time work

Where
- Pages Worker: `apps/web/public/_worker.js`
- Web bootstrap + UX: `apps/web/src/main.tsx`, `apps/web/src/pages/StatusPage.tsx`, `apps/web/src/i18n/messages.ts`, `apps/web/src/components/*`
- Worker snapshot/public pipeline: `apps/worker/src/public/homepage.ts`, `apps/worker/src/routes/public.ts`, `apps/worker/src/schemas/public-homepage.ts`, `apps/worker/src/snapshots/public-homepage.ts`
- Tests/benchmarks: `apps/worker/test/pages-homepage-worker.test.ts`, `apps/worker/test/public-homepage-routes.test.ts`, `apps/worker/test/snapshots-public-homepage.test.ts`, `apps/worker/test/homepage-snapshot.bench.ts`

How to verify
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @uptimer/web build`
- `pnpm --filter @uptimer/worker bench:homepage`
- `SCHEDULER_BENCH_RUNS=24 SCHEDULER_BENCH_WARMUPS=5 pnpm --filter @uptimer/worker bench:scheduler`

Benchmarks
- Pages homepage root miss benchmark (`pnpm --filter @uptimer/worker bench:homepage`)
- `50 monitors`: mean `1.959ms`, median `1.130ms`, p95 `8.297ms`
- `100 monitors`: mean `1.239ms`, median `0.898ms`, p95 `3.194ms`
- `250 monitors`: mean `1.674ms`, median `1.097ms`, p95 `8.359ms`
- artifact payload stayed bounded at `62.6KB`, with `42.9KB` preload HTML and `13.1KB` bootstrap snapshot
- homepage snapshot compute benchmark on the same run: `1000 monitors` median `13.510ms`; `5000 monitors` median `46.707ms`

Scheduler note
- stable 24-run scheduler bench on this branch is much closer to baseline after lightening the artifact payload, especially on the large no-channel path
- current measured results:
- `1000 due / no channels`: baseline median `6.554ms`, current median `10.155ms`
- `5000 due / no channels`: baseline median `41.790ms`, current median `43.236ms`
- `5000 due / 1 webhook`: baseline median `45.848ms`, current median `46.466ms`
- so the large-path regression is effectively flattened, but the small `1000 due / no channels` scenario is still slower than baseline; I have not hidden that

Commits
- `perf(worker): precompute homepage artifact`
- `fix(web): surface partial homepage bootstrap state`
- `perf(pages): lighten homepage artifact payload`
- `test(worker): benchmark homepage root misses`
