### PR TITLE
fix: guard homepage bootstrap against deploy-window downgrade

### DIFF
--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -371,6 +371,16 @@ export function StatusPage() {
     queryFn: fetchHomepage,
     staleTime: 60_000,
     refetchInterval: 60_000,
+    // Keep a recent injected homepage bootstrap stable through the current monitor window.
+    // Immediate mount refetch can temporarily downgrade recent artifact data to UNKNOWN
+    // before the next scheduled check has refreshed monitor_state/snapshots.
+    refetchOnMount: (query) => {
+      const data = query.state.data as PublicHomepageResponse | undefined;
+      if (!data || typeof data.generated_at !== 'number') {
+        return true;
+      }
+      return Date.now() - data.generated_at * 1000 > 2 * 60_000;
+    },
   });
 
   const derivedTitle = homepageQuery.data?.site_title || 'Uptimer';

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -27,6 +27,7 @@ import {
   readHomepageSnapshotJson,
   readStatusSnapshot,
   readStaleHomepageSnapshot,
+  readStaleHomepageSnapshotArtifact,
   readStaleHomepageSnapshotArtifactJson,
   toSnapshotPayload,
   writeStatusSnapshot,
@@ -39,6 +40,8 @@ type PublicStatusSnapshotRow = {
   generated_at: number;
   body_json: string;
 };
+
+const HOMEPAGE_UNKNOWN_DOWNGRADE_GUARD_SECONDS = 2 * 60;
 
 function safeJsonParse(text: string): unknown | null {
   const trimmed = text.trim();
@@ -71,6 +74,52 @@ function applyPrivateNoStore(res: Response): Response {
 
 function withVisibilityAwareCaching(res: Response, includeHiddenMonitors: boolean): Response {
   return includeHiddenMonitors ? applyPrivateNoStore(res) : res;
+}
+
+function shouldPreferRecentHomepageArtifact(opts: {
+  artifact:
+    | {
+        age: number;
+        data: {
+          snapshot: {
+            overall_status: string;
+            banner: { status: string };
+            summary: { unknown: number };
+          };
+        };
+      }
+    | null;
+  computed: {
+    overall_status: string;
+    banner: { status: string };
+    summary: { unknown: number };
+  };
+}): boolean {
+  const { artifact, computed } = opts;
+  if (!artifact) return false;
+
+  const snapshot = artifact.data.snapshot;
+  if (artifact.age > HOMEPAGE_UNKNOWN_DOWNGRADE_GUARD_SECONDS) {
+    return false;
+  }
+
+  const computedShowsUnknownLead =
+    computed.overall_status === 'unknown' || computed.banner.status === 'unknown';
+  if (!computedShowsUnknownLead) {
+    return false;
+  }
+
+  const artifactShowsKnownLead =
+    snapshot.overall_status !== 'unknown' || snapshot.banner.status !== 'unknown';
+  if (!artifactShowsKnownLead) {
+    return false;
+  }
+
+  return (
+    computed.summary.unknown > snapshot.summary.unknown ||
+    computed.overall_status !== snapshot.overall_status ||
+    computed.banner.status !== snapshot.banner.status
+  );
 }
 
 async function readStaleStatusSnapshot(
@@ -567,8 +616,20 @@ publicRoutes.get('/homepage', async (c) => {
     return res;
   }
 
+  const artifactSnapshotPromise = readStaleHomepageSnapshotArtifact(c.env.DB, now);
+
   try {
     const statusPayload = await computePublicStatusPayload(c.env.DB, now);
+    const artifactSnapshot = await artifactSnapshotPromise;
+    if (
+      artifactSnapshot &&
+      shouldPreferRecentHomepageArtifact({ artifact: artifactSnapshot, computed: statusPayload })
+    ) {
+      const res = c.json(artifactSnapshot.data.snapshot);
+      applyHomepageCacheHeaders(res, Math.min(60, artifactSnapshot.age));
+      return res;
+    }
+
     const payload = homepageFromStatusPayload(statusPayload, await historyPreviewsPromise);
     const res = c.json(payload);
     applyHomepageCacheHeaders(res, 0);
@@ -601,6 +662,13 @@ publicRoutes.get('/homepage', async (c) => {
       );
       const res = c.json(payload);
       applyHomepageCacheHeaders(res, Math.min(60, staleStatus.age));
+      return res;
+    }
+
+    const staleArtifact = await artifactSnapshotPromise;
+    if (staleArtifact) {
+      const res = c.json(staleArtifact.data.snapshot);
+      applyHomepageCacheHeaders(res, Math.min(60, staleArtifact.age));
       return res;
     }
 

--- a/apps/worker/test/public-homepage-downgrade-guard.test.ts
+++ b/apps/worker/test/public-homepage-downgrade-guard.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { computePublicStatusPayload } = vi.hoisted(() => ({
+  computePublicStatusPayload: vi.fn(),
+}));
+
+vi.mock('../src/public/status', () => ({
+  computePublicStatusPayload,
+}));
+
+import type { Env } from '../src/env';
+import { handleError, handleNotFound } from '../src/middleware/errors';
+import { publicRoutes } from '../src/routes/public';
+import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
+
+function installCacheMock() {
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: {
+      open: vi.fn(async () => ({
+        async match() {
+          return undefined;
+        },
+        async put() {
+          return undefined;
+        },
+      })),
+    },
+  });
+}
+
+function sampleArtifactSnapshot(now = 190) {
+  return {
+    generated_at: now,
+    bootstrap_mode: 'partial' as const,
+    monitor_count_total: 40,
+    site_title: 'Status Hub',
+    site_description: 'Production services',
+    site_locale: 'en' as const,
+    site_timezone: 'UTC',
+    uptime_rating_level: 3 as const,
+    overall_status: 'up' as const,
+    banner: {
+      source: 'monitors' as const,
+      status: 'operational' as const,
+      title: 'All Systems Operational',
+      down_ratio: null,
+    },
+    summary: {
+      up: 40,
+      down: 0,
+      maintenance: 0,
+      paused: 0,
+      unknown: 0,
+    },
+    monitors: [],
+    active_incidents: [],
+    maintenance_windows: {
+      active: [],
+      upcoming: [],
+    },
+    resolved_incident_preview: null,
+    maintenance_history_preview: null,
+  };
+}
+
+function sampleRender(now = 190) {
+  const snapshot = sampleArtifactSnapshot(now);
+  return {
+    generated_at: snapshot.generated_at,
+    preload_html: '<div id="uptimer-preload"></div>',
+    snapshot,
+    meta_title: snapshot.site_title,
+    meta_description: snapshot.banner.title,
+  };
+}
+
+async function requestHomepage(
+  handlers: FakeD1QueryHandler[],
+  waitUntil = vi.fn(),
+) {
+  installCacheMock();
+
+  const env = {
+    DB: createFakeD1Database(handlers),
+    ADMIN_TOKEN: 'test-admin-token',
+  } as unknown as Env;
+
+  const app = new Hono<{ Bindings: Env }>();
+  app.onError(handleError);
+  app.notFound(handleNotFound);
+  app.route('/api/v1/public', publicRoutes);
+
+  const res = await app.fetch(
+    new Request('https://status.example.com/api/v1/public/homepage'),
+    env,
+    { waitUntil } as unknown as ExecutionContext,
+  );
+
+  return { res, waitUntil };
+}
+
+describe('public homepage downgrade guard', () => {
+  const originalCaches = (globalThis as { caches?: unknown }).caches;
+
+  afterEach(() => {
+    if (originalCaches === undefined) {
+      delete (globalThis as { caches?: unknown }).caches;
+    } else {
+      Object.defineProperty(globalThis, 'caches', {
+        configurable: true,
+        value: originalCaches,
+      });
+    }
+
+    vi.restoreAllMocks();
+    computePublicStatusPayload.mockReset();
+  });
+
+  it('keeps a recent homepage artifact when live status compute would downgrade it to unknown', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(260_000);
+    let statusSnapshotWrites = 0;
+    computePublicStatusPayload.mockResolvedValue({
+      generated_at: 260,
+      site_title: 'Status Hub',
+      site_description: 'Production services',
+      site_locale: 'en',
+      site_timezone: 'UTC',
+      uptime_rating_level: 3,
+      overall_status: 'unknown',
+      banner: {
+        source: 'monitors',
+        status: 'unknown',
+        title: 'Status Unknown',
+      },
+      summary: {
+        up: 0,
+        down: 0,
+        maintenance: 0,
+        paused: 0,
+        unknown: 40,
+      },
+      monitors: [],
+      active_incidents: [],
+      maintenance_windows: {
+        active: [],
+        upcoming: [],
+      },
+    });
+
+    const { res } = await requestHomepage([
+      {
+        match: 'from public_snapshots',
+        first: (args) => {
+          if (args[0] === 'homepage:artifact') {
+            return {
+              generated_at: 190,
+              body_json: JSON.stringify(sampleRender(190)),
+            };
+          }
+          return null;
+        },
+      },
+      {
+        match: 'from incidents',
+        all: () => [],
+      },
+      {
+        match: 'from maintenance_windows',
+        all: () => [],
+      },
+      {
+        match: 'insert into public_snapshots',
+        run: () => {
+          statusSnapshotWrites += 1;
+          return 1;
+        },
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      generated_at: 190,
+      bootstrap_mode: 'partial',
+      overall_status: 'up',
+      banner: {
+        status: 'operational',
+      },
+      summary: {
+        unknown: 0,
+      },
+    });
+    expect(computePublicStatusPayload).toHaveBeenCalledOnce();
+    expect(statusSnapshotWrites).toBe(0);
+  });
+
+  it('still upgrades to computed homepage data when the live status payload is healthy', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(260_000);
+    let statusSnapshotWrites = 0;
+    computePublicStatusPayload.mockResolvedValue({
+      generated_at: 260,
+      site_title: 'Status Hub',
+      site_description: 'Production services',
+      site_locale: 'en',
+      site_timezone: 'UTC',
+      uptime_rating_level: 3,
+      overall_status: 'up',
+      banner: {
+        source: 'monitors',
+        status: 'operational',
+        title: 'All Systems Operational',
+        down_ratio: null,
+      },
+      summary: {
+        up: 40,
+        down: 0,
+        maintenance: 0,
+        paused: 0,
+        unknown: 0,
+      },
+      monitors: [],
+      active_incidents: [],
+      maintenance_windows: {
+        active: [],
+        upcoming: [],
+      },
+    });
+
+    const { res } = await requestHomepage([
+      {
+        match: 'from public_snapshots',
+        first: (args) => {
+          if (args[0] === 'homepage:artifact') {
+            return {
+              generated_at: 190,
+              body_json: JSON.stringify(sampleRender(190)),
+            };
+          }
+          return null;
+        },
+      },
+      {
+        match: 'insert into public_snapshots',
+        run: () => {
+          statusSnapshotWrites += 1;
+          return 1;
+        },
+      },
+      {
+        match: 'from incidents',
+        all: () => [],
+      },
+      {
+        match: 'from maintenance_windows',
+        all: () => [],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      generated_at: 260,
+      bootstrap_mode: 'full',
+      overall_status: 'up',
+      banner: {
+        status: 'operational',
+      },
+      summary: {
+        unknown: 0,
+      },
+    });
+    expect(computePublicStatusPayload).toHaveBeenCalledOnce();
+    expect(statusSnapshotWrites).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- keep `/api/v1/public/homepage` from replacing a recent homepage artifact with a freshly computed `unknown` payload during the deploy window before the next scheduled check lands
- stop the homepage query from immediately refetching on mount, so the injected bootstrap stays stable through the current monitor window instead of self-downgrading
- add a route regression test that verifies recent artifacts win only for the narrow `unknown` downgrade case and that healthy live payloads still upgrade normally

## Why
After the CPU optimization PR merged, deploys could hit a narrow window where `/` first rendered correctly from `homepage:artifact`, then the client immediately called `/public/homepage`, live-computed against slightly stale `monitor_state`, and overwrote the page with `overall_status = unknown` until the next scheduler tick.

This change fixes that without restoring full homepage refreshes into the scheduler hot path.

## Validation
- `pnpm --filter @uptimer/worker lint`
- `pnpm --filter @uptimer/web lint`
- `pnpm --filter @uptimer/worker typecheck`
- `pnpm --filter @uptimer/web typecheck`
- `pnpm --filter @uptimer/worker exec vitest run --config vitest.config.ts test/public-homepage-downgrade-guard.test.ts test/public-homepage-routes.test.ts test/pages-homepage-worker.test.ts`
- `pnpm --filter @uptimer/worker test`
- `pnpm --filter @uptimer/web build`
