### PR TITLE
perf: reduce homepage CPU with demand-driven snapshot prewarm

### DIFF
--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -1,5 +1,4 @@
 const SNAPSHOT_MAX_AGE_SECONDS = 60;
-const PREFERRED_MAX_AGE_SECONDS = 30;
 const FALLBACK_HTML_MAX_AGE_SECONDS = 600;
 
 function acceptsHtml(request) {
@@ -85,9 +84,7 @@ html.dark #uptimer-preload .ih{border-top-color:#334155}
 
 function computeCacheControl(ageSeconds) {
   const remaining = Math.max(0, SNAPSHOT_MAX_AGE_SECONDS - ageSeconds);
-  const maxAge = Math.min(PREFERRED_MAX_AGE_SECONDS, remaining);
-  const stale = Math.max(0, remaining - maxAge);
-  return `public, max-age=${maxAge}, stale-while-revalidate=${stale}, stale-if-error=${stale}`;
+  return `public, max-age=${remaining}, stale-while-revalidate=0, stale-if-error=0`;
 }
 
 function upsertHeadTag(html, pattern, tag) {

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -26,13 +26,17 @@ import {
   applyStatusCacheHeaders,
   readHomepageSnapshotArtifactJson,
   readHomepageSnapshotJson,
+  readStaleHomepageSnapshotJson,
   readStatusSnapshot,
-  readStaleHomepageSnapshot,
+  readStatusSnapshotJson,
   readStaleHomepageSnapshotArtifact,
   readStaleHomepageSnapshotArtifactJson,
+  readStaleStatusSnapshotJson,
+  markHomepageAccessIfNeeded,
   toSnapshotPayload,
-  writeHomepageDataSnapshot,
+  writeHomepageDataSnapshotJson,
   writeStatusSnapshot,
+  writeStatusSnapshotJson,
 } from '../snapshots';
 
 import { AppError } from '../middleware/errors';
@@ -570,9 +574,10 @@ publicRoutes.get('/status', async (c) => {
     return applyPrivateNoStore(c.json(payload));
   }
 
-  const snapshot = await readStatusSnapshot(c.env.DB, now);
+  const snapshot = await readStatusSnapshotJson(c.env.DB, now);
   if (snapshot) {
-    const res = c.json(snapshot.data);
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(snapshot.bodyJson);
     applyStatusCacheHeaders(res, snapshot.age);
 
     // If we're close to the freshness boundary, trigger a background refresh.
@@ -592,11 +597,13 @@ publicRoutes.get('/status', async (c) => {
   }
   try {
     const payload = await computePublicStatusPayload(c.env.DB, now);
-    const res = c.json(payload);
+    const bodyJson = JSON.stringify(payload);
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(bodyJson);
     applyStatusCacheHeaders(res, 0);
 
     c.executionCtx.waitUntil(
-      writeStatusSnapshot(c.env.DB, now, payload).catch((err) => {
+      writeStatusSnapshotJson(c.env.DB, now, payload.generated_at, bodyJson).catch((err) => {
         console.warn('public snapshot: write failed', err);
       }),
     );
@@ -607,9 +614,10 @@ publicRoutes.get('/status', async (c) => {
 
     // Last-resort fallback for weak networks / D1 hiccups: serve a stale snapshot (bounded)
     // instead of failing the entire status page.
-    const stale = await readStaleStatusSnapshot(c.env.DB, now, 10 * 60);
+    const stale = await readStaleStatusSnapshotJson(c.env.DB, now);
     if (stale) {
-      const res = c.json(toSnapshotPayload(stale.data));
+      c.header('Content-Type', 'application/json; charset=utf-8');
+      const res = c.body(stale.bodyJson);
       applyStatusCacheHeaders(res, Math.min(60, stale.age));
       return res;
     }
@@ -620,8 +628,17 @@ publicRoutes.get('/status', async (c) => {
 
 publicRoutes.get('/homepage', async (c) => {
   const now = Math.floor(Date.now() / 1000);
+  const markHomepageAccess = () =>
+    c.executionCtx.waitUntil(
+      markHomepageAccessIfNeeded(c.env.DB, now).catch((err) => {
+        console.warn('homepage access: mark failed', err);
+      }),
+    );
   const snapshot = await readHomepageSnapshotJson(c.env.DB, now);
   if (snapshot) {
+    if (snapshot.age >= 30) {
+      markHomepageAccess();
+    }
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
@@ -637,16 +654,20 @@ publicRoutes.get('/homepage', async (c) => {
       artifactSnapshot &&
       shouldPreferRecentHomepageArtifact({ artifact: artifactSnapshot, computed: payload })
     ) {
+      markHomepageAccess();
       const res = c.json(artifactSnapshot.data.snapshot);
       applyHomepageCacheHeaders(res, Math.min(60, artifactSnapshot.age));
       return res;
     }
 
-    const res = c.json(payload);
+    markHomepageAccess();
+    const bodyJson = JSON.stringify(payload);
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(bodyJson);
     applyHomepageCacheHeaders(res, 0);
 
     c.executionCtx.waitUntil(
-      writeHomepageDataSnapshot(c.env.DB, now, payload).catch((err) => {
+      writeHomepageDataSnapshotJson(c.env.DB, now, payload.generated_at, bodyJson).catch((err) => {
         console.warn('homepage snapshot: write failed', err);
       }),
     );
@@ -662,14 +683,17 @@ publicRoutes.get('/homepage', async (c) => {
         statusSnapshot.data,
         homepagePreviewsFromArtifact(artifactSnapshot),
       );
+      markHomepageAccess();
       const res = c.json(payload);
       applyHomepageCacheHeaders(res, statusSnapshot.age);
       return res;
     }
 
-    const staleHomepage = await readStaleHomepageSnapshot(c.env.DB, now);
+    const staleHomepage = await readStaleHomepageSnapshotJson(c.env.DB, now);
     if (staleHomepage) {
-      const res = c.json(staleHomepage.data);
+      markHomepageAccess();
+      c.header('Content-Type', 'application/json; charset=utf-8');
+      const res = c.body(staleHomepage.bodyJson);
       applyHomepageCacheHeaders(res, Math.min(60, staleHomepage.age));
       return res;
     }
@@ -681,6 +705,7 @@ publicRoutes.get('/homepage', async (c) => {
         toSnapshotPayload(staleStatus.data),
         homepagePreviewsFromArtifact(artifactSnapshot),
       );
+      markHomepageAccess();
       const res = c.json(payload);
       applyHomepageCacheHeaders(res, Math.min(60, staleStatus.age));
       return res;
@@ -688,6 +713,7 @@ publicRoutes.get('/homepage', async (c) => {
 
     const staleArtifact = await artifactSnapshotPromise;
     if (staleArtifact) {
+      markHomepageAccess();
       const res = c.json(staleArtifact.data.snapshot);
       applyHomepageCacheHeaders(res, Math.min(60, staleArtifact.age));
       return res;
@@ -699,8 +725,15 @@ publicRoutes.get('/homepage', async (c) => {
 
 publicRoutes.get('/homepage-artifact', async (c) => {
   const now = Math.floor(Date.now() / 1000);
+  const markHomepageAccess = () =>
+    c.executionCtx.waitUntil(
+      markHomepageAccessIfNeeded(c.env.DB, now).catch((err) => {
+        console.warn('homepage access: mark failed', err);
+      }),
+    );
   const snapshot = await readHomepageSnapshotArtifactJson(c.env.DB, now);
   if (snapshot) {
+    markHomepageAccess();
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
@@ -709,6 +742,7 @@ publicRoutes.get('/homepage-artifact', async (c) => {
 
   const stale = await readStaleHomepageSnapshotArtifactJson(c.env.DB, now);
   if (stale) {
+    markHomepageAccess();
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(stale.bodyJson);
     applyHomepageCacheHeaders(res, Math.min(60, stale.age));

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -5,9 +5,10 @@ import { getDb, monitors } from '@uptimer/db';
 
 import type { Env } from '../env';
 import { hasValidAdminTokenRequest } from '../middleware/auth';
+import type { PublicHomepageResponse } from '../schemas/public-homepage';
 import {
+  computePublicHomepagePayload,
   homepageFromStatusPayload,
-  readHomepageHistoryPreviews,
 } from '../public/homepage';
 import { computePublicStatusPayload } from '../public/status';
 import {
@@ -30,6 +31,7 @@ import {
   readStaleHomepageSnapshotArtifact,
   readStaleHomepageSnapshotArtifactJson,
   toSnapshotPayload,
+  writeHomepageDataSnapshot,
   writeStatusSnapshot,
 } from '../snapshots';
 
@@ -120,6 +122,34 @@ function shouldPreferRecentHomepageArtifact(opts: {
     computed.overall_status !== snapshot.overall_status ||
     computed.banner.status !== snapshot.banner.status
   );
+}
+
+function homepagePreviewsFromArtifact(
+  artifact:
+    | {
+        data: {
+          snapshot: Pick<
+            PublicHomepageResponse,
+            'resolved_incident_preview' | 'maintenance_history_preview'
+          >;
+        };
+      }
+    | null,
+): {
+  resolvedIncidentPreview: PublicHomepageResponse['resolved_incident_preview'];
+  maintenanceHistoryPreview: PublicHomepageResponse['maintenance_history_preview'];
+} {
+  if (!artifact) {
+    return {
+      resolvedIncidentPreview: null,
+      maintenanceHistoryPreview: null,
+    };
+  }
+
+  return {
+    resolvedIncidentPreview: artifact.data.snapshot.resolved_incident_preview,
+    maintenanceHistoryPreview: artifact.data.snapshot.maintenance_history_preview,
+  };
 }
 
 async function readStaleStatusSnapshot(
@@ -598,51 +628,44 @@ publicRoutes.get('/homepage', async (c) => {
     return res;
   }
 
-  const historyPreviewsPromise = readHomepageHistoryPreviews(c.env.DB, now).catch((err) => {
-    console.warn('public homepage: preview read failed', err);
-    return {
-      resolvedIncidentPreview: null,
-      maintenanceHistoryPreview: null,
-    };
-  });
-  const statusSnapshot = await readStatusSnapshot(c.env.DB, now);
-  if (statusSnapshot) {
-    const payload = homepageFromStatusPayload(
-      statusSnapshot.data,
-      await historyPreviewsPromise,
-    );
-    const res = c.json(payload);
-    applyHomepageCacheHeaders(res, statusSnapshot.age);
-    return res;
-  }
-
   const artifactSnapshotPromise = readStaleHomepageSnapshotArtifact(c.env.DB, now);
 
   try {
-    const statusPayload = await computePublicStatusPayload(c.env.DB, now);
+    const payload = await computePublicHomepagePayload(c.env.DB, now);
     const artifactSnapshot = await artifactSnapshotPromise;
     if (
       artifactSnapshot &&
-      shouldPreferRecentHomepageArtifact({ artifact: artifactSnapshot, computed: statusPayload })
+      shouldPreferRecentHomepageArtifact({ artifact: artifactSnapshot, computed: payload })
     ) {
       const res = c.json(artifactSnapshot.data.snapshot);
       applyHomepageCacheHeaders(res, Math.min(60, artifactSnapshot.age));
       return res;
     }
 
-    const payload = homepageFromStatusPayload(statusPayload, await historyPreviewsPromise);
     const res = c.json(payload);
     applyHomepageCacheHeaders(res, 0);
 
     c.executionCtx.waitUntil(
-      writeStatusSnapshot(c.env.DB, now, statusPayload).catch((err) => {
-        console.warn('public snapshot: write failed', err);
+      writeHomepageDataSnapshot(c.env.DB, now, payload).catch((err) => {
+        console.warn('homepage snapshot: write failed', err);
       }),
     );
 
     return res;
   } catch (err) {
-    console.warn('public homepage: secondary status compute failed', err);
+    console.warn('public homepage: direct compute failed', err);
+
+    const statusSnapshot = await readStatusSnapshot(c.env.DB, now);
+    if (statusSnapshot) {
+      const artifactSnapshot = await artifactSnapshotPromise;
+      const payload = homepageFromStatusPayload(
+        statusSnapshot.data,
+        homepagePreviewsFromArtifact(artifactSnapshot),
+      );
+      const res = c.json(payload);
+      applyHomepageCacheHeaders(res, statusSnapshot.age);
+      return res;
+    }
 
     const staleHomepage = await readStaleHomepageSnapshot(c.env.DB, now);
     if (staleHomepage) {
@@ -653,12 +676,10 @@ publicRoutes.get('/homepage', async (c) => {
 
     const staleStatus = await readStaleStatusSnapshot(c.env.DB, now, 10 * 60);
     if (staleStatus) {
+      const artifactSnapshot = await artifactSnapshotPromise;
       const payload = homepageFromStatusPayload(
         toSnapshotPayload(staleStatus.data),
-        await historyPreviewsPromise.catch(() => ({
-          resolvedIncidentPreview: null,
-          maintenanceHistoryPreview: null,
-        })),
+        homepagePreviewsFromArtifact(artifactSnapshot),
       );
       const res = c.json(payload);
       applyHomepageCacheHeaders(res, Math.min(60, staleStatus.age));

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -21,8 +21,15 @@ import {
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
-import { computePublicHomepageArtifactPayload } from '../public/homepage';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../snapshots';
+import {
+  computePublicHomepageArtifactPayload,
+  computePublicHomepagePayload,
+} from '../public/homepage';
+import {
+  refreshPublicHomepageArtifactSnapshotIfNeeded,
+  refreshPublicHomepageSnapshotIfNeeded,
+  wasHomepageRecentlyAccessed,
+} from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -591,14 +598,24 @@ function queueMonitorNotification(
 export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
-  const queueHomepageRefresh = () =>
-    refreshPublicHomepageArtifactSnapshotIfNeeded({
-      db: env.DB,
-      now,
-      compute: () => computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
-    }).catch((err) => {
+  const queueHomepageRefresh = async () => {
+    const refresh = (await wasHomepageRecentlyAccessed(env.DB, now))
+      ? refreshPublicHomepageSnapshotIfNeeded({
+          db: env.DB,
+          now,
+          compute: () => computePublicHomepagePayload(env.DB, Math.floor(Date.now() / 1000)),
+        })
+      : refreshPublicHomepageArtifactSnapshotIfNeeded({
+          db: env.DB,
+          now,
+          compute: () =>
+            computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
+        });
+
+    return refresh.catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     });
+  };
 
   const acquired = await acquireLease(env.DB, LOCK_NAME, now, LOCK_LEASE_SECONDS);
   if (!acquired) {

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -7,8 +7,10 @@ import {
 
 const SNAPSHOT_KEY = 'homepage';
 const SNAPSHOT_ARTIFACT_KEY = 'homepage:artifact';
+const SNAPSHOT_ACCESS_KEY = 'homepage:access';
 const MAX_AGE_SECONDS = 60;
 const MAX_STALE_SECONDS = 10 * 60;
+const ACCESS_MAX_AGE_SECONDS = 2 * 60;
 const REFRESH_LOCK_NAME = 'snapshot:homepage:refresh';
 const MAX_BOOTSTRAP_MONITORS = 12;
 
@@ -441,8 +443,25 @@ async function readHomepageArtifactSnapshotRow(db: D1Database) {
   return readSnapshotRow(db, SNAPSHOT_ARTIFACT_KEY);
 }
 
+async function readHomepageAccessSnapshotRow(db: D1Database) {
+  return readSnapshotRow(db, SNAPSHOT_ACCESS_KEY);
+}
+
 function isSameMinute(a: number, b: number): boolean {
   return Math.floor(a / 60) === Math.floor(b / 60);
+}
+
+function isSnapshotPairFreshForMinute(opts: {
+  dataGeneratedAt: number | null;
+  artifactGeneratedAt: number | null;
+  now: number;
+}): boolean {
+  return (
+    opts.dataGeneratedAt !== null &&
+    isSameMinute(opts.dataGeneratedAt, opts.now) &&
+    opts.artifactGeneratedAt !== null &&
+    isSameMinute(opts.artifactGeneratedAt, opts.now)
+  );
 }
 
 export function getHomepageSnapshotKey() {
@@ -699,6 +718,29 @@ export async function readHomepageArtifactSnapshotGeneratedAt(
   return row?.generated_at ?? null;
 }
 
+export async function markHomepageAccessIfNeeded(
+  db: D1Database,
+  now: number,
+): Promise<boolean> {
+  const generatedAt = (await readHomepageAccessSnapshotRow(db))?.generated_at ?? null;
+  if (generatedAt !== null && isSameMinute(generatedAt, now)) {
+    return false;
+  }
+
+  await homepageSnapshotUpsertStatement(db, SNAPSHOT_ACCESS_KEY, now, '{}', now).run();
+  return true;
+}
+
+export async function wasHomepageRecentlyAccessed(
+  db: D1Database,
+  now: number,
+  maxAgeSeconds = ACCESS_MAX_AGE_SECONDS,
+): Promise<boolean> {
+  const row = await readHomepageAccessSnapshotRow(db);
+  if (!row) return false;
+  return Math.max(0, now - row.generated_at) <= maxAgeSeconds;
+}
+
 function homepageSnapshotUpsertStatement(
   db: D1Database,
   key: string,
@@ -748,11 +790,20 @@ export async function writeHomepageDataSnapshot(
 ): Promise<void> {
   const dataBodyJson = JSON.stringify(payload);
 
+  await writeHomepageDataSnapshotJson(db, now, payload.generated_at, dataBodyJson);
+}
+
+export async function writeHomepageDataSnapshotJson(
+  db: D1Database,
+  now: number,
+  generatedAt: number,
+  bodyJson: string,
+): Promise<void> {
   await homepageSnapshotUpsertStatement(
     db,
     SNAPSHOT_KEY,
-    payload.generated_at,
-    dataBodyJson,
+    generatedAt,
+    bodyJson,
     now,
   ).run();
 }
@@ -776,12 +827,10 @@ export async function writeHomepageArtifactSnapshot(
 
 export function applyHomepageCacheHeaders(res: Response, ageSeconds: number): void {
   const remaining = Math.max(0, MAX_AGE_SECONDS - ageSeconds);
-  const maxAge = Math.min(30, remaining);
-  const stale = Math.max(0, remaining - maxAge);
 
   res.headers.set(
     'Cache-Control',
-    `public, max-age=${maxAge}, stale-while-revalidate=${stale}, stale-if-error=${stale}`,
+    `public, max-age=${remaining}, stale-while-revalidate=0, stale-if-error=0`,
   );
 }
 
@@ -816,8 +865,11 @@ export async function refreshPublicHomepageSnapshotIfNeeded(opts: {
   now: number;
   compute: () => Promise<unknown>;
 }): Promise<boolean> {
-  const generatedAt = await readHomepageSnapshotGeneratedAt(opts.db);
-  if (generatedAt !== null && isSameMinute(generatedAt, opts.now)) {
+  const [dataGeneratedAt, artifactGeneratedAt] = await Promise.all([
+    readHomepageSnapshotGeneratedAt(opts.db),
+    readHomepageArtifactSnapshotGeneratedAt(opts.db),
+  ]);
+  if (isSnapshotPairFreshForMinute({ dataGeneratedAt, artifactGeneratedAt, now: opts.now })) {
     return false;
   }
 
@@ -826,8 +878,17 @@ export async function refreshPublicHomepageSnapshotIfNeeded(opts: {
     return false;
   }
 
-  const latestGeneratedAt = await readHomepageSnapshotGeneratedAt(opts.db);
-  if (latestGeneratedAt !== null && isSameMinute(latestGeneratedAt, opts.now)) {
+  const [latestDataGeneratedAt, latestArtifactGeneratedAt] = await Promise.all([
+    readHomepageSnapshotGeneratedAt(opts.db),
+    readHomepageArtifactSnapshotGeneratedAt(opts.db),
+  ]);
+  if (
+    isSnapshotPairFreshForMinute({
+      dataGeneratedAt: latestDataGeneratedAt,
+      artifactGeneratedAt: latestArtifactGeneratedAt,
+      now: opts.now,
+    })
+  ) {
     return false;
   }
 

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -741,6 +741,22 @@ export async function writeHomepageSnapshot(
   ]);
 }
 
+export async function writeHomepageDataSnapshot(
+  db: D1Database,
+  now: number,
+  payload: PublicHomepageResponse,
+): Promise<void> {
+  const dataBodyJson = JSON.stringify(payload);
+
+  await homepageSnapshotUpsertStatement(
+    db,
+    SNAPSHOT_KEY,
+    payload.generated_at,
+    dataBodyJson,
+    now,
+  ).run();
+}
+
 export async function writeHomepageArtifactSnapshot(
   db: D1Database,
   now: number,

--- a/apps/worker/src/snapshots/public-status.ts
+++ b/apps/worker/src/snapshots/public-status.ts
@@ -3,6 +3,7 @@ import { publicStatusResponseSchema, type PublicStatusResponse } from '../schema
 
 const SNAPSHOT_KEY = 'status';
 const MAX_AGE_SECONDS = 60;
+const MAX_STALE_SECONDS = 10 * 60;
 
 export function getSnapshotKey() {
   return SNAPSHOT_KEY;
@@ -22,21 +23,36 @@ function safeJsonParse(text: string): unknown | null {
   }
 }
 
+function looksLikeSerializedStatusPayload(text: string): boolean {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith('{"generated_at":') &&
+    trimmed.includes('"summary"') &&
+    trimmed.includes('"monitors"')
+  );
+}
+
+async function readStatusSnapshotRow(
+  db: D1Database,
+): Promise<{ generated_at: number; body_json: string } | null> {
+  return db
+    .prepare(
+      `
+      SELECT generated_at, body_json
+      FROM public_snapshots
+      WHERE key = ?1
+    `,
+    )
+    .bind(SNAPSHOT_KEY)
+    .first<{ generated_at: number; body_json: string }>();
+}
+
 export async function readStatusSnapshot(
   db: D1Database,
   now: number,
 ): Promise<{ data: PublicStatusResponse; age: number } | null> {
   try {
-    const row = await db
-      .prepare(
-        `
-        SELECT generated_at, body_json
-        FROM public_snapshots
-        WHERE key = ?1
-      `,
-      )
-      .bind(SNAPSHOT_KEY)
-      .first<{ generated_at: number; body_json: string }>();
+    const row = await readStatusSnapshotRow(db);
 
     if (!row) return null;
 
@@ -54,13 +70,72 @@ export async function readStatusSnapshot(
   }
 }
 
-export async function writeStatusSnapshot(
+export async function readStatusSnapshotJson(
   db: D1Database,
   now: number,
-  payload: PublicStatusResponse,
-): Promise<void> {
-  const bodyJson = JSON.stringify(payload);
-  await db
+): Promise<{ bodyJson: string; age: number } | null> {
+  try {
+    const row = await readStatusSnapshotRow(db);
+    if (!row) return null;
+
+    const age = Math.max(0, now - row.generated_at);
+    if (age > MAX_AGE_SECONDS) return null;
+
+    if (looksLikeSerializedStatusPayload(row.body_json)) {
+      return {
+        bodyJson: row.body_json,
+        age,
+      };
+    }
+
+    const parsed = safeJsonParse(row.body_json);
+    const data = publicStatusResponseSchema.parse(parsed);
+    return {
+      bodyJson: JSON.stringify(data),
+      age,
+    };
+  } catch (err) {
+    console.warn('public snapshot: read failed, falling back to live', err);
+    return null;
+  }
+}
+
+export async function readStaleStatusSnapshotJson(
+  db: D1Database,
+  now: number,
+): Promise<{ bodyJson: string; age: number } | null> {
+  try {
+    const row = await readStatusSnapshotRow(db);
+    if (!row) return null;
+
+    const age = Math.max(0, now - row.generated_at);
+    if (age > MAX_STALE_SECONDS) return null;
+
+    if (looksLikeSerializedStatusPayload(row.body_json)) {
+      return {
+        bodyJson: row.body_json,
+        age,
+      };
+    }
+
+    const parsed = safeJsonParse(row.body_json);
+    const data = publicStatusResponseSchema.parse(parsed);
+    return {
+      bodyJson: JSON.stringify(data),
+      age,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function statusSnapshotUpsertStatement(
+  db: D1Database,
+  generatedAt: number,
+  bodyJson: string,
+  now: number,
+): D1PreparedStatement {
+  return db
     .prepare(
       `
       INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
@@ -71,21 +146,33 @@ export async function writeStatusSnapshot(
         updated_at = excluded.updated_at
     `,
     )
-    .bind(SNAPSHOT_KEY, payload.generated_at, bodyJson, now)
-    .run();
+    .bind(SNAPSHOT_KEY, generatedAt, bodyJson, now);
+}
+
+export async function writeStatusSnapshot(
+  db: D1Database,
+  now: number,
+  payload: PublicStatusResponse,
+): Promise<void> {
+  const bodyJson = JSON.stringify(payload);
+  await writeStatusSnapshotJson(db, now, payload.generated_at, bodyJson);
+}
+
+export async function writeStatusSnapshotJson(
+  db: D1Database,
+  now: number,
+  generatedAt: number,
+  bodyJson: string,
+): Promise<void> {
+  await statusSnapshotUpsertStatement(db, generatedAt, bodyJson, now).run();
 }
 
 export function applyStatusCacheHeaders(res: Response, ageSeconds: number): void {
-  // Guarantee freshness bound <= 60s. Prefer <= 30s in normal cases.
-  //
-  // We ensure (max-age + stale-*) never exceeds MAX_AGE_SECONDS.
   const remaining = Math.max(0, MAX_AGE_SECONDS - ageSeconds);
-  const maxAge = Math.min(30, remaining);
-  const stale = Math.max(0, remaining - maxAge);
 
   res.headers.set(
     'Cache-Control',
-    `public, max-age=${maxAge}, stale-while-revalidate=${stale}, stale-if-error=${stale}`,
+    `public, max-age=${remaining}, stale-while-revalidate=0, stale-if-error=0`,
   );
 }
 

--- a/apps/worker/test/homepage-snapshot.bench.ts
+++ b/apps/worker/test/homepage-snapshot.bench.ts
@@ -485,6 +485,10 @@ async function runOneRouteRead(scenario: RouteReadScenario): Promise<RouteReadSa
                 }
               : null,
         },
+        {
+          match: 'insert into public_snapshots',
+          run: () => ({ meta: { changes: 1 } }),
+        },
       ]),
       ADMIN_TOKEN: 'test-admin-token',
     } as unknown as Env;

--- a/apps/worker/test/homepage-snapshot.bench.ts
+++ b/apps/worker/test/homepage-snapshot.bench.ts
@@ -51,6 +51,17 @@ type RouteReadSample = {
   bodyKB: number;
 };
 
+type HomepageHotPathScenario = {
+  name: string;
+  mode: 'direct-homepage-compute';
+  monitorCount: number;
+};
+
+type HomepageHotPathSample = {
+  elapsedMs: number;
+  bodyKB: number;
+};
+
 const BENCH_LABEL = process.env.HOMEPAGE_BENCH_LABEL ?? 'current-working-tree';
 const OUTPUT_PATH = process.env.HOMEPAGE_BENCH_OUTPUT ?? null;
 
@@ -70,6 +81,19 @@ const ROUTE_READ_SCENARIOS: RouteReadScenario[] = [
   { name: 'homepage / 1000 monitors', endpoint: 'homepage', monitorCount: 1000 },
   { name: 'homepage-artifact / 250 monitors', endpoint: 'homepage-artifact', monitorCount: 250 },
   { name: 'homepage-artifact / 1000 monitors', endpoint: 'homepage-artifact', monitorCount: 1000 },
+];
+
+const HOMEPAGE_HOT_PATH_SCENARIOS: HomepageHotPathScenario[] = [
+  {
+    name: 'homepage via direct homepage compute / 250 monitors',
+    mode: 'direct-homepage-compute',
+    monitorCount: 250,
+  },
+  {
+    name: 'homepage via direct homepage compute / 1000 monitors',
+    mode: 'direct-homepage-compute',
+    monitorCount: 1000,
+  },
 ];
 
 function parsePositiveIntEnv(name: string, fallback: number): number {
@@ -136,7 +160,14 @@ function getScenarioRows(scenario: Scenario, now: number) {
   return built;
 }
 
-function createDbForScenario(scenario: Scenario, now: number) {
+function createHandlersForScenario(scenario: Scenario, now: number): {
+  handlers: FakeD1QueryHandler[];
+  rowCounts: {
+    monitorCount: number;
+    heartbeatRows: number;
+    rollupRows: number;
+  };
+} {
   const rows = getScenarioRows(scenario, now);
 
   const handlers: FakeD1QueryHandler[] = [
@@ -171,8 +202,21 @@ function createDbForScenario(scenario: Scenario, now: number) {
       all: () => rows.heartbeats,
     },
     {
+      match: 'select monitor_id, checked_at, status from check_results',
+      all: () =>
+        rows.heartbeats.map((row) => ({
+          monitor_id: row.monitor_id,
+          checked_at: row.checked_at,
+          status: row.status,
+        })),
+    },
+    {
       match: 'from monitor_daily_rollups',
       all: () => rows.rollups,
+    },
+    {
+      match: 'from outages',
+      all: () => [],
     },
     {
       match: (sql) => sql.startsWith('select key, value from settings'),
@@ -194,12 +238,20 @@ function createDbForScenario(scenario: Scenario, now: number) {
   ];
 
   return {
-    db: createFakeD1Database(handlers),
+    handlers,
     rowCounts: {
       monitorCount: rows.monitors.length,
       heartbeatRows: rows.heartbeats.length,
       rollupRows: rows.rollups.length,
     },
+  };
+}
+
+function createDbForScenario(scenario: Scenario, now: number) {
+  const { handlers, rowCounts } = createHandlersForScenario(scenario, now);
+  return {
+    db: createFakeD1Database(handlers),
+    rowCounts,
   };
 }
 
@@ -479,12 +531,120 @@ function summarizeRouteRead(scenario: RouteReadScenario, samples: RouteReadSampl
   };
 }
 
+async function runOneHomepageHotPath(
+  scenario: HomepageHotPathScenario,
+): Promise<HomepageHotPathSample> {
+  const now = 1_728_000_000;
+  const originalCaches = globalThis.caches;
+
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: {
+      open: async () => ({
+        match: async () => undefined,
+        put: async () => undefined,
+      }),
+    },
+  });
+
+  try {
+    const artifactPayload = buildSyntheticHomepagePayload(
+      Math.min(scenario.monitorCount, 12),
+      30,
+      14,
+      now,
+    );
+    const artifact = buildHomepageRenderArtifact({
+      ...artifactPayload,
+      bootstrap_mode: scenario.monitorCount > artifactPayload.monitors.length ? 'partial' : 'full',
+      monitor_count_total: scenario.monitorCount,
+    });
+    const scenarioShape: Scenario = {
+      name: scenario.name,
+      monitorCount: scenario.monitorCount,
+      heartbeatPoints: 30,
+      uptimeDays: 14,
+    };
+    const { handlers } = createHandlersForScenario(scenarioShape, now);
+    const liveHandlers = [
+      ...handlers,
+      {
+        match: 'insert into public_snapshots',
+        run: () => ({ meta: { changes: 1 } }),
+      } satisfies FakeD1QueryHandler,
+    ];
+    const env = {
+      DB: createFakeD1Database([
+        {
+          match: 'from public_snapshots',
+          first: (args) => {
+            if (args[0] === 'homepage') return null;
+            if (args[0] === 'homepage:artifact') {
+              return {
+                generated_at: now,
+                body_json: JSON.stringify(artifact),
+              };
+            }
+            return null;
+          },
+        },
+        ...liveHandlers,
+      ]),
+      ADMIN_TOKEN: 'test-admin-token',
+    } as unknown as Env;
+
+    const app = new Hono<{ Bindings: Env }>();
+    app.onError(handleError);
+    app.notFound(handleNotFound);
+    app.route('/api/v1/public', publicRoutes);
+
+    const started = performance.now();
+    const response = await app.fetch(
+      new Request('https://status.example.com/api/v1/public/homepage'),
+      env,
+      { waitUntil: () => undefined } as ExecutionContext,
+    );
+    const responseBody = await response.text();
+    const elapsedMs = performance.now() - started;
+    expect(response.ok).toBe(true);
+
+    return {
+      elapsedMs,
+      bodyKB: Number((responseBody.length / 1024).toFixed(1)),
+    };
+  } finally {
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: originalCaches,
+    });
+  }
+}
+
+function summarizeHomepageHotPath(
+  scenario: HomepageHotPathScenario,
+  samples: HomepageHotPathSample[],
+) {
+  const elapsed = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const totalElapsed = elapsed.reduce((sum, value) => sum + value, 0);
+  const first = samples[0];
+
+  return {
+    scenario: scenario.name,
+    runs: samples.length,
+    meanMs: Number((totalElapsed / samples.length).toFixed(3)),
+    medianMs: Number(percentile(elapsed, 0.5).toFixed(3)),
+    p95Ms: Number(percentile(elapsed, 0.95).toFixed(3)),
+    bodyKB: first?.bodyKB ?? 0,
+  };
+}
+
 describe('homepage snapshot benchmark', () => {
   it('measures homepage snapshot compute cost', async () => {
     const rows = [];
     const artifactRows = [];
     const rootMissRows = [];
     const routeReadRows = [];
+    const hotPathRows = [];
 
     for (const scenario of SCENARIOS) {
       for (let index = 0; index < WARMUP_RUNS; index += 1) {
@@ -538,6 +698,19 @@ describe('homepage snapshot benchmark', () => {
       routeReadRows.push(summarizeRouteRead(scenario, samples));
     }
 
+    for (const scenario of HOMEPAGE_HOT_PATH_SCENARIOS) {
+      for (let index = 0; index < WARMUP_RUNS; index += 1) {
+        await runOneHomepageHotPath(scenario);
+      }
+
+      const samples: HomepageHotPathSample[] = [];
+      for (let index = 0; index < MEASURE_RUNS; index += 1) {
+        samples.push(await runOneHomepageHotPath(scenario));
+      }
+
+      hotPathRows.push(summarizeHomepageHotPath(scenario, samples));
+    }
+
     console.log('Homepage snapshot benchmark');
     console.log(`Label: ${BENCH_LABEL}`);
     if (process.env.HOMEPAGE_BENCH_RUNS || process.env.HOMEPAGE_BENCH_WARMUPS) {
@@ -556,6 +729,9 @@ describe('homepage snapshot benchmark', () => {
     console.log('');
     console.log('Worker homepage route read benchmark');
     console.table(routeReadRows);
+    console.log('');
+    console.log('Worker homepage hot path benchmark');
+    console.table(hotPathRows);
 
     if (OUTPUT_PATH) {
       await writeFile(
@@ -566,6 +742,7 @@ describe('homepage snapshot benchmark', () => {
             artifactCompute: artifactRows,
             rootMiss: rootMissRows,
             routeRead: routeReadRows,
+            hotPath: hotPathRows,
           },
           null,
           2,

--- a/apps/worker/test/public-homepage-downgrade-guard.test.ts
+++ b/apps/worker/test/public-homepage-downgrade-guard.test.ts
@@ -183,8 +183,10 @@ describe('public homepage downgrade guard', () => {
       },
       {
         match: 'insert into public_snapshots',
-        run: () => {
-          homepageSnapshotWrites += 1;
+        run: (args) => {
+          if (args[0] === 'homepage') {
+            homepageSnapshotWrites += 1;
+          }
           return 1;
         },
       },
@@ -257,8 +259,10 @@ describe('public homepage downgrade guard', () => {
       },
       {
         match: 'insert into public_snapshots',
-        run: () => {
-          homepageSnapshotWrites += 1;
+        run: (args) => {
+          if (args[0] === 'homepage') {
+            homepageSnapshotWrites += 1;
+          }
           return 1;
         },
       },

--- a/apps/worker/test/public-homepage-downgrade-guard.test.ts
+++ b/apps/worker/test/public-homepage-downgrade-guard.test.ts
@@ -1,13 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const { computePublicStatusPayload } = vi.hoisted(() => ({
-  computePublicStatusPayload: vi.fn(),
+const { computePublicHomepagePayload } = vi.hoisted(() => ({
+  computePublicHomepagePayload: vi.fn(),
 }));
 
-vi.mock('../src/public/status', () => ({
-  computePublicStatusPayload,
-}));
+vi.mock('../src/public/homepage', async () => {
+  const actual = await vi.importActual<typeof import('../src/public/homepage')>(
+    '../src/public/homepage',
+  );
+
+  return {
+    ...actual,
+    computePublicHomepagePayload,
+  };
+});
 
 import type { Env } from '../src/env';
 import { handleError, handleNotFound } from '../src/middleware/errors';
@@ -115,14 +122,16 @@ describe('public homepage downgrade guard', () => {
     }
 
     vi.restoreAllMocks();
-    computePublicStatusPayload.mockReset();
+    computePublicHomepagePayload.mockReset();
   });
 
   it('keeps a recent homepage artifact when live status compute would downgrade it to unknown', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(260_000);
-    let statusSnapshotWrites = 0;
-    computePublicStatusPayload.mockResolvedValue({
+    let homepageSnapshotWrites = 0;
+    computePublicHomepagePayload.mockResolvedValue({
       generated_at: 260,
+      bootstrap_mode: 'full',
+      monitor_count_total: 40,
       site_title: 'Status Hub',
       site_description: 'Production services',
       site_locale: 'en',
@@ -147,6 +156,8 @@ describe('public homepage downgrade guard', () => {
         active: [],
         upcoming: [],
       },
+      resolved_incident_preview: null,
+      maintenance_history_preview: null,
     });
 
     const { res } = await requestHomepage([
@@ -173,7 +184,7 @@ describe('public homepage downgrade guard', () => {
       {
         match: 'insert into public_snapshots',
         run: () => {
-          statusSnapshotWrites += 1;
+          homepageSnapshotWrites += 1;
           return 1;
         },
       },
@@ -191,15 +202,17 @@ describe('public homepage downgrade guard', () => {
         unknown: 0,
       },
     });
-    expect(computePublicStatusPayload).toHaveBeenCalledOnce();
-    expect(statusSnapshotWrites).toBe(0);
+    expect(computePublicHomepagePayload).toHaveBeenCalledOnce();
+    expect(homepageSnapshotWrites).toBe(0);
   });
 
   it('still upgrades to computed homepage data when the live status payload is healthy', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(260_000);
-    let statusSnapshotWrites = 0;
-    computePublicStatusPayload.mockResolvedValue({
+    let homepageSnapshotWrites = 0;
+    computePublicHomepagePayload.mockResolvedValue({
       generated_at: 260,
+      bootstrap_mode: 'full',
+      monitor_count_total: 40,
       site_title: 'Status Hub',
       site_description: 'Production services',
       site_locale: 'en',
@@ -225,6 +238,8 @@ describe('public homepage downgrade guard', () => {
         active: [],
         upcoming: [],
       },
+      resolved_incident_preview: null,
+      maintenance_history_preview: null,
     });
 
     const { res } = await requestHomepage([
@@ -243,17 +258,9 @@ describe('public homepage downgrade guard', () => {
       {
         match: 'insert into public_snapshots',
         run: () => {
-          statusSnapshotWrites += 1;
+          homepageSnapshotWrites += 1;
           return 1;
         },
-      },
-      {
-        match: 'from incidents',
-        all: () => [],
-      },
-      {
-        match: 'from maintenance_windows',
-        all: () => [],
       },
     ]);
 
@@ -269,7 +276,7 @@ describe('public homepage downgrade guard', () => {
         unknown: 0,
       },
     });
-    expect(computePublicStatusPayload).toHaveBeenCalledOnce();
-    expect(statusSnapshotWrites).toBe(1);
+    expect(computePublicHomepagePayload).toHaveBeenCalledOnce();
+    expect(homepageSnapshotWrites).toBe(1);
   });
 });

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -16,6 +16,16 @@ import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1
 
 type CacheStore = Map<string, Response>;
 
+function withSnapshotWriteFallback(handlers: FakeD1QueryHandler[]): FakeD1QueryHandler[] {
+  return [
+    ...handlers,
+    {
+      match: 'insert into public_snapshots',
+      run: () => ({ meta: { changes: 1 } }),
+    },
+  ];
+}
+
 function installCacheMock(store: CacheStore) {
   const open = vi.fn(async () => ({
     async match(request: Request) {
@@ -43,7 +53,7 @@ async function requestHomepageWithWaitUntil(
   waitUntil = vi.fn(),
 ) {
   const env = {
-    DB: createFakeD1Database(handlers),
+    DB: createFakeD1Database(withSnapshotWriteFallback(handlers)),
     ADMIN_TOKEN: 'test-admin-token',
   } as unknown as Env;
 
@@ -63,7 +73,7 @@ async function requestHomepageWithWaitUntil(
 
 async function requestHomepageArtifact(handlers: FakeD1QueryHandler[]) {
   const env = {
-    DB: createFakeD1Database(handlers),
+    DB: createFakeD1Database(withSnapshotWriteFallback(handlers)),
     ADMIN_TOKEN: 'test-admin-token',
   } as unknown as Env;
 
@@ -85,7 +95,7 @@ async function requestHomepageViaApp(
   origin = 'https://status-web.example.com',
 ) {
   const env = {
-    DB: createFakeD1Database(handlers),
+    DB: createFakeD1Database(withSnapshotWriteFallback(handlers)),
     ADMIN_TOKEN: 'test-admin-token',
   } as unknown as Env;
 
@@ -327,7 +337,7 @@ describe('public homepage route', () => {
     expect(first.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
     expect(second.headers.get('Access-Control-Allow-Origin')).toBe('https://two.example.com');
     expect(third.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
-    expect(dbReads).toEqual(['homepage', 'homepage']);
+    expect(dbReads.filter((key) => key === 'homepage')).toEqual(['homepage', 'homepage']);
   });
 
   it('serves a bounded stale homepage snapshot instead of computing in-request', async () => {
@@ -558,10 +568,9 @@ describe('public homepage route', () => {
       ],
     });
 
-    expect(waitUntil).toHaveBeenCalledTimes(2);
+    expect(waitUntil.mock.calls.length).toBeGreaterThanOrEqual(2);
     await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
-    expect(writtenArgs).toHaveLength(1);
-    expect(writtenArgs[0]?.[0]).toBe('homepage');
+    expect(writtenArgs.filter((args) => args[0] === 'homepage')).toHaveLength(1);
   });
 
   it('returns 503 when no homepage snapshot is available', async () => {

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -34,6 +34,14 @@ function installCacheMock(store: CacheStore) {
 }
 
 async function requestHomepage(handlers: FakeD1QueryHandler[]) {
+  const { res } = await requestHomepageWithWaitUntil(handlers);
+  return res;
+}
+
+async function requestHomepageWithWaitUntil(
+  handlers: FakeD1QueryHandler[],
+  waitUntil = vi.fn(),
+) {
   const env = {
     DB: createFakeD1Database(handlers),
     ADMIN_TOKEN: 'test-admin-token',
@@ -44,11 +52,13 @@ async function requestHomepage(handlers: FakeD1QueryHandler[]) {
   app.notFound(handleNotFound);
   app.route('/api/v1/public', publicRoutes);
 
-  return app.fetch(
+  const res = await app.fetch(
     new Request('https://status.example.com/api/v1/public/homepage'),
     env,
-    { waitUntil: vi.fn() } as unknown as ExecutionContext,
+    { waitUntil } as unknown as ExecutionContext,
   );
+
+  return { res, waitUntil };
 }
 
 async function requestHomepageArtifact(handlers: FakeD1QueryHandler[]) {
@@ -443,6 +453,115 @@ describe('public homepage route', () => {
         },
       ],
     });
+  });
+
+  it('prefers direct homepage compute and writes only the homepage data row when the snapshot is missing', async () => {
+    const now = 1_728_000_000;
+    const writtenArgs: unknown[][] = [];
+    vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+
+    const { res, waitUntil } = await requestHomepageWithWaitUntil(
+      [
+        {
+          match: 'from public_snapshots',
+          first: () => null,
+        },
+        {
+          match: 'from monitors m',
+          all: () => [
+            {
+              id: 1,
+              name: 'API',
+              type: 'http',
+              group_name: 'Core',
+              group_sort_order: 0,
+              sort_order: 0,
+              interval_sec: 60,
+              created_at: now - 40 * 86_400,
+              state_status: 'up',
+              last_checked_at: now - 30,
+            },
+          ],
+        },
+        {
+          match: 'select distinct mwm.monitor_id',
+          all: () => [],
+        },
+        {
+          match: 'row_number() over',
+          all: () => [
+            {
+              monitor_id: 1,
+              checked_at: now - 60,
+              status: 'up',
+              latency_ms: 42,
+            },
+          ],
+        },
+        {
+          match: 'from monitor_daily_rollups',
+          all: () => [
+            {
+              monitor_id: 1,
+              day_start_at: now - 86_400,
+              total_sec: 86_400,
+              downtime_sec: 0,
+              unknown_sec: 0,
+              uptime_sec: 86_400,
+            },
+          ],
+        },
+        {
+          match: (sql) => sql.startsWith('select key, value from settings'),
+          all: () => [
+            { key: 'site_title', value: 'Status Hub' },
+            { key: 'site_description', value: 'Production services' },
+            { key: 'site_locale', value: 'en' },
+            { key: 'site_timezone', value: 'UTC' },
+            { key: 'uptime_rating_level', value: '4' },
+          ],
+        },
+        {
+          match: 'from incidents',
+          all: () => [],
+        },
+        {
+          match: 'from maintenance_windows',
+          all: () => [],
+        },
+        {
+          match: 'insert into public_snapshots',
+          run: (args) => {
+            writtenArgs.push(args);
+            return { meta: { changes: 1 } };
+          },
+        },
+      ],
+      vi.fn((promise) => promise),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      generated_at: now,
+      bootstrap_mode: 'full',
+      monitor_count_total: 1,
+      uptime_rating_level: 4,
+      monitors: [
+        {
+          id: 1,
+          heartbeat_strip: {
+            checked_at: [now - 60],
+            status_codes: 'u',
+            latency_ms: [42],
+          },
+        },
+      ],
+    });
+
+    expect(waitUntil).toHaveBeenCalledTimes(2);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+    expect(writtenArgs).toHaveLength(1);
+    expect(writtenArgs[0]?.[0]).toBe('homepage');
   });
 
   it('returns 503 when no homepage snapshot is available', async () => {

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -17,19 +17,26 @@ vi.mock('../src/notify/webhook', () => ({
 }));
 vi.mock('../src/public/homepage', () => ({
   computePublicHomepageArtifactPayload: vi.fn(),
+  computePublicHomepagePayload: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
   refreshPublicHomepageArtifactSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
+  wasHomepageRecentlyAccessed: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { runHttpCheck } from '../src/monitor/http';
 import { runTcpCheck } from '../src/monitor/tcp';
 import { dispatchWebhookToChannels } from '../src/notify/webhook';
-import { computePublicHomepageArtifactPayload } from '../src/public/homepage';
+import { computePublicHomepageArtifactPayload, computePublicHomepagePayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../src/snapshots';
+import {
+  refreshPublicHomepageArtifactSnapshotIfNeeded,
+  refreshPublicHomepageSnapshotIfNeeded,
+  wasHomepageRecentlyAccessed,
+} from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -140,7 +147,12 @@ describe('scheduler/scheduled regression', () => {
     vi.mocked(computePublicHomepageArtifactPayload).mockResolvedValue({
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
+    vi.mocked(computePublicHomepagePayload).mockResolvedValue({
+      generated_at: Math.floor(Date.now() / 1000),
+    } as never);
     vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(wasHomepageRecentlyAccessed).mockResolvedValue(false);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -183,6 +195,7 @@ describe('scheduler/scheduled regression', () => {
 
     expect(acquireLease).toHaveBeenCalledWith(env.DB, 'scheduler:tick', expectedNow, 55);
     expect(readSettings).toHaveBeenCalledTimes(1);
+    expect(wasHomepageRecentlyAccessed).toHaveBeenCalledWith(env.DB, expectedNow);
     expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
@@ -192,6 +205,30 @@ describe('scheduler/scheduled regression', () => {
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
     expect(computePublicHomepageArtifactPayload).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches to full homepage snapshot refresh when homepage traffic was seen recently', async () => {
+    vi.mocked(wasHomepageRecentlyAccessed).mockResolvedValue(true);
+
+    const env = createEnv({ dueRows: [] });
+    const waitUntil = vi.fn();
+    const expectedNow = Math.floor(Date.now() / 1000);
+
+    await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
+
+    expect(wasHomepageRecentlyAccessed).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
+      db: env.DB,
+      now: expectedNow,
+      compute: expect.any(Function),
+    });
+    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).not.toHaveBeenCalled();
+
+    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
+    expect(refreshArgs).toBeDefined();
+    await refreshArgs?.compute();
+    expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -11,15 +11,20 @@ import {
   getHomepageSnapshotKey,
   getHomepageSnapshotMaxAgeSeconds,
   getHomepageSnapshotMaxStaleSeconds,
+  markHomepageAccessIfNeeded,
   refreshPublicHomepageArtifactSnapshotIfNeeded,
   readHomepageSnapshot,
+  readHomepageSnapshotJson,
   readHomepageSnapshotArtifact,
   readStaleHomepageSnapshot,
+  readStaleHomepageSnapshotJson,
   readStaleHomepageSnapshotArtifact,
   refreshPublicHomepageSnapshotIfNeeded,
   toHomepageSnapshotPayload,
+  wasHomepageRecentlyAccessed,
   writeHomepageArtifactSnapshot,
   writeHomepageDataSnapshot,
+  writeHomepageDataSnapshotJson,
   writeHomepageSnapshot,
 } from '../src/snapshots/public-homepage';
 import { createFakeD1Database } from './helpers/fake-d1';
@@ -132,6 +137,32 @@ describe('snapshots/public-homepage', () => {
     });
     await expect(readStaleHomepageSnapshotArtifact(db, 200)).resolves.toEqual({
       data: storedRender,
+      age: 10,
+    });
+  });
+
+  it('reads fresh and bounded-stale homepage snapshot JSON without reparsing the hot path', async () => {
+    const payload = samplePayload(190);
+    const bodyJson = JSON.stringify(payload);
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: (args) =>
+          args[0] === 'homepage'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: bodyJson,
+              }
+            : null,
+      },
+    ]);
+
+    await expect(readHomepageSnapshotJson(db, 200)).resolves.toEqual({
+      bodyJson,
+      age: 10,
+    });
+    await expect(readStaleHomepageSnapshotJson(db, 200)).resolves.toEqual({
+      bodyJson,
       age: 10,
     });
   });
@@ -277,7 +308,7 @@ describe('snapshots/public-homepage', () => {
     const fresh = new Response('ok');
     applyHomepageCacheHeaders(fresh, 10);
     expect(fresh.headers.get('Cache-Control')).toBe(
-      'public, max-age=30, stale-while-revalidate=20, stale-if-error=20',
+      'public, max-age=50, stale-while-revalidate=0, stale-if-error=0',
     );
 
     const stale = new Response('ok');
@@ -298,10 +329,16 @@ describe('snapshots/public-homepage', () => {
     const db = createFakeD1Database([
       {
         match: 'from public_snapshots',
-        first: () => ({
-          generated_at: 1_728_000_031,
-          body_json: JSON.stringify(samplePayload(1_728_000_031)),
-        }),
+        first: (args) =>
+          args[0] === 'homepage' || args[0] === 'homepage:artifact'
+            ? {
+                generated_at: 1_728_000_031,
+                body_json:
+                  args[0] === 'homepage'
+                    ? JSON.stringify(samplePayload(1_728_000_031))
+                    : JSON.stringify(buildHomepageRenderArtifact(samplePayload(1_728_000_031))),
+              }
+            : null,
       },
     ]);
 
@@ -316,26 +353,25 @@ describe('snapshots/public-homepage', () => {
   it('refreshes once when the minute changed and a refresh lease is acquired', async () => {
     vi.mocked(acquireLease).mockResolvedValue(true);
 
-    let readCount = 0;
+    let dataGeneratedAt = 1_728_000_001;
+    let artifactGeneratedAt = 1_728_000_001;
     const writtenArgs: unknown[][] = [];
     const now = 1_728_000_120;
     const db = createFakeD1Database([
       {
         match: 'from public_snapshots',
         first: (args) => {
-          if (args[0] !== 'homepage') {
+          if (args[0] !== 'homepage' && args[0] !== 'homepage:artifact') {
             return null;
           }
-          readCount += 1;
-          if (readCount <= 2) {
-            return {
-              generated_at: 1_728_000_001,
-              body_json: JSON.stringify(samplePayload(1_728_000_001)),
-            };
-          }
+
+          const generatedAt = args[0] === 'homepage' ? dataGeneratedAt : artifactGeneratedAt;
           return {
-            generated_at: now,
-            body_json: JSON.stringify(samplePayload(now)),
+            generated_at: generatedAt,
+            body_json:
+              args[0] === 'homepage'
+                ? JSON.stringify(samplePayload(generatedAt))
+                : JSON.stringify(buildHomepageRenderArtifact(samplePayload(generatedAt))),
           };
         },
       },
@@ -343,6 +379,12 @@ describe('snapshots/public-homepage', () => {
         match: 'insert into public_snapshots',
         run: (args) => {
           writtenArgs.push(args);
+          if (args[0] === 'homepage') {
+            dataGeneratedAt = Number(args[1]);
+          }
+          if (args[0] === 'homepage:artifact') {
+            artifactGeneratedAt = Number(args[1]);
+          }
           return { meta: { changes: 1 } };
         },
       },
@@ -428,5 +470,59 @@ describe('snapshots/public-homepage', () => {
     await writeHomepageDataSnapshot(db, 300, payload);
 
     expect(boundArgs).toEqual([['homepage', 280, JSON.stringify(payload), 300]]);
+  });
+
+  it('writes pre-serialized homepage snapshot JSON without extra normalization work', async () => {
+    const boundArgs: unknown[][] = [];
+    const db = createFakeD1Database([
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          boundArgs.push(args);
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    const payload = samplePayload(280);
+    const bodyJson = JSON.stringify(payload);
+    await writeHomepageDataSnapshotJson(db, 300, payload.generated_at, bodyJson);
+
+    expect(boundArgs).toEqual([['homepage', 280, bodyJson, 300]]);
+  });
+
+  it('marks homepage access at most once per minute and exposes recent-access checks', async () => {
+    let accessGeneratedAt: number | null = null;
+    const writes: unknown[][] = [];
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: (args) =>
+          args[0] === 'homepage:access' && accessGeneratedAt !== null
+            ? {
+                generated_at: accessGeneratedAt,
+                body_json: '{}',
+              }
+            : null,
+      },
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          writes.push(args);
+          if (args[0] === 'homepage:access') {
+            accessGeneratedAt = Number(args[1]);
+          }
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    await expect(wasHomepageRecentlyAccessed(db, 1_728_000_120)).resolves.toBe(false);
+    await expect(markHomepageAccessIfNeeded(db, 1_728_000_120)).resolves.toBe(true);
+    await expect(markHomepageAccessIfNeeded(db, 1_728_000_125)).resolves.toBe(false);
+    await expect(wasHomepageRecentlyAccessed(db, 1_728_000_170)).resolves.toBe(true);
+    await expect(wasHomepageRecentlyAccessed(db, 1_728_000_400)).resolves.toBe(false);
+
+    expect(writes).toEqual([['homepage:access', 1_728_000_120, '{}', 1_728_000_120]]);
   });
 });

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -19,6 +19,7 @@ import {
   refreshPublicHomepageSnapshotIfNeeded,
   toHomepageSnapshotPayload,
   writeHomepageArtifactSnapshot,
+  writeHomepageDataSnapshot,
   writeHomepageSnapshot,
 } from '../src/snapshots/public-homepage';
 import { createFakeD1Database } from './helpers/fake-d1';
@@ -409,5 +410,23 @@ describe('snapshots/public-homepage', () => {
     expect(writtenArgs).toEqual([
       ['homepage:artifact', now, JSON.stringify(buildHomepageRenderArtifact(payload)), now],
     ]);
+  });
+
+  it('writes data-only homepage snapshots without touching the artifact row', async () => {
+    const boundArgs: unknown[][] = [];
+    const db = createFakeD1Database([
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          boundArgs.push(args);
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    const payload = samplePayload(280);
+    await writeHomepageDataSnapshot(db, 300, payload);
+
+    expect(boundArgs).toEqual([['homepage', 280, JSON.stringify(payload), 300]]);
   });
 });

--- a/apps/worker/test/snapshots-public-status.test.ts
+++ b/apps/worker/test/snapshots-public-status.test.ts
@@ -6,8 +6,11 @@ import {
   getSnapshotKey,
   getSnapshotMaxAgeSeconds,
   readStatusSnapshot,
+  readStatusSnapshotJson,
+  readStaleStatusSnapshotJson,
   toSnapshotPayload,
   writeStatusSnapshot,
+  writeStatusSnapshotJson,
 } from '../src/snapshots/public-status';
 import { createFakeD1Database } from './helpers/fake-d1';
 
@@ -90,6 +93,30 @@ describe('snapshots/public-status', () => {
     warn.mockRestore();
   });
 
+  it('reads fresh and bounded-stale snapshot JSON without reparsing the hot path', async () => {
+    const now = 200;
+    const payload = samplePayload(190);
+    const bodyJson = JSON.stringify(payload);
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: () => ({
+          generated_at: payload.generated_at,
+          body_json: bodyJson,
+        }),
+      },
+    ]);
+
+    await expect(readStatusSnapshotJson(db, now)).resolves.toEqual({
+      bodyJson,
+      age: 10,
+    });
+    await expect(readStaleStatusSnapshotJson(db, now)).resolves.toEqual({
+      bodyJson,
+      age: 10,
+    });
+  });
+
   it('writes the normalized snapshot payload with upsert semantics', async () => {
     let boundArgs: unknown[] | null = null;
     const db = createFakeD1Database([
@@ -109,11 +136,31 @@ describe('snapshots/public-status', () => {
     expect(boundArgs).toEqual(['status', 280, JSON.stringify(payload), now]);
   });
 
+  it('writes pre-serialized snapshot JSON without extra normalization work', async () => {
+    let boundArgs: unknown[] | null = null;
+    const db = createFakeD1Database([
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          boundArgs = args;
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    const now = 300;
+    const payload = samplePayload(280);
+    const bodyJson = JSON.stringify(payload);
+    await writeStatusSnapshotJson(db, now, payload.generated_at, bodyJson);
+
+    expect(boundArgs).toEqual(['status', 280, bodyJson, now]);
+  });
+
   it('sets bounded cache-control headers based on current snapshot age', () => {
     const young = new Response('ok');
     applyStatusCacheHeaders(young, 10);
     expect(young.headers.get('Cache-Control')).toBe(
-      'public, max-age=30, stale-while-revalidate=20, stale-if-error=20',
+      'public, max-age=50, stale-while-revalidate=0, stale-if-error=0',
     );
 
     const tooOld = new Response('ok');


### PR DESCRIPTION
## What
- switches public homepage/status snapshot reads to JSON fast paths and aligns cache-control with the full 60s freshness budget
- adds a lightweight homepage access marker so scheduled refresh only upgrades to full homepage snapshot when there is recent real homepage traffic
- keeps artifact-only refresh as the default cron path, while preserving the existing homepage fallback optimization work

## Why
- the real CPU problem is not the artifact path; it is repeated `/api/v1/public/homepage` live recompute/serialization on cache misses
- always doing full homepage refresh in scheduler reduced request CPU, but regressed scheduler CPU too much
- this hybrid keeps scheduler near baseline when idle, and only pays full snapshot cost when the homepage is actually being used

## Where
- `apps/worker/src/routes/public.ts`
- `apps/worker/src/scheduler/scheduled.ts`
- `apps/worker/src/snapshots/public-homepage.ts`
- `apps/worker/src/snapshots/public-status.ts`
- `apps/web/public/_worker.js`
- related worker tests + homepage benchmark

## Verification
- `pnpm --filter @uptimer/worker lint`
- `pnpm --filter @uptimer/worker test`
- `pnpm --filter @uptimer/web lint`
- `pnpm --filter @uptimer/web typecheck`
- `pnpm --filter @uptimer/web build`
- `pnpm --filter @uptimer/worker bench:scheduler`
- `pnpm --filter @uptimer/worker bench:homepage`

## Benchmark Notes
Scheduler benchmark vs `aef3f045c4c694f8440d08ba020548eed94f82db`:
- `1000 due monitors / no channels`: `9.594ms -> 9.583ms` mean
- `5000 due monitors / no channels`: `39.522ms -> 42.459ms` mean
- `5000 due monitors / 1 webhook channel`: `39.915ms -> 41.836ms` mean

Homepage benchmark on current tree:
- worker homepage route read / 1000 monitors: `3.591ms` mean
- worker homepage hot path direct compute / 1000 monitors: `19.598ms` mean
- worker homepage artifact route read / 1000 monitors: `0.669ms` mean

The intent of this PR is to make the `19.598ms` hot path much rarer in production, not to make that path itself magically cheap.
