### PR TITLE
perf(worker): shift homepage refresh to state-backed paths

### DIFF
--- a/apps/worker/src/public/homepage.ts
+++ b/apps/worker/src/public/homepage.ts
@@ -19,6 +19,14 @@ import {
   type UptimeWindowTotals,
 } from './data';
 import {
+  advancePublicMonitorCacheCoverageInPlace,
+  buildPublicMonitorCacheSeeds,
+  createEmptyPublicMonitorCache,
+  materializePublicMonitorCache,
+  type MaterializedPublicMonitorCache,
+  type PublicMonitorCache,
+} from './monitor-cache';
+import {
   buildNumberedPlaceholders,
   chunkPositiveIntegerIds,
   filterStatusPageScopedMonitorIds,
@@ -65,10 +73,295 @@ type HomepageRollupRow = {
   uptime_sec: number;
 };
 
-type HomepageMonitorDataOptions = {
-  cardLimit?: number;
-  uptimeRatingLevel?: 1 | 2 | 3 | 4 | 5;
+export type PublicHomepageStateMonitor = {
+  id: number;
+  name: string;
+  type: HomepageMonitorCard['type'];
+  group_name: string | null;
+  interval_sec: number;
+  created_at: number;
+  state_status: HomepageMonitorStatus;
+  last_checked_at: number | null;
+  covered_until_at: number;
+  cache: PublicMonitorCache;
 };
+
+export type PublicHomepageState = {
+  generated_at: number;
+  monitor_count_total: number;
+  site_title: string;
+  site_description: string;
+  site_locale: PublicHomepageResponse['site_locale'];
+  site_timezone: string;
+  uptime_rating_level: 1 | 2 | 3 | 4 | 5;
+  monitors: PublicHomepageStateMonitor[];
+  resolved_incident_preview: IncidentSummary | null;
+  maintenance_history_preview: MaintenancePreview | null;
+};
+
+type SerializedHomepageMonitorType = 'h' | 't';
+type SerializedHomepageMonitorStatus = 'u' | 'd' | 'm' | 'p' | 'x';
+
+type SerializedPublicHomepageStateMonitor = [
+  id: number,
+  name: string,
+  type: SerializedHomepageMonitorType,
+  groupName: string,
+  intervalSec: number,
+  createdAt: number,
+  stateStatus: SerializedHomepageMonitorStatus,
+  lastCheckedAt: number,
+  coveredUntilAt: number,
+  heartbeatCheckedAt: number[],
+  heartbeatStatusCodes: string,
+  heartbeatLatencyMs: Array<number | null>,
+  uptimeDayStartAt: number[],
+  uptimeTotalSec: number[],
+  uptimeDowntimeSec: number[],
+  uptimeUnknownSec: number[],
+  uptimeSec: number[],
+];
+
+type SerializedPublicHomepageState = {
+  v: 1;
+  g: number;
+  c: number;
+  t: string;
+  d: string;
+  l: PublicHomepageResponse['site_locale'];
+  z: string;
+  r: 1 | 2 | 3 | 4 | 5;
+  m: SerializedPublicHomepageStateMonitor[];
+  i: IncidentSummary | null;
+  w: MaintenancePreview | null;
+};
+
+function encodeSerializedHomepageMonitorType(
+  value: HomepageMonitorCard['type'],
+): SerializedHomepageMonitorType {
+  return value === 'tcp' ? 't' : 'h';
+}
+
+function decodeSerializedHomepageMonitorType(
+  value: unknown,
+): HomepageMonitorCard['type'] | null {
+  if (value === 't') return 'tcp';
+  if (value === 'h') return 'http';
+  return null;
+}
+
+function encodeSerializedHomepageMonitorStatus(
+  value: HomepageMonitorStatus,
+): SerializedHomepageMonitorStatus {
+  switch (value) {
+    case 'up':
+      return 'u';
+    case 'down':
+      return 'd';
+    case 'maintenance':
+      return 'm';
+    case 'paused':
+      return 'p';
+    case 'unknown':
+    default:
+      return 'x';
+  }
+}
+
+function decodeSerializedHomepageMonitorStatus(
+  value: unknown,
+): HomepageMonitorStatus | null {
+  switch (value) {
+    case 'u':
+      return 'up';
+    case 'd':
+      return 'down';
+    case 'm':
+      return 'maintenance';
+    case 'p':
+      return 'paused';
+    case 'x':
+      return 'unknown';
+    default:
+      return null;
+  }
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'number');
+}
+
+function isNullableNumberArray(value: unknown): value is Array<number | null> {
+  return (
+    Array.isArray(value) &&
+    value.every((entry) => entry === null || typeof entry === 'number')
+  );
+}
+
+function parseSerializedPublicHomepageStateMonitor(
+  value: unknown,
+): PublicHomepageStateMonitor | null {
+  if (!Array.isArray(value) || value.length !== 17) {
+    return null;
+  }
+
+  const [
+    id,
+    name,
+    type,
+    groupName,
+    intervalSec,
+    createdAt,
+    stateStatus,
+    lastCheckedAt,
+    coveredUntilAt,
+    heartbeatCheckedAt,
+    heartbeatStatusCodes,
+    heartbeatLatencyMs,
+    uptimeDayStartAt,
+    uptimeTotalSec,
+    uptimeDowntimeSec,
+    uptimeUnknownSec,
+    uptimeSec,
+  ] = value as SerializedPublicHomepageStateMonitor;
+
+  const decodedType = decodeSerializedHomepageMonitorType(type);
+  const decodedStateStatus = decodeSerializedHomepageMonitorStatus(stateStatus);
+  if (
+    typeof id !== 'number' ||
+    typeof name !== 'string' ||
+    decodedType === null ||
+    typeof groupName !== 'string' ||
+    typeof intervalSec !== 'number' ||
+    typeof createdAt !== 'number' ||
+    decodedStateStatus === null ||
+    typeof lastCheckedAt !== 'number' ||
+    typeof coveredUntilAt !== 'number' ||
+    !isNumberArray(heartbeatCheckedAt) ||
+    typeof heartbeatStatusCodes !== 'string' ||
+    !isNullableNumberArray(heartbeatLatencyMs) ||
+    !isNumberArray(uptimeDayStartAt) ||
+    !isNumberArray(uptimeTotalSec) ||
+    !isNumberArray(uptimeDowntimeSec) ||
+    !isNumberArray(uptimeUnknownSec) ||
+    !isNumberArray(uptimeSec)
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    name,
+    type: decodedType,
+    group_name: groupName.trim() ? groupName : null,
+    interval_sec: intervalSec,
+    created_at: createdAt,
+    state_status: decodedStateStatus,
+    last_checked_at: lastCheckedAt > 0 ? lastCheckedAt : null,
+    covered_until_at: coveredUntilAt,
+    cache: {
+      heartbeat: {
+        checked_at: heartbeatCheckedAt,
+        status_codes: heartbeatStatusCodes,
+        latency_ms: heartbeatLatencyMs,
+      },
+      uptime_days: {
+        day_start_at: uptimeDayStartAt,
+        total_sec: uptimeTotalSec,
+        downtime_sec: uptimeDowntimeSec,
+        unknown_sec: uptimeUnknownSec,
+        uptime_sec: uptimeSec,
+      },
+    },
+  };
+}
+
+export function parsePublicHomepageState(value: unknown): PublicHomepageState | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Partial<PublicHomepageState>;
+  const compactCandidate = value as Partial<SerializedPublicHomepageState>;
+  if (
+    compactCandidate.v === 1 &&
+    typeof compactCandidate.g === 'number' &&
+    typeof compactCandidate.c === 'number' &&
+    typeof compactCandidate.t === 'string' &&
+    typeof compactCandidate.d === 'string' &&
+    typeof compactCandidate.z === 'string' &&
+    Array.isArray(compactCandidate.m)
+  ) {
+    const monitors = compactCandidate.m
+      .map((monitor) => parseSerializedPublicHomepageStateMonitor(monitor))
+      .filter((monitor): monitor is PublicHomepageStateMonitor => monitor !== null);
+    if (monitors.length !== compactCandidate.m.length) {
+      return null;
+    }
+
+    return {
+      generated_at: compactCandidate.g,
+      monitor_count_total: compactCandidate.c,
+      site_title: compactCandidate.t,
+      site_description: compactCandidate.d,
+      site_locale: compactCandidate.l ?? 'auto',
+      site_timezone: compactCandidate.z,
+      uptime_rating_level: compactCandidate.r ?? 3,
+      monitors,
+      resolved_incident_preview: compactCandidate.i ?? null,
+      maintenance_history_preview: compactCandidate.w ?? null,
+    };
+  }
+
+  if (
+    typeof candidate.generated_at !== 'number' ||
+    typeof candidate.monitor_count_total !== 'number' ||
+    typeof candidate.site_title !== 'string' ||
+    typeof candidate.site_description !== 'string' ||
+    typeof candidate.site_timezone !== 'string' ||
+    !Array.isArray(candidate.monitors)
+  ) {
+    return null;
+  }
+
+  return candidate as PublicHomepageState;
+}
+
+export function serializePublicHomepageState(state: PublicHomepageState): string {
+  const compact: SerializedPublicHomepageState = {
+    v: 1,
+    g: state.generated_at,
+    c: state.monitor_count_total,
+    t: state.site_title,
+    d: state.site_description,
+    l: state.site_locale,
+    z: state.site_timezone,
+    r: state.uptime_rating_level,
+    m: state.monitors.map((monitor) => [
+      monitor.id,
+      monitor.name,
+      encodeSerializedHomepageMonitorType(monitor.type),
+      monitor.group_name ?? '',
+      monitor.interval_sec,
+      monitor.created_at,
+      encodeSerializedHomepageMonitorStatus(monitor.state_status),
+      monitor.last_checked_at ?? 0,
+      monitor.covered_until_at,
+      monitor.cache.heartbeat.checked_at,
+      monitor.cache.heartbeat.status_codes,
+      monitor.cache.heartbeat.latency_ms,
+      monitor.cache.uptime_days.day_start_at,
+      monitor.cache.uptime_days.total_sec,
+      monitor.cache.uptime_days.downtime_sec,
+      monitor.cache.uptime_days.unknown_sec,
+      monitor.cache.uptime_days.uptime_sec,
+    ]),
+    i: state.resolved_incident_preview,
+    w: state.maintenance_history_preview,
+  };
+
+  return JSON.stringify(compact);
+}
 
 function toHeartbeatStatusCode(status: string | null | undefined): string {
   switch (status) {
@@ -135,20 +428,6 @@ function maintenancePreviewFromStatusWindow(
     ends_at: window.ends_at,
     monitor_ids: window.monitor_ids,
   };
-}
-
-async function readHomepageUptimeRatingLevel(db: D1Database): Promise<1 | 2 | 3 | 4 | 5> {
-  const row = await db
-    .prepare('SELECT value FROM settings WHERE key = ?1')
-    .bind('uptime_rating_level')
-    .first<{ value: string }>();
-
-  const raw = row?.value ?? '';
-  const parsed = Number.parseInt(raw, 10);
-  if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 5) {
-    return parsed as 1 | 2 | 3 | 4 | 5;
-  }
-  return 3;
 }
 
 async function listHomepageMaintenanceMonitorIds(
@@ -573,30 +852,129 @@ async function buildHomepageMonitorCardsFromRows(
   return monitors;
 }
 
-async function buildHomepageMonitorData(
+function toHomepageStateMonitor(
+  row: HomepageMonitorRow,
+  cache: PublicMonitorCache,
+  coveredUntilAt: number,
+): PublicHomepageStateMonitor {
+  return {
+    id: row.id,
+    name: row.name,
+    type: toHomepageMonitorType(row.type),
+    group_name: row.group_name?.trim() ? row.group_name.trim() : null,
+    interval_sec: row.interval_sec,
+    created_at: row.created_at,
+    state_status: toMonitorStatus(row.state_status),
+    last_checked_at: row.last_checked_at,
+    covered_until_at: coveredUntilAt,
+    cache,
+  };
+}
+
+function toHomepageMonitorCardFromState(
+  monitor: PublicHomepageStateMonitor,
+  presentation: Pick<HomepageMonitorCard, 'status' | 'is_stale'>,
+  materialized: MaterializedPublicMonitorCache,
+): HomepageMonitorCard {
+  return {
+    id: monitor.id,
+    name: monitor.name,
+    type: monitor.type,
+    group_name: monitor.group_name,
+    status: presentation.status,
+    is_stale: presentation.is_stale,
+    last_checked_at: monitor.last_checked_at,
+    heartbeat_strip: materialized.heartbeat_strip,
+    uptime_30d: materialized.uptime_30d,
+    uptime_day_strip: materialized.uptime_day_strip,
+  };
+}
+
+export function advancePublicHomepageStateCoverageInPlace(
+  state: PublicHomepageState,
+  now: number,
+): void {
+  if (state.generated_at >= now) {
+    return;
+  }
+
+  for (const monitor of state.monitors) {
+    if (!monitor || monitor.covered_until_at >= now) {
+      continue;
+    }
+
+    advancePublicMonitorCacheCoverageInPlace(monitor.cache, {
+      status: monitor.state_status,
+      checkedAt: monitor.last_checked_at ?? 0,
+      intervalSec: monitor.interval_sec,
+      createdAt: monitor.created_at,
+      from: monitor.covered_until_at,
+      to: now,
+    });
+    monitor.covered_until_at = now;
+  }
+
+  state.generated_at = now;
+}
+
+export async function buildPublicHomepageState(
   db: D1Database,
   now: number,
-  includeHiddenMonitors: boolean,
-  opts: HomepageMonitorDataOptions = {},
-): Promise<{
-  monitors: HomepageMonitorCard[];
-  monitorCountTotal: number;
-  summary: PublicHomepageResponse['summary'];
-  overallStatus: HomepageMonitorStatus;
-  uptimeRatingLevel: 1 | 2 | 3 | 4 | 5;
-}> {
-  const rawMonitors = await listHomepageMonitorRows(db, includeHiddenMonitors);
-  const monitorCountTotal = rawMonitors.length;
-  const ids = rawMonitors.map((monitor) => monitor.id);
-  const selectedRows =
-    opts.cardLimit === undefined ? rawMonitors : rawMonitors.slice(0, Math.max(0, opts.cardLimit));
-
-  const [maintenanceMonitorIds, uptimeRatingLevel] = await Promise.all([
-    listHomepageMaintenanceMonitorIds(db, now, ids),
-    opts.uptimeRatingLevel === undefined
-      ? readHomepageUptimeRatingLevel(db)
-      : Promise.resolve(opts.uptimeRatingLevel),
+): Promise<PublicHomepageState> {
+  const includeHiddenMonitors = false;
+  const [settings, rows, historyPreviews] = await Promise.all([
+    readPublicSiteSettings(db),
+    listHomepageMonitorRows(db, includeHiddenMonitors),
+    readHomepageHistoryPreviews(db, now),
   ]);
+
+  const caches = await buildPublicMonitorCacheSeeds(
+    db,
+    now,
+    rows.map((row) => ({
+      id: row.id,
+      interval_sec: row.interval_sec,
+      created_at: row.created_at,
+      last_checked_at: row.last_checked_at,
+    })),
+  );
+
+  return {
+    generated_at: now,
+    monitor_count_total: rows.length,
+    site_title: settings.site_title,
+    site_description: settings.site_description,
+    site_locale: settings.site_locale,
+    site_timezone: settings.site_timezone,
+    uptime_rating_level: settings.uptime_rating_level,
+    monitors: rows.map((row) =>
+      toHomepageStateMonitor(
+        row,
+        caches.get(row.id) ?? createEmptyPublicMonitorCache(),
+        now,
+      ),
+    ),
+    resolved_incident_preview: historyPreviews.resolvedIncidentPreview,
+    maintenance_history_preview: historyPreviews.maintenanceHistoryPreview,
+  };
+}
+
+export function buildPublicHomepagePayloadFromState(opts: {
+  state: PublicHomepageState;
+  now: number;
+  activeIncidents: Awaited<ReturnType<typeof listVisibleActiveIncidents>>;
+  maintenanceWindows: Awaited<ReturnType<typeof listVisibleMaintenanceWindows>>;
+  monitorLimit?: number;
+}): PublicHomepageResponse {
+  const { state, now, activeIncidents, maintenanceWindows, monitorLimit } = opts;
+  advancePublicHomepageStateCoverageInPlace(state, now);
+
+  const maintenanceMonitorIds = new Set<number>();
+  for (const window of maintenanceWindows.active) {
+    for (const monitorId of window.monitorIds) {
+      maintenanceMonitorIds.add(monitorId);
+    }
+  }
 
   const summary: PublicHomepageResponse['summary'] = {
     up: 0,
@@ -605,38 +983,66 @@ async function buildHomepageMonitorData(
     paused: 0,
     unknown: 0,
   };
+  const monitors: HomepageMonitorCard[] = [];
+  const maxMonitors =
+    monitorLimit === undefined ? Number.POSITIVE_INFINITY : Math.max(0, monitorLimit);
 
-  for (let index = 0; index < rawMonitors.length; index += 1) {
-    const row = rawMonitors[index];
-    if (!row) continue;
+  for (const monitor of state.monitors) {
+    if (!monitor) continue;
 
-    const presentation = computeHomepageMonitorPresentation(row, now, maintenanceMonitorIds);
+    const presentation = computeHomepageMonitorPresentation(
+      {
+        id: monitor.id,
+        interval_sec: monitor.interval_sec,
+        last_checked_at: monitor.last_checked_at,
+        state_status: monitor.state_status,
+      },
+      now,
+      maintenanceMonitorIds,
+    );
+
     summary[presentation.status] += 1;
-  }
 
-  if (selectedRows.length === 0) {
-    return {
-      monitors: [],
-      monitorCountTotal,
-      summary,
-      overallStatus: computeOverallStatus(summary),
-      uptimeRatingLevel,
-    };
-  }
+    if (monitors.length >= maxMonitors) {
+      continue;
+    }
 
-  const monitors = await buildHomepageMonitorCardsFromRows(
-    db,
-    now,
-    selectedRows,
-    maintenanceMonitorIds,
-  );
+    const materialized = materializePublicMonitorCache(monitor.cache, {
+      assumeNormalized: true,
+    });
+    monitors.push(toHomepageMonitorCardFromState(monitor, presentation, materialized));
+  }
 
   return {
-    monitors,
-    monitorCountTotal,
+    generated_at: now,
+    bootstrap_mode:
+      monitorLimit !== undefined && state.monitor_count_total > monitors.length ? 'partial' : 'full',
+    monitor_count_total: state.monitor_count_total,
+    site_title: state.site_title,
+    site_description: state.site_description,
+    site_locale: state.site_locale,
+    site_timezone: state.site_timezone,
+    uptime_rating_level: state.uptime_rating_level,
+    overall_status: computeOverallStatus(summary),
+    banner: buildPublicStatusBanner({
+      counts: summary,
+      monitorCount: state.monitor_count_total,
+      activeIncidents,
+      activeMaintenanceWindows: maintenanceWindows.active,
+    }),
     summary,
-    overallStatus: computeOverallStatus(summary),
-    uptimeRatingLevel,
+    monitors,
+    active_incidents: activeIncidents.map(({ row }) => toIncidentSummary(row)),
+    maintenance_windows: {
+      active: maintenanceWindows.active.map(({ row, monitorIds }) =>
+        toMaintenancePreview(row, monitorIds),
+      ),
+      upcoming: maintenanceWindows.upcoming.map(({ row, monitorIds }) =>
+        toMaintenancePreview(row, monitorIds),
+      ),
+    },
+    resolved_incident_preview: state.resolved_incident_preview,
+    maintenance_history_preview: state.maintenance_history_preview,
   };
 }
 
@@ -869,75 +1275,18 @@ export async function computePublicHomepagePayload(
   now: number,
 ): Promise<PublicHomepageResponse> {
   const includeHiddenMonitors = false;
-  const settingsPromise = readPublicSiteSettings(db);
-
-  const [
-    settings,
-    monitorData,
-    activeIncidents,
-    maintenanceWindows,
-    historyPreviews,
-  ] = await Promise.all([
-    settingsPromise,
-    settingsPromise.then((settings) =>
-      buildHomepageMonitorData(db, now, includeHiddenMonitors, {
-        uptimeRatingLevel: settings.uptime_rating_level,
-      }),
-    ),
+  const [state, activeIncidents, maintenanceWindows] = await Promise.all([
+    buildPublicHomepageState(db, now),
     listVisibleActiveIncidents(db, includeHiddenMonitors),
     listVisibleMaintenanceWindows(db, now, includeHiddenMonitors),
-    readHomepageHistoryPreviews(db, now),
   ]);
 
-  const activeIncidentSummaries = new Array<IncidentSummary>(activeIncidents.length);
-  for (let index = 0; index < activeIncidents.length; index += 1) {
-    const incident = activeIncidents[index];
-    if (!incident) continue;
-    activeIncidentSummaries[index] = toIncidentSummary(incident.row);
-  }
-
-  const activeMaintenancePreview = new Array<MaintenancePreview>(maintenanceWindows.active.length);
-  for (let index = 0; index < maintenanceWindows.active.length; index += 1) {
-    const window = maintenanceWindows.active[index];
-    if (!window) continue;
-    activeMaintenancePreview[index] = toMaintenancePreview(window.row, window.monitorIds);
-  }
-
-  const upcomingMaintenancePreview = new Array<MaintenancePreview>(
-    maintenanceWindows.upcoming.length,
-  );
-  for (let index = 0; index < maintenanceWindows.upcoming.length; index += 1) {
-    const window = maintenanceWindows.upcoming[index];
-    if (!window) continue;
-    upcomingMaintenancePreview[index] = toMaintenancePreview(window.row, window.monitorIds);
-  }
-
-  return {
-    generated_at: now,
-    bootstrap_mode: 'full',
-    monitor_count_total: monitorData.monitorCountTotal,
-    site_title: settings.site_title,
-    site_description: settings.site_description,
-    site_locale: settings.site_locale,
-    site_timezone: settings.site_timezone,
-    uptime_rating_level: monitorData.uptimeRatingLevel,
-    overall_status: monitorData.overallStatus,
-    banner: buildPublicStatusBanner({
-      counts: monitorData.summary,
-      monitorCount: monitorData.monitors.length,
-      activeIncidents,
-      activeMaintenanceWindows: maintenanceWindows.active,
-    }),
-    summary: monitorData.summary,
-    monitors: monitorData.monitors,
-    active_incidents: activeIncidentSummaries,
-    maintenance_windows: {
-      active: activeMaintenancePreview,
-      upcoming: upcomingMaintenancePreview,
-    },
-    resolved_incident_preview: historyPreviews.resolvedIncidentPreview,
-    maintenance_history_preview: historyPreviews.maintenanceHistoryPreview,
-  };
+  return buildPublicHomepagePayloadFromState({
+    state,
+    now,
+    activeIncidents,
+    maintenanceWindows,
+  });
 }
 
 export async function computePublicHomepageArtifactPayload(

--- a/apps/worker/src/public/monitor-cache.ts
+++ b/apps/worker/src/public/monitor-cache.ts
@@ -1,0 +1,587 @@
+import { z } from 'zod';
+
+import { computeTodayPartialUptimeBatch, utcDayStart } from './data';
+import { buildNumberedPlaceholders } from './visibility';
+
+const HEARTBEAT_POINTS = 60;
+const UPTIME_DAYS = 30;
+
+const publicMonitorHeartbeatCacheSchema = z.object({
+  checked_at: z.array(z.number().int()),
+  status_codes: z.string(),
+  latency_ms: z.array(z.number().int().nullable()),
+});
+
+const publicMonitorUptimeCacheSchema = z.object({
+  day_start_at: z.array(z.number().int()),
+  total_sec: z.array(z.number().int()),
+  downtime_sec: z.array(z.number().int()),
+  unknown_sec: z.array(z.number().int()),
+  uptime_sec: z.array(z.number().int()),
+});
+
+const publicMonitorCacheSchema = z.object({
+  heartbeat: publicMonitorHeartbeatCacheSchema,
+  uptime_days: publicMonitorUptimeCacheSchema,
+});
+
+export type PublicMonitorCache = z.infer<typeof publicMonitorCacheSchema>;
+
+export type PublicMonitorCacheSeedRow = {
+  id: number;
+  interval_sec: number;
+  created_at: number;
+  last_checked_at: number | null;
+};
+
+type HeartbeatQueryRow = {
+  monitor_id: number;
+  checked_at: number;
+  status: string;
+  latency_ms: number | null;
+};
+
+type UptimeRollupRow = {
+  monitor_id: number;
+  day_start_at: number;
+  total_sec: number;
+  downtime_sec: number;
+  unknown_sec: number;
+  uptime_sec: number;
+};
+
+export type MaterializedPublicMonitorCache = {
+  heartbeat_strip: {
+    checked_at: number[];
+    status_codes: string;
+    latency_ms: Array<number | null>;
+  };
+  uptime_day_strip: {
+    day_start_at: number[];
+    downtime_sec: number[];
+    unknown_sec: number[];
+    uptime_pct_milli: Array<number | null>;
+  };
+  uptime_30d: { uptime_pct: number } | null;
+};
+
+type SegmentStatus = 'up' | 'down' | 'unknown' | 'maintenance' | 'paused' | null;
+
+function toHeartbeatStatusCode(status: string | null | undefined): string {
+  switch (status) {
+    case 'up':
+      return 'u';
+    case 'down':
+      return 'd';
+    case 'maintenance':
+      return 'm';
+    case 'unknown':
+    default:
+      return 'x';
+  }
+}
+
+function normalizeHeartbeatCache(
+  input: PublicMonitorCache['heartbeat'],
+): PublicMonitorCache['heartbeat'] {
+  const length = Math.min(
+    HEARTBEAT_POINTS,
+    input.checked_at.length,
+    input.latency_ms.length,
+    input.status_codes.length,
+  );
+
+  return {
+    checked_at: input.checked_at.slice(0, length),
+    status_codes: input.status_codes.slice(0, length),
+    latency_ms: input.latency_ms.slice(0, length),
+  };
+}
+
+function normalizeUptimeDaysCache(
+  input: PublicMonitorCache['uptime_days'],
+): PublicMonitorCache['uptime_days'] {
+  const length = Math.min(
+    input.day_start_at.length,
+    input.total_sec.length,
+    input.downtime_sec.length,
+    input.unknown_sec.length,
+    input.uptime_sec.length,
+  );
+  const boundedLength = Math.min(length, UPTIME_DAYS);
+  const start = Math.max(0, length - boundedLength);
+
+  return {
+    day_start_at: input.day_start_at.slice(start, length),
+    total_sec: input.total_sec.slice(start, length),
+    downtime_sec: input.downtime_sec.slice(start, length),
+    unknown_sec: input.unknown_sec.slice(start, length),
+    uptime_sec: input.uptime_sec.slice(start, length),
+  };
+}
+
+function normalizePublicMonitorCache(cache: PublicMonitorCache): PublicMonitorCache {
+  return {
+    heartbeat: normalizeHeartbeatCache(cache.heartbeat),
+    uptime_days: normalizeUptimeDaysCache(cache.uptime_days),
+  };
+}
+
+function clonePublicMonitorCache(cache: PublicMonitorCache): PublicMonitorCache {
+  return {
+    heartbeat: {
+      checked_at: [...cache.heartbeat.checked_at],
+      status_codes: cache.heartbeat.status_codes,
+      latency_ms: [...cache.heartbeat.latency_ms],
+    },
+    uptime_days: {
+      day_start_at: [...cache.uptime_days.day_start_at],
+      total_sec: [...cache.uptime_days.total_sec],
+      downtime_sec: [...cache.uptime_days.downtime_sec],
+      unknown_sec: [...cache.uptime_days.unknown_sec],
+      uptime_sec: [...cache.uptime_days.uptime_sec],
+    },
+  };
+}
+
+function ensureUptimeDayIndex(
+  cache: PublicMonitorCache['uptime_days'],
+  dayStartAt: number,
+): number {
+  const existingIndex = cache.day_start_at.indexOf(dayStartAt);
+  if (existingIndex >= 0) {
+    return existingIndex;
+  }
+
+  cache.day_start_at.push(dayStartAt);
+  cache.total_sec.push(0);
+  cache.downtime_sec.push(0);
+  cache.unknown_sec.push(0);
+  cache.uptime_sec.push(0);
+
+  return cache.day_start_at.length - 1;
+}
+
+function trimUptimeDaysWindow(cache: PublicMonitorCache['uptime_days'], now: number): void {
+  const minDayStart = utcDayStart(now) - (UPTIME_DAYS - 1) * 86_400;
+
+  while (cache.day_start_at.length > 0) {
+    const dayStartAt = cache.day_start_at[0];
+    if (dayStartAt === undefined || dayStartAt >= minDayStart) {
+      break;
+    }
+
+    cache.day_start_at.shift();
+    cache.total_sec.shift();
+    cache.downtime_sec.shift();
+    cache.unknown_sec.shift();
+    cache.uptime_sec.shift();
+  }
+
+  while (cache.day_start_at.length > UPTIME_DAYS) {
+    cache.day_start_at.shift();
+    cache.total_sec.shift();
+    cache.downtime_sec.shift();
+    cache.unknown_sec.shift();
+    cache.uptime_sec.shift();
+  }
+}
+
+function addBucketSeconds(
+  cache: PublicMonitorCache['uptime_days'],
+  dayStartAt: number,
+  seconds: { total: number; downtime: number; unknown: number; uptime: number },
+): void {
+  if (seconds.total <= 0) {
+    return;
+  }
+
+  const index = ensureUptimeDayIndex(cache, dayStartAt);
+  cache.total_sec[index] = (cache.total_sec[index] ?? 0) + seconds.total;
+  cache.downtime_sec[index] = (cache.downtime_sec[index] ?? 0) + seconds.downtime;
+  cache.unknown_sec[index] = (cache.unknown_sec[index] ?? 0) + seconds.unknown;
+  cache.uptime_sec[index] = (cache.uptime_sec[index] ?? 0) + seconds.uptime;
+}
+
+function applyRealtimeSegment(
+  cache: PublicMonitorCache,
+  opts: {
+    status: SegmentStatus;
+    checkedAt: number;
+    intervalSec: number;
+    createdAt: number;
+    from: number | null;
+    to: number;
+  },
+): void {
+  if (opts.from === null) {
+    return;
+  }
+
+  const segmentStart = Math.max(opts.from, opts.createdAt);
+  if (opts.to <= segmentStart) {
+    return;
+  }
+
+  if (
+    opts.status !== 'up' &&
+    opts.status !== 'down' &&
+    opts.status !== 'unknown'
+  ) {
+    return;
+  }
+
+  const validUntil =
+    opts.status === 'up' && Number.isFinite(opts.intervalSec) && opts.intervalSec > 0
+      ? opts.checkedAt + opts.intervalSec * 2
+      : opts.checkedAt;
+
+  let cursor = segmentStart;
+
+  while (cursor < opts.to) {
+    const dayStartAt = utcDayStart(cursor);
+    const dayEnd = Math.min(opts.to, dayStartAt + 86_400);
+    if (dayEnd <= cursor) {
+      break;
+    }
+
+    if (opts.status === 'down') {
+      addBucketSeconds(cache.uptime_days, dayStartAt, {
+        total: dayEnd - cursor,
+        downtime: dayEnd - cursor,
+        unknown: 0,
+        uptime: 0,
+      });
+    } else if (opts.status === 'unknown') {
+      addBucketSeconds(cache.uptime_days, dayStartAt, {
+        total: dayEnd - cursor,
+        downtime: 0,
+        unknown: dayEnd - cursor,
+        uptime: 0,
+      });
+    } else {
+      const uptimeEnd = Math.min(dayEnd, Math.max(cursor, validUntil));
+      const uptimeSeconds = Math.max(0, uptimeEnd - cursor);
+      const unknownSeconds = Math.max(0, dayEnd - uptimeEnd);
+
+      addBucketSeconds(cache.uptime_days, dayStartAt, {
+        total: dayEnd - cursor,
+        downtime: 0,
+        unknown: unknownSeconds,
+        uptime: uptimeSeconds,
+      });
+    }
+
+    cursor = dayEnd;
+  }
+}
+
+function buildCacheFromRows(opts: {
+  heartbeats: HeartbeatQueryRow[];
+  uptimeDays: Array<{
+    day_start_at: number;
+    total_sec: number;
+    downtime_sec: number;
+    unknown_sec: number;
+    uptime_sec: number;
+  }>;
+}): PublicMonitorCache {
+  const heartbeatStatusCodes = new Array<string>(opts.heartbeats.length);
+  for (let index = 0; index < opts.heartbeats.length; index += 1) {
+    heartbeatStatusCodes[index] = toHeartbeatStatusCode(opts.heartbeats[index]?.status);
+  }
+
+  return normalizePublicMonitorCache({
+    heartbeat: {
+      checked_at: opts.heartbeats.map((row) => row.checked_at),
+      status_codes: heartbeatStatusCodes.join(''),
+      latency_ms: opts.heartbeats.map((row) => row.latency_ms),
+    },
+    uptime_days: {
+      day_start_at: opts.uptimeDays.map((row) => row.day_start_at),
+      total_sec: opts.uptimeDays.map((row) => row.total_sec),
+      downtime_sec: opts.uptimeDays.map((row) => row.downtime_sec),
+      unknown_sec: opts.uptimeDays.map((row) => row.unknown_sec),
+      uptime_sec: opts.uptimeDays.map((row) => row.uptime_sec),
+    },
+  });
+}
+
+export function createEmptyPublicMonitorCache(): PublicMonitorCache {
+  return {
+    heartbeat: {
+      checked_at: [],
+      status_codes: '',
+      latency_ms: [],
+    },
+    uptime_days: {
+      day_start_at: [],
+      total_sec: [],
+      downtime_sec: [],
+      unknown_sec: [],
+      uptime_sec: [],
+    },
+  };
+}
+
+export function parsePublicMonitorCache(value: string | null | undefined): PublicMonitorCache | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    const result = publicMonitorCacheSchema.safeParse(parsed);
+    if (!result.success) {
+      return null;
+    }
+    return normalizePublicMonitorCache(result.data);
+  } catch {
+    return null;
+  }
+}
+
+export function serializePublicMonitorCache(cache: PublicMonitorCache): string {
+  return JSON.stringify(normalizePublicMonitorCache(cache));
+}
+
+export function appendHeartbeatToPublicMonitorCache(
+  cache: PublicMonitorCache,
+  entry: { checkedAt: number; status: string; latencyMs: number | null },
+): PublicMonitorCache {
+  const next = clonePublicMonitorCache(cache);
+  appendHeartbeatToPublicMonitorCacheInPlace(next, entry);
+  return next;
+}
+
+export function appendHeartbeatToPublicMonitorCacheInPlace(
+  cache: PublicMonitorCache,
+  entry: { checkedAt: number; status: string; latencyMs: number | null },
+): void {
+  const nextStatusCode = toHeartbeatStatusCode(entry.status);
+  const currentHead = cache.heartbeat.checked_at[0];
+
+  if (currentHead === entry.checkedAt) {
+    cache.heartbeat.checked_at[0] = entry.checkedAt;
+    cache.heartbeat.latency_ms[0] = entry.latencyMs;
+    cache.heartbeat.status_codes =
+      nextStatusCode + cache.heartbeat.status_codes.slice(1);
+  } else {
+    cache.heartbeat.checked_at.unshift(entry.checkedAt);
+    cache.heartbeat.latency_ms.unshift(entry.latencyMs);
+    cache.heartbeat.status_codes = nextStatusCode + cache.heartbeat.status_codes;
+  }
+
+  cache.heartbeat.checked_at = cache.heartbeat.checked_at.slice(0, HEARTBEAT_POINTS);
+  cache.heartbeat.latency_ms = cache.heartbeat.latency_ms.slice(0, HEARTBEAT_POINTS);
+  cache.heartbeat.status_codes = cache.heartbeat.status_codes.slice(0, HEARTBEAT_POINTS);
+}
+
+export function extendPublicMonitorCacheToTime(
+  cache: PublicMonitorCache,
+  opts: {
+    status: SegmentStatus;
+    lastCheckedAt: number | null;
+    intervalSec: number;
+    createdAt: number;
+    now: number;
+  },
+): PublicMonitorCache {
+  const next = clonePublicMonitorCache(cache);
+  applyRealtimeSegment(next, {
+    status: opts.status,
+    checkedAt: opts.lastCheckedAt ?? 0,
+    intervalSec: opts.intervalSec,
+    createdAt: opts.createdAt,
+    from: opts.lastCheckedAt,
+    to: opts.now,
+  });
+  trimUptimeDaysWindow(next.uptime_days, opts.now);
+  return next;
+}
+
+export function advancePublicMonitorCacheCoverage(
+  cache: PublicMonitorCache,
+  opts: {
+    status: SegmentStatus;
+    checkedAt: number;
+    intervalSec: number;
+    createdAt: number;
+    from: number | null;
+    to: number;
+  },
+): PublicMonitorCache {
+  const next = clonePublicMonitorCache(cache);
+  advancePublicMonitorCacheCoverageInPlace(next, opts);
+  return next;
+}
+
+export function advancePublicMonitorCacheCoverageInPlace(
+  cache: PublicMonitorCache,
+  opts: {
+    status: SegmentStatus;
+    checkedAt: number;
+    intervalSec: number;
+    createdAt: number;
+    from: number | null;
+    to: number;
+  },
+): void {
+  applyRealtimeSegment(cache, opts);
+  trimUptimeDaysWindow(cache.uptime_days, opts.to);
+}
+
+export function materializePublicMonitorCache(
+  cache: PublicMonitorCache,
+  opts: { assumeNormalized?: boolean } = {},
+): MaterializedPublicMonitorCache {
+  const normalized = opts.assumeNormalized ? cache : normalizePublicMonitorCache(cache);
+  const uptimePctMilli = new Array<number | null>(normalized.uptime_days.day_start_at.length);
+
+  let totalSec = 0;
+  let uptimeSec = 0;
+
+  for (let index = 0; index < normalized.uptime_days.day_start_at.length; index += 1) {
+    const bucketTotal = normalized.uptime_days.total_sec[index] ?? 0;
+    const bucketUptime = normalized.uptime_days.uptime_sec[index] ?? 0;
+
+    totalSec += bucketTotal;
+    uptimeSec += bucketUptime;
+    uptimePctMilli[index] = bucketTotal <= 0 ? null : Math.round((bucketUptime / bucketTotal) * 100_000);
+  }
+
+  return {
+    heartbeat_strip: {
+      checked_at: normalized.heartbeat.checked_at,
+      status_codes: normalized.heartbeat.status_codes,
+      latency_ms: normalized.heartbeat.latency_ms,
+    },
+    uptime_day_strip: {
+      day_start_at: normalized.uptime_days.day_start_at,
+      downtime_sec: normalized.uptime_days.downtime_sec,
+      unknown_sec: normalized.uptime_days.unknown_sec,
+      uptime_pct_milli: uptimePctMilli,
+    },
+    uptime_30d:
+      totalSec <= 0
+        ? null
+        : {
+            uptime_pct: (uptimeSec / totalSec) * 100,
+          },
+  };
+}
+
+export async function buildPublicMonitorCacheSeeds(
+  db: D1Database,
+  now: number,
+  rows: PublicMonitorCacheSeedRow[],
+): Promise<Map<number, PublicMonitorCache>> {
+  const uniqueRows = [...new Map(rows.map((row) => [row.id, row])).values()];
+  const out = new Map<number, PublicMonitorCache>();
+  if (uniqueRows.length === 0) {
+    return out;
+  }
+
+  const ids = uniqueRows.map((row) => row.id);
+  const placeholders = buildNumberedPlaceholders(ids.length);
+  const rangeStart = utcDayStart(now) - (UPTIME_DAYS - 1) * 86_400;
+  const todayStartAt = utcDayStart(now);
+
+  const [heartbeatRows, rollupRows, todayByMonitorId] = await Promise.all([
+    db
+      .prepare(
+        `
+        SELECT monitor_id, checked_at, status, latency_ms
+        FROM (
+          SELECT
+            id,
+            monitor_id,
+            checked_at,
+            status,
+            latency_ms,
+            ROW_NUMBER() OVER (
+              PARTITION BY monitor_id
+              ORDER BY checked_at DESC, id DESC
+            ) AS rn
+          FROM check_results
+          WHERE monitor_id IN (${placeholders})
+        )
+        WHERE rn <= ?${ids.length + 1}
+        ORDER BY monitor_id, checked_at DESC, id DESC
+      `,
+      )
+      .bind(...ids, HEARTBEAT_POINTS)
+      .all<HeartbeatQueryRow>()
+      .then(({ results }) => results ?? []),
+    db
+      .prepare(
+        `
+        SELECT monitor_id, day_start_at, total_sec, downtime_sec, unknown_sec, uptime_sec
+        FROM monitor_daily_rollups
+        WHERE monitor_id IN (${placeholders})
+          AND day_start_at >= ?${ids.length + 1}
+          AND day_start_at < ?${ids.length + 2}
+        ORDER BY monitor_id, day_start_at
+      `,
+      )
+      .bind(...ids, rangeStart, todayStartAt)
+      .all<UptimeRollupRow>()
+      .then(({ results }) => results ?? []),
+    computeTodayPartialUptimeBatch(
+      db,
+      uniqueRows,
+      Math.max(todayStartAt, rangeStart),
+      now,
+    ),
+  ]);
+
+  const heartbeatsByMonitorId = new Map<number, HeartbeatQueryRow[]>();
+  for (const row of heartbeatRows) {
+    const existing = heartbeatsByMonitorId.get(row.monitor_id);
+    if (existing) {
+      existing.push(row);
+      continue;
+    }
+    heartbeatsByMonitorId.set(row.monitor_id, [row]);
+  }
+
+  const rollupsByMonitorId = new Map<number, UptimeRollupRow[]>();
+  for (const row of rollupRows) {
+    const existing = rollupsByMonitorId.get(row.monitor_id);
+    if (existing) {
+      existing.push(row);
+      continue;
+    }
+    rollupsByMonitorId.set(row.monitor_id, [row]);
+  }
+
+  for (const row of uniqueRows) {
+    const historicalDays = (rollupsByMonitorId.get(row.id) ?? []).map((bucket) => ({
+      day_start_at: bucket.day_start_at,
+      total_sec: bucket.total_sec ?? 0,
+      downtime_sec: bucket.downtime_sec ?? 0,
+      unknown_sec: bucket.unknown_sec ?? 0,
+      uptime_sec: bucket.uptime_sec ?? 0,
+    }));
+    const today = todayByMonitorId.get(row.id);
+    if (today && today.total_sec > 0) {
+      historicalDays.push({
+        day_start_at: todayStartAt,
+        total_sec: today.total_sec,
+        downtime_sec: today.downtime_sec,
+        unknown_sec: today.unknown_sec,
+        uptime_sec: today.uptime_sec,
+      });
+    }
+
+    out.set(
+      row.id,
+      buildCacheFromRows({
+        heartbeats: heartbeatsByMonitorId.get(row.id) ?? [],
+        uptimeDays: historicalDays,
+      }),
+    );
+  }
+
+  return out;
+}

--- a/apps/worker/src/routes/admin-settings.ts
+++ b/apps/worker/src/routes/admin-settings.ts
@@ -2,8 +2,16 @@ import { Hono } from 'hono';
 
 import type { Env } from '../env';
 import { AppError } from '../middleware/errors';
-import { computePublicHomepagePayload } from '../public/homepage';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../snapshots';
+import {
+  buildPublicHomepagePayloadFromState,
+  buildPublicHomepageState,
+  serializePublicHomepageState,
+} from '../public/homepage';
+import {
+  listVisibleActiveIncidents,
+  listVisibleMaintenanceWindows,
+} from '../public/data';
+import { refreshPublicHomepageStateAndArtifactIfNeeded } from '../snapshots';
 import { parseSettingsPatch, patchSettings, readSettings } from '../settings';
 
 export const adminSettingsRoutes = new Hono<{ Bindings: Env }>();
@@ -11,10 +19,31 @@ export const adminSettingsRoutes = new Hono<{ Bindings: Env }>();
 function queuePublicHomepageSnapshotRefresh(c: { env: Env; executionCtx: ExecutionContext }) {
   const now = Math.floor(Date.now() / 1000);
   c.executionCtx.waitUntil(
-    refreshPublicHomepageSnapshotIfNeeded({
+    refreshPublicHomepageStateAndArtifactIfNeeded({
       db: c.env.DB,
       now,
-      compute: () => computePublicHomepagePayload(c.env.DB, Math.floor(Date.now() / 1000)),
+      compute: async () => {
+        const refreshNow = Math.floor(Date.now() / 1000);
+        const includeHiddenMonitors = false;
+        const [state, activeIncidents, maintenanceWindows] = await Promise.all([
+          buildPublicHomepageState(c.env.DB, refreshNow),
+          listVisibleActiveIncidents(c.env.DB, includeHiddenMonitors),
+          listVisibleMaintenanceWindows(c.env.DB, refreshNow, includeHiddenMonitors),
+        ]);
+        const artifactPayload = buildPublicHomepagePayloadFromState({
+          state,
+          now: refreshNow,
+          activeIncidents,
+          maintenanceWindows,
+          monitorLimit: 12,
+        });
+
+        return {
+          stateGeneratedAt: state.generated_at,
+          stateBodyJson: serializePublicHomepageState(state),
+          artifactPayload,
+        };
+      },
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     }),

--- a/apps/worker/src/routes/admin.ts
+++ b/apps/worker/src/routes/admin.ts
@@ -20,8 +20,16 @@ import type { Env } from '../env';
 import { requireAdmin } from '../middleware/auth';
 import { AppError } from '../middleware/errors';
 import { requireAdminRateLimit } from '../middleware/rate-limit';
-import { computePublicHomepagePayload } from '../public/homepage';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../snapshots';
+import {
+  buildPublicHomepagePayloadFromState,
+  buildPublicHomepageState,
+  serializePublicHomepageState,
+} from '../public/homepage';
+import {
+  listVisibleActiveIncidents,
+  listVisibleMaintenanceWindows,
+} from '../public/data';
+import { refreshPublicHomepageStateAndArtifactIfNeeded } from '../snapshots';
 import { runHttpCheck } from '../monitor/http';
 import {
   validateHttpResponseAssertionConfig,
@@ -80,10 +88,31 @@ adminRoutes.route('/settings', adminSettingsRoutes);
 function queuePublicHomepageSnapshotRefresh(c: { env: Env; executionCtx: ExecutionContext }) {
   const now = Math.floor(Date.now() / 1000);
   c.executionCtx.waitUntil(
-    refreshPublicHomepageSnapshotIfNeeded({
+    refreshPublicHomepageStateAndArtifactIfNeeded({
       db: c.env.DB,
       now,
-      compute: () => computePublicHomepagePayload(c.env.DB, Math.floor(Date.now() / 1000)),
+      compute: async () => {
+        const refreshNow = Math.floor(Date.now() / 1000);
+        const includeHiddenMonitors = false;
+        const [state, activeIncidents, maintenanceWindows] = await Promise.all([
+          buildPublicHomepageState(c.env.DB, refreshNow),
+          listVisibleActiveIncidents(c.env.DB, includeHiddenMonitors),
+          listVisibleMaintenanceWindows(c.env.DB, refreshNow, includeHiddenMonitors),
+        ]);
+        const artifactPayload = buildPublicHomepagePayloadFromState({
+          state,
+          now: refreshNow,
+          activeIncidents,
+          maintenanceWindows,
+          monitorLimit: 12,
+        });
+
+        return {
+          stateGeneratedAt: state.generated_at,
+          stateBodyJson: serializePublicHomepageState(state),
+          artifactPayload,
+        };
+      },
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     }),

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -7,9 +7,15 @@ import type { Env } from '../env';
 import { hasValidAdminTokenRequest } from '../middleware/auth';
 import type { PublicHomepageResponse } from '../schemas/public-homepage';
 import {
+  buildPublicHomepagePayloadFromState,
   computePublicHomepagePayload,
+  parsePublicHomepageState,
   homepageFromStatusPayload,
 } from '../public/homepage';
+import {
+  listVisibleActiveIncidents,
+  listVisibleMaintenanceWindows,
+} from '../public/data';
 import { computePublicStatusPayload } from '../public/status';
 import {
   buildNumberedPlaceholders,
@@ -26,6 +32,7 @@ import {
   applyStatusCacheHeaders,
   readHomepageSnapshotArtifactJson,
   readHomepageSnapshotJson,
+  readHomepageStateSnapshotJson,
   readStaleHomepageSnapshotJson,
   readStatusSnapshot,
   readStatusSnapshotJson,
@@ -48,6 +55,7 @@ type PublicStatusSnapshotRow = {
 };
 
 const HOMEPAGE_UNKNOWN_DOWNGRADE_GUARD_SECONDS = 2 * 60;
+const HOMEPAGE_STATE_FAST_PATH_MAX_AGE_SECONDS = 2 * 60;
 
 function safeJsonParse(text: string): unknown | null {
   const trimmed = text.trim();
@@ -154,6 +162,45 @@ function homepagePreviewsFromArtifact(
     resolvedIncidentPreview: artifact.data.snapshot.resolved_incident_preview,
     maintenanceHistoryPreview: artifact.data.snapshot.maintenance_history_preview,
   };
+}
+
+async function tryBuildHomepageFromStateSnapshot(
+  db: D1Database,
+  now: number,
+  stored?: { generatedAt: number; bodyJson: string } | null,
+): Promise<PublicHomepageResponse | null> {
+  const snapshot = stored ?? (await readHomepageStateSnapshotJson(db));
+  if (!snapshot) {
+    return null;
+  }
+
+  const age = Math.max(0, now - snapshot.generatedAt);
+  if (age > HOMEPAGE_STATE_FAST_PATH_MAX_AGE_SECONDS) {
+    return null;
+  }
+
+  let state = null;
+  try {
+    state = parsePublicHomepageState(JSON.parse(snapshot.bodyJson) as unknown);
+  } catch {
+    state = null;
+  }
+  if (!state) {
+    return null;
+  }
+
+  const includeHiddenMonitors = false;
+  const [activeIncidents, maintenanceWindows] = await Promise.all([
+    listVisibleActiveIncidents(db, includeHiddenMonitors),
+    listVisibleMaintenanceWindows(db, now, includeHiddenMonitors),
+  ]);
+
+  return buildPublicHomepagePayloadFromState({
+    state,
+    now,
+    activeIncidents,
+    maintenanceWindows,
+  });
 }
 
 async function readStaleStatusSnapshot(
@@ -634,8 +681,14 @@ publicRoutes.get('/homepage', async (c) => {
         console.warn('homepage access: mark failed', err);
       }),
     );
-  const snapshot = await readHomepageSnapshotJson(c.env.DB, now);
-  if (snapshot) {
+  const [snapshot, stateSnapshot] = await Promise.all([
+    readHomepageSnapshotJson(c.env.DB, now),
+    readHomepageStateSnapshotJson(c.env.DB),
+  ]);
+  if (
+    snapshot &&
+    (!stateSnapshot || stateSnapshot.generatedAt <= snapshot.generated_at)
+  ) {
     if (snapshot.age >= 30) {
       markHomepageAccess();
     }
@@ -648,7 +701,8 @@ publicRoutes.get('/homepage', async (c) => {
   const artifactSnapshotPromise = readStaleHomepageSnapshotArtifact(c.env.DB, now);
 
   try {
-    const payload = await computePublicHomepagePayload(c.env.DB, now);
+    const statePayload = await tryBuildHomepageFromStateSnapshot(c.env.DB, now, stateSnapshot);
+    const payload = statePayload ?? (await computePublicHomepagePayload(c.env.DB, now));
     const artifactSnapshot = await artifactSnapshotPromise;
     if (
       artifactSnapshot &&

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -685,9 +685,11 @@ publicRoutes.get('/homepage', async (c) => {
     readHomepageSnapshotJson(c.env.DB, now),
     readHomepageStateSnapshotJson(c.env.DB),
   ]);
+  const snapshotGeneratedAt = snapshot ? now - snapshot.age : null;
   if (
     snapshot &&
-    (!stateSnapshot || stateSnapshot.generatedAt <= snapshot.generated_at)
+    (!stateSnapshot ||
+      (snapshotGeneratedAt !== null && stateSnapshot.generatedAt <= snapshotGeneratedAt))
   ) {
     if (snapshot.age >= 30) {
       markHomepageAccess();

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -22,19 +22,35 @@ import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
 import {
+  advancePublicHomepageStateCoverageInPlace,
+  buildPublicHomepagePayloadFromState,
+  buildPublicHomepageState,
   computePublicHomepageArtifactPayload,
-  computePublicHomepagePayload,
+  parsePublicHomepageState,
+  serializePublicHomepageState,
+  type PublicHomepageState,
 } from '../public/homepage';
 import {
+  listVisibleActiveIncidents,
+  listVisibleMaintenanceWindows,
+} from '../public/data';
+import {
+  advancePublicMonitorCacheCoverageInPlace,
+  appendHeartbeatToPublicMonitorCacheInPlace,
+} from '../public/monitor-cache';
+import {
+  readHomepageArtifactSnapshotGeneratedAt,
+  readHomepageStateSnapshotJson,
   refreshPublicHomepageArtifactSnapshotIfNeeded,
-  refreshPublicHomepageSnapshotIfNeeded,
   wasHomepageRecentlyAccessed,
+  writeHomepageStateAndArtifactJson,
 } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
 const LOCK_NAME = 'scheduler:tick';
 const LOCK_LEASE_SECONDS = 55;
+const HOMEPAGE_REFRESH_LOCK_NAME = 'snapshot:homepage:refresh';
 
 const CHECK_CONCURRENCY = 5;
 const PERSIST_BATCH_SIZE = 25;
@@ -47,6 +63,7 @@ type DueMonitorRow = {
   name: string;
   type: string;
   target: string;
+  show_on_status_page: number;
   interval_sec: number;
   timeout_ms: number;
   http_method: string | null;
@@ -264,6 +281,23 @@ function toMonitorStatus(value: string | null): MonitorStatus | null {
   }
 }
 
+function isSameMinute(a: number, b: number): boolean {
+  return Math.floor(a / 60) === Math.floor(b / 60);
+}
+
+function isHomepageStateAndArtifactFreshForMinute(opts: {
+  stateGeneratedAt: number | null;
+  artifactGeneratedAt: number | null;
+  now: number;
+}): boolean {
+  return (
+    opts.stateGeneratedAt !== null &&
+    isSameMinute(opts.stateGeneratedAt, opts.now) &&
+    opts.artifactGeneratedAt !== null &&
+    isSameMinute(opts.artifactGeneratedAt, opts.now)
+  );
+}
+
 async function listDueMonitors(db: D1Database, checkedAt: number): Promise<DueMonitorRow[]> {
   const { results } = await db
     .prepare(
@@ -273,6 +307,7 @@ async function listDueMonitors(db: D1Database, checkedAt: number): Promise<DueMo
         m.name,
         m.type,
         m.target,
+        m.show_on_status_page,
         m.interval_sec,
         m.timeout_ms,
         m.http_method,
@@ -535,6 +570,106 @@ async function persistCompletedMonitors(
   }
 }
 
+function applyCompletedMonitorToHomepageState(
+  state: PublicHomepageState,
+  monitorIndexById: ReadonlyMap<number, number>,
+  completed: CompletedDueMonitor,
+): boolean {
+  const monitorIndex = monitorIndexById.get(completed.row.id);
+  if (monitorIndex === undefined) {
+    return completed.row.show_on_status_page !== 1;
+  }
+
+  const monitor = state.monitors[monitorIndex];
+  if (!monitor) {
+    return false;
+  }
+
+  if (monitor.covered_until_at < completed.checkedAt) {
+    advancePublicMonitorCacheCoverageInPlace(monitor.cache, {
+      status: monitor.state_status,
+      checkedAt: monitor.last_checked_at ?? 0,
+      intervalSec: monitor.interval_sec,
+      createdAt: monitor.created_at,
+      from: monitor.covered_until_at,
+      to: completed.checkedAt,
+    });
+  }
+
+  monitor.state_status = completed.next.status;
+  monitor.last_checked_at = completed.checkedAt;
+  monitor.covered_until_at = completed.checkedAt;
+  appendHeartbeatToPublicMonitorCacheInPlace(monitor.cache, {
+    checkedAt: completed.checkedAt,
+    status: completed.outcome.status,
+    latencyMs: completed.outcome.latencyMs,
+  });
+
+  return true;
+}
+
+async function refreshHomepageStateAndArtifactFromState(opts: {
+  db: D1Database;
+  now: number;
+  completed: CompletedDueMonitor[];
+  storedState?: { generatedAt: number; bodyJson: string } | null;
+}): Promise<boolean> {
+  let parsed: PublicHomepageState | null = null;
+  const stored = opts.storedState ?? (await readHomepageStateSnapshotJson(opts.db));
+  if (stored) {
+    try {
+      parsed = parsePublicHomepageState(JSON.parse(stored.bodyJson) as unknown);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  const state = parsed;
+  if (!state) {
+    return false;
+  }
+
+  const monitorIndexById = new Map<number, number>();
+  for (let index = 0; index < state.monitors.length; index += 1) {
+    const monitor = state.monitors[index];
+    if (!monitor) continue;
+    monitorIndexById.set(monitor.id, index);
+  }
+
+  for (const completed of opts.completed) {
+    if (!applyCompletedMonitorToHomepageState(state, monitorIndexById, completed)) {
+      return false;
+    }
+  }
+
+  advancePublicHomepageStateCoverageInPlace(state, opts.now);
+
+  const includeHiddenMonitors = false;
+  const [activeIncidents, maintenanceWindows] = await Promise.all([
+    listVisibleActiveIncidents(opts.db, includeHiddenMonitors),
+    listVisibleMaintenanceWindows(opts.db, opts.now, includeHiddenMonitors),
+  ]);
+
+  const artifactPayload = buildPublicHomepagePayloadFromState({
+    state,
+    now: opts.now,
+    activeIncidents,
+    maintenanceWindows,
+    monitorLimit: 12,
+  });
+  const stateBodyJson = serializePublicHomepageState(state);
+
+  await writeHomepageStateAndArtifactJson({
+    db: opts.db,
+    now: opts.now,
+    stateGeneratedAt: state.generated_at,
+    stateBodyJson,
+    artifactPayload,
+  });
+
+  return true;
+}
+
 function queueMonitorNotification(
   env: Env,
   notify: NotifyContext | null,
@@ -598,23 +733,90 @@ function queueMonitorNotification(
 export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
-  const queueHomepageRefresh = async () => {
-    const refresh = (await wasHomepageRecentlyAccessed(env.DB, now))
-      ? refreshPublicHomepageSnapshotIfNeeded({
-          db: env.DB,
-          now,
-          compute: () => computePublicHomepagePayload(env.DB, Math.floor(Date.now() / 1000)),
-        })
-      : refreshPublicHomepageArtifactSnapshotIfNeeded({
+  const queueHomepageRefresh = async (completed: CompletedDueMonitor[] = []) => {
+    try {
+      if (!(await wasHomepageRecentlyAccessed(env.DB, now))) {
+        await refreshPublicHomepageArtifactSnapshotIfNeeded({
           db: env.DB,
           now,
           compute: () =>
             computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
         });
+        return;
+      }
 
-    return refresh.catch((err) => {
+      const [stateSnapshot, artifactGeneratedAt] = await Promise.all([
+        readHomepageStateSnapshotJson(env.DB),
+        readHomepageArtifactSnapshotGeneratedAt(env.DB),
+      ]);
+      if (
+        isHomepageStateAndArtifactFreshForMinute({
+          stateGeneratedAt: stateSnapshot?.generatedAt ?? null,
+          artifactGeneratedAt,
+          now,
+        })
+      ) {
+        return;
+      }
+
+      const acquired = await acquireLease(env.DB, HOMEPAGE_REFRESH_LOCK_NAME, now, 55);
+      if (!acquired) {
+        return;
+      }
+
+      const [latestStateSnapshot, latestArtifactGeneratedAt] = await Promise.all([
+        readHomepageStateSnapshotJson(env.DB),
+        readHomepageArtifactSnapshotGeneratedAt(env.DB),
+      ]);
+      if (
+        isHomepageStateAndArtifactFreshForMinute({
+          stateGeneratedAt: latestStateSnapshot?.generatedAt ?? null,
+          artifactGeneratedAt: latestArtifactGeneratedAt,
+          now,
+        })
+      ) {
+        return;
+      }
+
+      const refreshNow = Math.floor(Date.now() / 1000);
+      const refreshedFromState =
+        latestStateSnapshot
+          ? await refreshHomepageStateAndArtifactFromState({
+              db: env.DB,
+              now: refreshNow,
+              completed,
+              storedState: latestStateSnapshot,
+            })
+          : false;
+      if (refreshedFromState) {
+        return;
+      }
+
+      const state = await buildPublicHomepageState(env.DB, refreshNow);
+      const includeHiddenMonitors = false;
+      const [activeIncidents, maintenanceWindows] = await Promise.all([
+        listVisibleActiveIncidents(env.DB, includeHiddenMonitors),
+        listVisibleMaintenanceWindows(env.DB, refreshNow, includeHiddenMonitors),
+      ]);
+      const payload = buildPublicHomepagePayloadFromState({
+        state,
+        now: refreshNow,
+        activeIncidents,
+        maintenanceWindows,
+        monitorLimit: 12,
+      });
+      const stateBodyJson = serializePublicHomepageState(state);
+
+      await writeHomepageStateAndArtifactJson({
+        db: env.DB,
+        now: refreshNow,
+        stateGeneratedAt: state.generated_at,
+        stateBodyJson,
+        artifactPayload: payload,
+      });
+    } catch (err) {
       console.warn('homepage snapshot: refresh failed', err);
-    });
+    }
   };
 
   const acquired = await acquireLease(env.DB, LOCK_NAME, now, LOCK_LEASE_SECONDS);
@@ -751,5 +953,5 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
     console.log(`scheduled: processed ${settled.length} monitors at ${checkedAt}`);
   }
 
-  ctx.waitUntil(queueHomepageRefresh());
+  ctx.waitUntil(queueHomepageRefresh(completed));
 }

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -7,6 +7,7 @@ import {
 
 const SNAPSHOT_KEY = 'homepage';
 const SNAPSHOT_ARTIFACT_KEY = 'homepage:artifact';
+const SNAPSHOT_STATE_KEY = 'homepage:state';
 const SNAPSHOT_ACCESS_KEY = 'homepage:access';
 const MAX_AGE_SECONDS = 60;
 const MAX_STALE_SECONDS = 10 * 60;
@@ -443,6 +444,10 @@ async function readHomepageArtifactSnapshotRow(db: D1Database) {
   return readSnapshotRow(db, SNAPSHOT_ARTIFACT_KEY);
 }
 
+async function readHomepageStateSnapshotRow(db: D1Database) {
+  return readSnapshotRow(db, SNAPSHOT_STATE_KEY);
+}
+
 async function readHomepageAccessSnapshotRow(db: D1Database) {
   return readSnapshotRow(db, SNAPSHOT_ACCESS_KEY);
 }
@@ -718,6 +723,17 @@ export async function readHomepageArtifactSnapshotGeneratedAt(
   return row?.generated_at ?? null;
 }
 
+export async function readHomepageStateSnapshotJson(
+  db: D1Database,
+): Promise<{ generatedAt: number; bodyJson: string } | null> {
+  const row = await readHomepageStateSnapshotRow(db);
+  if (!row) return null;
+  return {
+    generatedAt: row.generated_at,
+    bodyJson: row.body_json,
+  };
+}
+
 export async function markHomepageAccessIfNeeded(
   db: D1Database,
   now: number,
@@ -825,6 +841,49 @@ export async function writeHomepageArtifactSnapshot(
   ).run();
 }
 
+export async function writeHomepageStateSnapshotJson(
+  db: D1Database,
+  now: number,
+  generatedAt: number,
+  bodyJson: string,
+): Promise<void> {
+  await homepageSnapshotUpsertStatement(
+    db,
+    SNAPSHOT_STATE_KEY,
+    generatedAt,
+    bodyJson,
+    now,
+  ).run();
+}
+
+export async function writeHomepageStateAndArtifactJson(opts: {
+  db: D1Database;
+  now: number;
+  stateGeneratedAt: number;
+  stateBodyJson: string;
+  artifactPayload: PublicHomepageResponse;
+}): Promise<void> {
+  const render = buildHomepageRenderArtifact(opts.artifactPayload);
+  const renderBodyJson = JSON.stringify(render);
+
+  await opts.db.batch([
+    homepageSnapshotUpsertStatement(
+      opts.db,
+      SNAPSHOT_STATE_KEY,
+      opts.stateGeneratedAt,
+      opts.stateBodyJson,
+      opts.now,
+    ),
+    homepageSnapshotUpsertStatement(
+      opts.db,
+      SNAPSHOT_ARTIFACT_KEY,
+      render.generated_at,
+      renderBodyJson,
+      opts.now,
+    ),
+  ]);
+}
+
 export function applyHomepageCacheHeaders(res: Response, ageSeconds: number): void {
   const remaining = Math.max(0, MAX_AGE_SECONDS - ageSeconds);
 
@@ -917,5 +976,56 @@ export async function refreshPublicHomepageArtifactSnapshotIfNeeded(opts: {
   }
 
   await refreshPublicHomepageArtifactSnapshot(opts);
+  return true;
+}
+
+export async function refreshPublicHomepageStateAndArtifactIfNeeded(opts: {
+  db: D1Database;
+  now: number;
+  compute: () => Promise<{
+    stateGeneratedAt: number;
+    stateBodyJson: string;
+    artifactPayload: PublicHomepageResponse;
+  }>;
+}): Promise<boolean> {
+  const [stateSnapshot, artifactGeneratedAt] = await Promise.all([
+    readHomepageStateSnapshotJson(opts.db),
+    readHomepageArtifactSnapshotGeneratedAt(opts.db),
+  ]);
+  if (
+    stateSnapshot &&
+    isSameMinute(stateSnapshot.generatedAt, opts.now) &&
+    artifactGeneratedAt !== null &&
+    isSameMinute(artifactGeneratedAt, opts.now)
+  ) {
+    return false;
+  }
+
+  const acquired = await acquireLease(opts.db, REFRESH_LOCK_NAME, opts.now, 55);
+  if (!acquired) {
+    return false;
+  }
+
+  const [latestStateSnapshot, latestArtifactGeneratedAt] = await Promise.all([
+    readHomepageStateSnapshotJson(opts.db),
+    readHomepageArtifactSnapshotGeneratedAt(opts.db),
+  ]);
+  if (
+    latestStateSnapshot &&
+    isSameMinute(latestStateSnapshot.generatedAt, opts.now) &&
+    latestArtifactGeneratedAt !== null &&
+    isSameMinute(latestArtifactGeneratedAt, opts.now)
+  ) {
+    return false;
+  }
+
+  const computed = await opts.compute();
+  await writeHomepageStateAndArtifactJson({
+    db: opts.db,
+    now: opts.now,
+    stateGeneratedAt: computed.stateGeneratedAt,
+    stateBodyJson: computed.stateBodyJson,
+    artifactPayload: computed.artifactPayload,
+  });
   return true;
 }

--- a/apps/worker/test/admin-monitor-response-assertions.test.ts
+++ b/apps/worker/test/admin-monitor-response-assertions.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
 vi.mock('../src/snapshots', () => ({
-  refreshPublicHomepageSnapshotIfNeeded: vi.fn().mockResolvedValue(false),
+  refreshPublicHomepageStateAndArtifactIfNeeded: vi.fn().mockResolvedValue(false),
 }));
 vi.mock('../src/monitor/tcp', () => ({
   runTcpCheck: vi.fn(),

--- a/apps/worker/test/admin-settings-homepage-refresh.test.ts
+++ b/apps/worker/test/admin-settings-homepage-refresh.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/snapshots', () => ({
-  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageStateAndArtifactIfNeeded: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { adminSettingsRoutes } from '../src/routes/admin-settings';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../src/snapshots';
+import { refreshPublicHomepageStateAndArtifactIfNeeded } from '../src/snapshots';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
 describe('admin settings homepage snapshot refresh', () => {
@@ -46,7 +46,7 @@ describe('admin settings homepage snapshot refresh', () => {
       },
     ];
 
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageStateAndArtifactIfNeeded).mockResolvedValue(false);
 
     const env = {
       DB: createFakeD1Database(handlers),
@@ -71,6 +71,6 @@ describe('admin settings homepage snapshot refresh', () => {
     });
     expect(waitUntil).toHaveBeenCalledTimes(1);
     await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageStateAndArtifactIfNeeded).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/worker/test/homepage-snapshot.bench.ts
+++ b/apps/worker/test/homepage-snapshot.bench.ts
@@ -53,7 +53,7 @@ type RouteReadSample = {
 
 type HomepageHotPathScenario = {
   name: string;
-  mode: 'direct-homepage-compute';
+  mode: 'direct-homepage-compute' | 'state-snapshot-materialize';
   monitorCount: number;
 };
 
@@ -85,6 +85,16 @@ const ROUTE_READ_SCENARIOS: RouteReadScenario[] = [
 
 const HOMEPAGE_HOT_PATH_SCENARIOS: HomepageHotPathScenario[] = [
   {
+    name: 'homepage via state snapshot materialize / 250 monitors',
+    mode: 'state-snapshot-materialize',
+    monitorCount: 250,
+  },
+  {
+    name: 'homepage via state snapshot materialize / 1000 monitors',
+    mode: 'state-snapshot-materialize',
+    monitorCount: 1000,
+  },
+  {
     name: 'homepage via direct homepage compute / 250 monitors',
     mode: 'direct-homepage-compute',
     monitorCount: 250,
@@ -110,12 +120,148 @@ function parsePositiveIntEnv(name: string, fallback: number): number {
 const WARMUP_RUNS = parsePositiveIntEnv('HOMEPAGE_BENCH_WARMUPS', 3);
 const MEASURE_RUNS = parsePositiveIntEnv('HOMEPAGE_BENCH_RUNS', 12);
 
+function serializePublicMonitorCache(cache: {
+  heartbeat: {
+    checked_at: number[];
+    status_codes: string;
+    latency_ms: Array<number | null>;
+  };
+  uptime_days: {
+    day_start_at: number[];
+    total_sec: number[];
+    downtime_sec: number[];
+    unknown_sec: number[];
+    uptime_sec: number[];
+  };
+}) {
+  return JSON.stringify(cache);
+}
+
+function serializeHomepageState(state: {
+  generated_at: number;
+  monitor_count_total: number;
+  site_title: string;
+  site_description: string;
+  site_locale: string;
+  site_timezone: string;
+  uptime_rating_level: number;
+  monitors: Array<{
+    id: number;
+    name: string;
+    type: 'http' | 'tcp';
+    group_name: string | null;
+    interval_sec: number;
+    created_at: number;
+    state_status: string;
+    last_checked_at: number | null;
+    covered_until_at: number;
+    cache: {
+      heartbeat: {
+        checked_at: number[];
+        status_codes: string;
+        latency_ms: Array<number | null>;
+      };
+      uptime_days: {
+        day_start_at: number[];
+        total_sec: number[];
+        downtime_sec: number[];
+        unknown_sec: number[];
+        uptime_sec: number[];
+      };
+    };
+  }>;
+  resolved_incident_preview: null;
+  maintenance_history_preview: null;
+}) {
+  return JSON.stringify({
+    v: 1,
+    g: state.generated_at,
+    c: state.monitor_count_total,
+    t: state.site_title,
+    d: state.site_description,
+    l: state.site_locale,
+    z: state.site_timezone,
+    r: state.uptime_rating_level,
+    m: state.monitors.map((monitor) => [
+      monitor.id,
+      monitor.name,
+      monitor.type === 'tcp' ? 't' : 'h',
+      monitor.group_name ?? '',
+      monitor.interval_sec,
+      monitor.created_at,
+      monitor.state_status === 'up'
+        ? 'u'
+        : monitor.state_status === 'down'
+          ? 'd'
+          : monitor.state_status === 'maintenance'
+            ? 'm'
+            : monitor.state_status === 'paused'
+              ? 'p'
+              : 'x',
+      monitor.last_checked_at ?? 0,
+      monitor.covered_until_at,
+      monitor.cache.heartbeat.checked_at,
+      monitor.cache.heartbeat.status_codes,
+      monitor.cache.heartbeat.latency_ms,
+      monitor.cache.uptime_days.day_start_at,
+      monitor.cache.uptime_days.total_sec,
+      monitor.cache.uptime_days.downtime_sec,
+      monitor.cache.uptime_days.unknown_sec,
+      monitor.cache.uptime_days.uptime_sec,
+    ]),
+    i: state.resolved_incident_preview,
+    w: state.maintenance_history_preview,
+  });
+}
+
 const scenarioCache = new Map<string, ReturnType<typeof buildScenarioRows>>();
 
 function buildScenarioRows(scenario: Scenario, now: number) {
-  const monitors = Array.from({ length: scenario.monitorCount }, (_, index) => ({
-    id: index + 1,
-    name: `Monitor ${index + 1}`,
+  const monitorIds = Array.from({ length: scenario.monitorCount }, (_, index) => index + 1);
+
+  const heartbeats = monitorIds.flatMap((monitorId) =>
+    Array.from({ length: scenario.heartbeatPoints }, (_, index) => ({
+      monitor_id: monitorId,
+      checked_at: now - (index + 1) * 60,
+      status: 'up',
+      latency_ms: 40 + ((monitorId + index) % 50),
+    })),
+  );
+
+  const rollups = monitorIds.flatMap((monitorId) =>
+    Array.from({ length: scenario.uptimeDays }, (_, index) => ({
+      monitor_id: monitorId,
+      day_start_at: now - (scenario.uptimeDays - index) * 86_400,
+      total_sec: 86_400,
+      downtime_sec: 0,
+      unknown_sec: 0,
+      uptime_sec: 86_400,
+    })),
+  );
+
+  const heartbeatsByMonitorId = new Map<number, typeof heartbeats>();
+  for (const row of heartbeats) {
+    const existing = heartbeatsByMonitorId.get(row.monitor_id);
+    if (existing) {
+      existing.push(row);
+      continue;
+    }
+    heartbeatsByMonitorId.set(row.monitor_id, [row]);
+  }
+
+  const rollupsByMonitorId = new Map<number, typeof rollups>();
+  for (const row of rollups) {
+    const existing = rollupsByMonitorId.get(row.monitor_id);
+    if (existing) {
+      existing.push(row);
+      continue;
+    }
+    rollupsByMonitorId.set(row.monitor_id, [row]);
+  }
+
+  const monitors = monitorIds.map((id, index) => ({
+    id,
+    name: `Monitor ${id}`,
     type: 'http',
     group_name: index % 2 === 0 ? 'Core' : 'Edge',
     group_sort_order: index % 2,
@@ -125,27 +271,21 @@ function buildScenarioRows(scenario: Scenario, now: number) {
     state_status: 'up',
     last_checked_at: now - 30,
     last_latency_ms: 40 + (index % 50),
+    public_cache_json: serializePublicMonitorCache({
+      heartbeat: {
+        checked_at: (heartbeatsByMonitorId.get(id) ?? []).map((row) => row.checked_at),
+        status_codes: 'u'.repeat(scenario.heartbeatPoints),
+        latency_ms: (heartbeatsByMonitorId.get(id) ?? []).map((row) => row.latency_ms),
+      },
+      uptime_days: {
+        day_start_at: (rollupsByMonitorId.get(id) ?? []).map((row) => row.day_start_at),
+        total_sec: (rollupsByMonitorId.get(id) ?? []).map((row) => row.total_sec),
+        downtime_sec: (rollupsByMonitorId.get(id) ?? []).map((row) => row.downtime_sec),
+        unknown_sec: (rollupsByMonitorId.get(id) ?? []).map((row) => row.unknown_sec),
+        uptime_sec: (rollupsByMonitorId.get(id) ?? []).map((row) => row.uptime_sec),
+      },
+    }),
   }));
-
-  const heartbeats = monitors.flatMap((monitor) =>
-    Array.from({ length: scenario.heartbeatPoints }, (_, index) => ({
-      monitor_id: monitor.id,
-      checked_at: now - (index + 1) * 60,
-      status: 'up',
-      latency_ms: 40 + ((monitor.id + index) % 50),
-    })),
-  );
-
-  const rollups = monitors.flatMap((monitor) =>
-    Array.from({ length: scenario.uptimeDays }, (_, index) => ({
-      monitor_id: monitor.id,
-      day_start_at: now - (scenario.uptimeDays - index) * 86_400,
-      total_sec: 86_400,
-      downtime_sec: 0,
-      unknown_sec: 0,
-      uptime_sec: 86_400,
-    })),
-  );
 
   return { monitors, heartbeats, rollups };
 }
@@ -158,6 +298,82 @@ function getScenarioRows(scenario: Scenario, now: number) {
   const built = buildScenarioRows(scenario, now);
   scenarioCache.set(key, built);
   return built;
+}
+
+function buildHomepageStateSnapshotJson(scenario: Scenario, now: number): string {
+  const rows = getScenarioRows(scenario, now);
+  const heartbeatRowsByMonitorId = new Map<number, typeof rows.heartbeats>();
+  for (const row of rows.heartbeats) {
+    const existing = heartbeatRowsByMonitorId.get(row.monitor_id);
+    if (existing) {
+      existing.push(row);
+      continue;
+    }
+    heartbeatRowsByMonitorId.set(row.monitor_id, [row]);
+  }
+
+  const rollupRowsByMonitorId = new Map<number, typeof rows.rollups>();
+  for (const row of rows.rollups) {
+    const existing = rollupRowsByMonitorId.get(row.monitor_id);
+    if (existing) {
+      existing.push(row);
+      continue;
+    }
+    rollupRowsByMonitorId.set(row.monitor_id, [row]);
+  }
+
+  return serializeHomepageState({
+    generated_at: now - 60,
+    monitor_count_total: rows.monitors.length,
+    site_title: 'Status Hub',
+    site_description: 'Production services',
+    site_locale: 'en',
+    site_timezone: 'UTC',
+    uptime_rating_level: 3,
+    monitors: rows.monitors.map((row) => ({
+      id: row.id,
+      name: row.name,
+      type: row.type === 'tcp' ? 'tcp' : 'http',
+      group_name: row.group_name,
+      interval_sec: row.interval_sec,
+      created_at: row.created_at,
+      state_status: row.state_status,
+      last_checked_at: row.last_checked_at,
+      covered_until_at: now - 60,
+      cache: JSON.parse(
+        serializePublicMonitorCache({
+          heartbeat: {
+            checked_at: (heartbeatRowsByMonitorId.get(row.id) ?? []).map(
+              (heartbeatRow) => heartbeatRow.checked_at,
+            ),
+            status_codes: 'u'.repeat(scenario.heartbeatPoints),
+            latency_ms: (heartbeatRowsByMonitorId.get(row.id) ?? []).map(
+              (heartbeatRow) => heartbeatRow.latency_ms,
+            ),
+          },
+          uptime_days: {
+            day_start_at: (rollupRowsByMonitorId.get(row.id) ?? []).map(
+              (rollupRow) => rollupRow.day_start_at,
+            ),
+            total_sec: (rollupRowsByMonitorId.get(row.id) ?? []).map(
+              (rollupRow) => rollupRow.total_sec,
+            ),
+            downtime_sec: (rollupRowsByMonitorId.get(row.id) ?? []).map(
+              (rollupRow) => rollupRow.downtime_sec,
+            ),
+            unknown_sec: (rollupRowsByMonitorId.get(row.id) ?? []).map(
+              (rollupRow) => rollupRow.unknown_sec,
+            ),
+            uptime_sec: (rollupRowsByMonitorId.get(row.id) ?? []).map(
+              (rollupRow) => rollupRow.uptime_sec,
+            ),
+          },
+        }),
+      ),
+    })),
+    resolved_incident_preview: null,
+    maintenance_history_preview: null,
+  });
 }
 
 function createHandlersForScenario(scenario: Scenario, now: number): {
@@ -570,6 +786,7 @@ async function runOneHomepageHotPath(
       uptimeDays: 14,
     };
     const { handlers } = createHandlersForScenario(scenarioShape, now);
+    const homepageStateBodyJson = buildHomepageStateSnapshotJson(scenarioShape, now);
     const liveHandlers = [
       ...handlers,
       {
@@ -587,6 +804,12 @@ async function runOneHomepageHotPath(
               return {
                 generated_at: now,
                 body_json: JSON.stringify(artifact),
+              };
+            }
+            if (args[0] === 'homepage:state' && scenario.mode === 'state-snapshot-materialize') {
+              return {
+                generated_at: now - 60,
+                body_json: homepageStateBodyJson,
               };
             }
             return null;

--- a/apps/worker/test/public-homepage-compute.test.ts
+++ b/apps/worker/test/public-homepage-compute.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { computePublicHomepagePayload } from '../src/public/homepage';
+import {
+  buildPublicHomepagePayloadFromState,
+  computePublicHomepagePayload,
+  type PublicHomepageState,
+} from '../src/public/homepage';
+import { serializePublicMonitorCache } from '../src/public/monitor-cache';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
 describe('computePublicHomepagePayload', () => {
@@ -128,5 +133,68 @@ describe('computePublicHomepagePayload', () => {
       },
     });
     expect(payload.monitors[0]?.uptime_30d?.uptime_pct).toBeCloseTo(99.965, 3);
+  });
+
+  it('materializes homepage payloads from cached homepage state', async () => {
+    const now = 1_728_000_000;
+    const state: PublicHomepageState = {
+      generated_at: now - 30,
+      monitor_count_total: 1,
+      site_title: 'Status Hub',
+      site_description: 'Production services',
+      site_locale: 'en',
+      site_timezone: 'UTC',
+      uptime_rating_level: 4,
+      monitors: [
+        {
+          id: 1,
+          name: 'API',
+          type: 'http',
+          group_name: 'Core',
+          interval_sec: 60,
+          created_at: now - 40 * 86_400,
+          state_status: 'up',
+          last_checked_at: now - 30,
+          covered_until_at: now - 30,
+          cache: JSON.parse(
+            serializePublicMonitorCache({
+              heartbeat: {
+                checked_at: [now - 60, now - 120],
+                status_codes: 'ud',
+                latency_ms: [42, null],
+              },
+              uptime_days: {
+                day_start_at: [now - 2 * 86_400, now - 86_400],
+                total_sec: [86_400, 86_400],
+                downtime_sec: [0, 60],
+                unknown_sec: [0, 0],
+                uptime_sec: [86_400, 86_340],
+              },
+            }),
+          ),
+        },
+      ],
+      resolved_incident_preview: null,
+      maintenance_history_preview: null,
+    };
+
+    const payload = buildPublicHomepagePayloadFromState({
+      state,
+      now,
+      activeIncidents: [],
+      maintenanceWindows: { active: [], upcoming: [] },
+    });
+
+    expect(payload.monitors[0]).toMatchObject({
+      heartbeat_strip: {
+        checked_at: [now - 60, now - 120],
+        status_codes: 'ud',
+        latency_ms: [42, null],
+      },
+      uptime_day_strip: {
+        day_start_at: [now - 2 * 86_400, now - 86_400],
+      },
+    });
+    expect(payload.monitors[0]?.uptime_30d?.uptime_pct).toBeGreaterThan(99.9);
   });
 });

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -10,6 +10,8 @@ vi.mock('../src/monitor/tcp', () => ({
 
 import type { Env } from '../src/env';
 import { handleError, handleNotFound } from '../src/middleware/errors';
+import { serializePublicMonitorCache } from '../src/public/monitor-cache';
+import { serializePublicHomepageState } from '../src/public/homepage';
 import worker from '../src/index';
 import { publicRoutes } from '../src/routes/public';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
@@ -181,6 +183,86 @@ describe('public homepage route', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual(payload);
+  });
+
+  it('skips a fresh homepage row when the homepage state snapshot is newer', async () => {
+    const now = 1_728_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+
+    const res = await requestHomepage([
+      {
+        match: 'from public_snapshots',
+        first: (args) => {
+          if (args[0] === 'homepage') {
+            return {
+              generated_at: now - 60,
+              body_json: JSON.stringify(samplePayload(now - 60)),
+            };
+          }
+          if (args[0] === 'homepage:state') {
+            return {
+              generated_at: now,
+              body_json: serializePublicHomepageState({
+                generated_at: now,
+                monitor_count_total: 1,
+                site_title: 'Status Hub',
+                site_description: 'Production services',
+                site_locale: 'en',
+                site_timezone: 'UTC',
+                uptime_rating_level: 4,
+                monitors: [
+                  {
+                    id: 1,
+                    name: 'API',
+                    type: 'http',
+                    group_name: 'Core',
+                    interval_sec: 60,
+                    created_at: now - 40 * 86_400,
+                    state_status: 'up',
+                    last_checked_at: now - 30,
+                    covered_until_at: now,
+                    cache: JSON.parse(
+                      serializePublicMonitorCache({
+                        heartbeat: {
+                          checked_at: [now - 60],
+                          status_codes: 'u',
+                          latency_ms: [42],
+                        },
+                        uptime_days: {
+                          day_start_at: [now - 86_400],
+                          total_sec: [86_400],
+                          downtime_sec: [0],
+                          unknown_sec: [0],
+                          uptime_sec: [86_400],
+                        },
+                      }),
+                    ),
+                  },
+                ],
+                resolved_incident_preview: null,
+                maintenance_history_preview: null,
+              }),
+            };
+          }
+          return null;
+        },
+      },
+      {
+        match: 'from incidents',
+        all: () => [],
+      },
+      {
+        match: 'from maintenance_windows',
+        all: () => [],
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      generated_at: now,
+      monitor_count_total: 1,
+      monitors: [{ id: 1 }],
+    });
   });
 
   it('serves homepage render artifacts from the artifact snapshot row', async () => {
@@ -359,6 +441,106 @@ describe('public homepage route', () => {
     expect(res.headers.get('Cache-Control')).toBe(
       'public, max-age=0, stale-while-revalidate=0, stale-if-error=0',
     );
+  });
+
+  it('materializes homepage data from the homepage state snapshot before falling back to live compute', async () => {
+    const now = 1_728_000_000;
+    const writtenArgs: unknown[][] = [];
+    vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+
+    const { res, waitUntil } = await requestHomepageWithWaitUntil(
+      [
+        {
+          match: 'from public_snapshots',
+          first: (args) => {
+            if (args[0] === 'homepage') {
+              return null;
+            }
+            if (args[0] === 'homepage:state') {
+              return {
+                generated_at: now - 60,
+                body_json: serializePublicHomepageState({
+                  generated_at: now - 60,
+                  monitor_count_total: 1,
+                  site_title: 'Status Hub',
+                  site_description: 'Production services',
+                  site_locale: 'en',
+                  site_timezone: 'UTC',
+                  uptime_rating_level: 4,
+                  monitors: [
+                    {
+                      id: 1,
+                      name: 'API',
+                      type: 'http',
+                      group_name: 'Core',
+                      interval_sec: 60,
+                      created_at: now - 40 * 86_400,
+                      state_status: 'up',
+                      last_checked_at: now - 30,
+                      covered_until_at: now - 60,
+                      cache: JSON.parse(
+                        serializePublicMonitorCache({
+                          heartbeat: {
+                            checked_at: [now - 60],
+                            status_codes: 'u',
+                            latency_ms: [42],
+                          },
+                          uptime_days: {
+                            day_start_at: [now - 86_400],
+                            total_sec: [86_400],
+                            downtime_sec: [0],
+                            unknown_sec: [0],
+                            uptime_sec: [86_400],
+                          },
+                        }),
+                      ),
+                    },
+                  ],
+                  resolved_incident_preview: null,
+                  maintenance_history_preview: null,
+                }),
+              };
+            }
+            return null;
+          },
+        },
+        {
+          match: 'from incidents',
+          all: () => [],
+        },
+        {
+          match: 'from maintenance_windows',
+          all: () => [],
+        },
+        {
+          match: 'insert into public_snapshots',
+          run: (args) => {
+            writtenArgs.push(args);
+            return { meta: { changes: 1 } };
+          },
+        },
+      ],
+      vi.fn((promise) => promise),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      generated_at: now,
+      monitor_count_total: 1,
+      monitors: [
+        {
+          id: 1,
+          heartbeat_strip: {
+            checked_at: [now - 60],
+            status_codes: 'u',
+            latency_ms: [42],
+          },
+        },
+      ],
+    });
+    expect(waitUntil.mock.calls.length).toBeGreaterThanOrEqual(2);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+    expect(writtenArgs.filter((args) => args[0] === 'homepage')).toHaveLength(1);
   });
 
   it('falls back to the fresh public status snapshot when the full homepage snapshot is missing', async () => {

--- a/apps/worker/test/public-monitor-cache.test.ts
+++ b/apps/worker/test/public-monitor-cache.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendHeartbeatToPublicMonitorCache,
+  createEmptyPublicMonitorCache,
+  extendPublicMonitorCacheToTime,
+  materializePublicMonitorCache,
+  parsePublicMonitorCache,
+  serializePublicMonitorCache,
+} from '../src/public/monitor-cache';
+
+describe('public monitor cache', () => {
+  it('extends cached uptime with live uptime and trailing unknown time for overdue monitors', () => {
+    const now = 1_728_000_000;
+    const expectedDayStart = Math.floor((now - 1) / 86_400) * 86_400;
+    const cache = createEmptyPublicMonitorCache();
+
+    const extended = extendPublicMonitorCacheToTime(cache, {
+      status: 'up',
+      lastCheckedAt: now - 180,
+      intervalSec: 60,
+      createdAt: now - 40 * 86_400,
+      now,
+    });
+    const materialized = materializePublicMonitorCache(extended);
+
+    expect(materialized.uptime_day_strip.day_start_at).toEqual([expectedDayStart]);
+    expect(materialized.uptime_day_strip.unknown_sec).toEqual([60]);
+    expect(materialized.uptime_30d?.uptime_pct).toBeCloseTo(66.666, 2);
+  });
+
+  it('appends newest heartbeat samples at the front of the cache', () => {
+    const now = 1_728_000_000;
+    const cache = appendHeartbeatToPublicMonitorCache(createEmptyPublicMonitorCache(), {
+      checkedAt: now - 60,
+      status: 'down',
+      latencyMs: null,
+    });
+    const next = appendHeartbeatToPublicMonitorCache(cache, {
+      checkedAt: now,
+      status: 'up',
+      latencyMs: 42,
+    });
+
+    expect(next.heartbeat.checked_at).toEqual([now, now - 60]);
+    expect(next.heartbeat.status_codes).toBe('ud');
+    expect(next.heartbeat.latency_ms).toEqual([42, null]);
+  });
+
+  it('round-trips serialized cache payloads', () => {
+    const cache = appendHeartbeatToPublicMonitorCache(createEmptyPublicMonitorCache(), {
+      checkedAt: 100,
+      status: 'up',
+      latencyMs: 12,
+    });
+
+    expect(parsePublicMonitorCache(serializePublicMonitorCache(cache))).toEqual(cache);
+  });
+});

--- a/apps/worker/test/scheduled.bench.ts
+++ b/apps/worker/test/scheduled.bench.ts
@@ -17,6 +17,7 @@ type Scenario = {
   name: string;
   monitorCount: number;
   withChannel: boolean;
+  recentHomepageAccess?: boolean;
 };
 
 type Sample = {
@@ -31,6 +32,12 @@ const OUTPUT_PATH = process.env.SCHEDULER_BENCH_OUTPUT ?? null;
 
 const SCENARIOS: Scenario[] = [
   { name: '1000 due monitors / no channels', monitorCount: 1000, withChannel: false },
+  {
+    name: '1000 due monitors / no channels / recent homepage access',
+    monitorCount: 1000,
+    withChannel: false,
+    recentHomepageAccess: true,
+  },
   { name: '5000 due monitors / no channels', monitorCount: 5000, withChannel: false },
   { name: '5000 due monitors / 1 webhook channel', monitorCount: 5000, withChannel: true },
 ];
@@ -49,15 +56,111 @@ function parsePositiveIntEnv(name: string, fallback: number): number {
 const WARMUP_RUNS = parsePositiveIntEnv('SCHEDULER_BENCH_WARMUPS', 3);
 const MEASURE_RUNS = parsePositiveIntEnv('SCHEDULER_BENCH_RUNS', 12);
 
+function serializePublicMonitorCache(cache: {
+  heartbeat: {
+    checked_at: number[];
+    status_codes: string;
+    latency_ms: Array<number | null>;
+  };
+  uptime_days: {
+    day_start_at: number[];
+    total_sec: number[];
+    downtime_sec: number[];
+    unknown_sec: number[];
+    uptime_sec: number[];
+  };
+}) {
+  return JSON.stringify(cache);
+}
+
+function serializeHomepageState(state: {
+  generated_at: number;
+  monitor_count_total: number;
+  site_title: string;
+  site_description: string;
+  site_locale: string;
+  site_timezone: string;
+  uptime_rating_level: number;
+  monitors: Array<{
+    id: number;
+    name: string;
+    type: 'http' | 'tcp';
+    group_name: string | null;
+    interval_sec: number;
+    created_at: number;
+    state_status: string;
+    last_checked_at: number | null;
+    covered_until_at: number;
+    cache: {
+      heartbeat: {
+        checked_at: number[];
+        status_codes: string;
+        latency_ms: Array<number | null>;
+      };
+      uptime_days: {
+        day_start_at: number[];
+        total_sec: number[];
+        downtime_sec: number[];
+        unknown_sec: number[];
+        uptime_sec: number[];
+      };
+    };
+  }>;
+  resolved_incident_preview: null;
+  maintenance_history_preview: null;
+}) {
+  return JSON.stringify({
+    v: 1,
+    g: state.generated_at,
+    c: state.monitor_count_total,
+    t: state.site_title,
+    d: state.site_description,
+    l: state.site_locale,
+    z: state.site_timezone,
+    r: state.uptime_rating_level,
+    m: state.monitors.map((monitor) => [
+      monitor.id,
+      monitor.name,
+      monitor.type === 'tcp' ? 't' : 'h',
+      monitor.group_name ?? '',
+      monitor.interval_sec,
+      monitor.created_at,
+      monitor.state_status === 'up'
+        ? 'u'
+        : monitor.state_status === 'down'
+          ? 'd'
+          : monitor.state_status === 'maintenance'
+            ? 'm'
+            : monitor.state_status === 'paused'
+              ? 'p'
+              : 'x',
+      monitor.last_checked_at ?? 0,
+      monitor.covered_until_at,
+      monitor.cache.heartbeat.checked_at,
+      monitor.cache.heartbeat.status_codes,
+      monitor.cache.heartbeat.latency_ms,
+      monitor.cache.uptime_days.day_start_at,
+      monitor.cache.uptime_days.total_sec,
+      monitor.cache.uptime_days.downtime_sec,
+      monitor.cache.uptime_days.unknown_sec,
+      monitor.cache.uptime_days.uptime_sec,
+    ]),
+    i: state.resolved_incident_preview,
+    w: state.maintenance_history_preview,
+  });
+}
+
 function makeDueRows(count: number) {
   return Array.from({ length: count }, (_, index) => ({
     id: index + 1,
     name: `Monitor ${index + 1}`,
     type: 'unsupported',
     target: `benchmark-target-${index + 1}`,
+    show_on_status_page: 1,
     group_name: index % 2 === 0 ? 'Core' : 'Edge',
     interval_sec: 60,
     created_at: 1_700_000_000 - 40 * 86_400,
+    last_checked_at: 1_700_000_000 - 60,
     timeout_ms: 5000,
     http_method: null,
     http_headers_json: null,
@@ -72,7 +175,50 @@ function makeDueRows(count: number) {
     last_changed_at: 1_700_000_000,
     consecutive_failures: 0,
     consecutive_successes: 3,
+    public_cache_json: serializePublicMonitorCache({
+      heartbeat: {
+        checked_at: Array.from({ length: 30 }, (_, heartbeatIndex) => 1_700_000_000 - (heartbeatIndex + 1) * 60),
+        status_codes: 'u'.repeat(30),
+        latency_ms: Array.from({ length: 30 }, (_, heartbeatIndex) => 40 + ((index + heartbeatIndex) % 50)),
+      },
+      uptime_days: {
+        day_start_at: Array.from({ length: 14 }, (_, dayIndex) => 1_700_000_000 - (14 - dayIndex) * 86_400),
+        total_sec: Array.from({ length: 14 }, () => 86_400),
+        downtime_sec: Array.from({ length: 14 }, () => 0),
+        unknown_sec: Array.from({ length: 14 }, () => 0),
+        uptime_sec: Array.from({ length: 14 }, () => 86_400),
+      },
+    }),
   }));
+}
+
+function buildHomepageStateJson(
+  dueRows: ReturnType<typeof makeDueRows>,
+  generatedAt: number,
+) {
+  return serializeHomepageState({
+    generated_at: generatedAt,
+    monitor_count_total: dueRows.length,
+    site_title: 'Status Hub',
+    site_description: 'Production services',
+    site_locale: 'en',
+    site_timezone: 'UTC',
+    uptime_rating_level: 3,
+    monitors: dueRows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      type: row.type === 'tcp' ? 'tcp' : 'http',
+      group_name: row.group_name,
+      interval_sec: row.interval_sec,
+      created_at: row.created_at,
+      state_status: row.state_status,
+      last_checked_at: row.last_checked_at,
+      covered_until_at: generatedAt,
+      cache: JSON.parse(row.public_cache_json),
+    })),
+    resolved_incident_preview: null,
+    maintenance_history_preview: null,
+  });
 }
 
 function createEnvForScenario(scenario: Scenario): {
@@ -85,7 +231,12 @@ function createEnvForScenario(scenario: Scenario): {
     waitUntilCalls: 0,
   };
   const dueRows = makeDueRows(scenario.monitorCount);
-  let homepageArtifactGeneratedAt = 0;
+  let homepageGeneratedAt = scenario.recentHomepageAccess ? 1_700_000_000 - 60 : 0;
+  let homepageArtifactGeneratedAt = scenario.recentHomepageAccess ? 1_700_000_000 - 60 : 0;
+  let homepageStateGeneratedAt = scenario.recentHomepageAccess ? 1_700_000_000 - 60 : 0;
+  let homepageStateBodyJson = scenario.recentHomepageAccess
+    ? buildHomepageStateJson(dueRows, homepageStateGeneratedAt)
+    : '';
   const channels = scenario.withChannel
     ? [
         {
@@ -138,6 +289,10 @@ function createEnvForScenario(scenario: Scenario): {
       all: () => [],
     },
     {
+      match: 'from incidents',
+      all: () => [],
+    },
+    {
       match: 'from maintenance_window_monitors',
       all: () => [],
     },
@@ -180,13 +335,33 @@ function createEnvForScenario(scenario: Scenario): {
     },
     {
       match: 'from public_snapshots',
-      first: (args) =>
-        args[0] === 'homepage:artifact' && homepageArtifactGeneratedAt > 0
-          ? {
-              generated_at: homepageArtifactGeneratedAt,
-              body_json: '{"generated_at":0}',
-            }
-          : null,
+      first: (args) => {
+        if (args[0] === 'homepage:access' && scenario.recentHomepageAccess) {
+          return {
+            generated_at: 1_700_000_000,
+            body_json: '{}',
+          };
+        }
+        if (args[0] === 'homepage' && homepageGeneratedAt > 0) {
+          return {
+            generated_at: homepageGeneratedAt,
+            body_json: '{"generated_at":0}',
+          };
+        }
+        if (args[0] === 'homepage:artifact' && homepageArtifactGeneratedAt > 0) {
+          return {
+            generated_at: homepageArtifactGeneratedAt,
+            body_json: '{"generated_at":0}',
+          };
+        }
+        if (args[0] === 'homepage:state' && homepageStateGeneratedAt > 0) {
+          return {
+            generated_at: homepageStateGeneratedAt,
+            body_json: homepageStateBodyJson,
+          };
+        }
+        return null;
+      },
     },
     {
       match: 'insert into check_results',
@@ -207,8 +382,15 @@ function createEnvForScenario(scenario: Scenario): {
     {
       match: 'insert into public_snapshots',
       run: (args) => {
+        if (args[0] === 'homepage') {
+          homepageGeneratedAt = Number(args[1]);
+        }
         if (args[0] === 'homepage:artifact') {
           homepageArtifactGeneratedAt = Number(args[1]);
+        }
+        if (args[0] === 'homepage:state') {
+          homepageStateGeneratedAt = Number(args[1]);
+          homepageStateBodyJson = String(args[2]);
         }
         return { meta: { changes: 1 } };
       },

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -16,29 +16,56 @@ vi.mock('../src/notify/webhook', () => ({
   dispatchWebhookToChannels: vi.fn(),
 }));
 vi.mock('../src/public/homepage', () => ({
+  advancePublicHomepageStateCoverageInPlace: vi.fn(),
+  buildPublicHomepagePayloadFromState: vi.fn(),
+  buildPublicHomepageState: vi.fn(),
   computePublicHomepageArtifactPayload: vi.fn(),
-  computePublicHomepagePayload: vi.fn(),
+  parsePublicHomepageState: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
+  readHomepageArtifactSnapshotGeneratedAt: vi.fn(),
+  readHomepageStateSnapshotJson: vi.fn(),
   refreshPublicHomepageArtifactSnapshotIfNeeded: vi.fn(),
-  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
   wasHomepageRecentlyAccessed: vi.fn(),
+  writeHomepageStateAndArtifactJson: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { runHttpCheck } from '../src/monitor/http';
 import { runTcpCheck } from '../src/monitor/tcp';
 import { dispatchWebhookToChannels } from '../src/notify/webhook';
-import { computePublicHomepageArtifactPayload, computePublicHomepagePayload } from '../src/public/homepage';
+import {
+  advancePublicHomepageStateCoverageInPlace,
+  buildPublicHomepagePayloadFromState,
+  buildPublicHomepageState,
+  computePublicHomepageArtifactPayload,
+} from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
 import {
+  readHomepageArtifactSnapshotGeneratedAt,
+  readHomepageStateSnapshotJson,
   refreshPublicHomepageArtifactSnapshotIfNeeded,
-  refreshPublicHomepageSnapshotIfNeeded,
   wasHomepageRecentlyAccessed,
+  writeHomepageStateAndArtifactJson,
 } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
+
+const EMPTY_PUBLIC_CACHE_JSON = JSON.stringify({
+  heartbeat: {
+    checked_at: [],
+    status_codes: '',
+    latency_ms: [],
+  },
+  uptime_days: {
+    day_start_at: [],
+    total_sec: [],
+    downtime_sec: [],
+    unknown_sec: [],
+    uptime_sec: [],
+  },
+});
 
 type CreateEnvOptions = {
   dueRows?: unknown[];
@@ -61,6 +88,18 @@ function createEnv(options: CreateEnvOptions = {}): Env {
     onRun,
   } = options;
 
+  const normalizedDueRows = dueRows.map((row) =>
+    Object.defineProperties(
+      {
+        show_on_status_page: 1,
+        created_at: 1_700_000_000 - 40 * 86_400,
+        last_checked_at: 1_700_000_000,
+        public_cache_json: EMPTY_PUBLIC_CACHE_JSON,
+      },
+      Object.getOwnPropertyDescriptors(row as Record<string, unknown>),
+    ),
+  );
+
   const handlers: FakeD1QueryHandler[] = [
     {
       match: 'from notification_channels',
@@ -68,7 +107,7 @@ function createEnv(options: CreateEnvOptions = {}): Env {
     },
     {
       match: 'from monitors m',
-      all: () => dueRows,
+      all: () => normalizedDueRows,
     },
     {
       match: 'select distinct mwm.monitor_id',
@@ -85,6 +124,10 @@ function createEnv(options: CreateEnvOptions = {}): Env {
         }
         return [];
       },
+    },
+    {
+      match: 'from incidents',
+      all: () => [],
     },
     {
       match: 'from maintenance_window_monitors',
@@ -144,15 +187,21 @@ describe('scheduler/scheduled regression', () => {
       uptime_rating_level: 3,
     });
     vi.mocked(dispatchWebhookToChannels).mockResolvedValue(undefined);
+    vi.mocked(advancePublicHomepageStateCoverageInPlace).mockImplementation(() => {});
+    vi.mocked(buildPublicHomepagePayloadFromState).mockReturnValue({
+      generated_at: Math.floor(Date.now() / 1000),
+    } as never);
+    vi.mocked(buildPublicHomepageState).mockResolvedValue({
+      generated_at: Math.floor(Date.now() / 1000),
+    } as never);
     vi.mocked(computePublicHomepageArtifactPayload).mockResolvedValue({
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
-    vi.mocked(computePublicHomepagePayload).mockResolvedValue({
-      generated_at: Math.floor(Date.now() / 1000),
-    } as never);
+    vi.mocked(readHomepageArtifactSnapshotGeneratedAt).mockResolvedValue(null);
+    vi.mocked(readHomepageStateSnapshotJson).mockResolvedValue(null);
     vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
     vi.mocked(wasHomepageRecentlyAccessed).mockResolvedValue(false);
+    vi.mocked(writeHomepageStateAndArtifactJson).mockResolvedValue(undefined);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -208,7 +257,7 @@ describe('scheduler/scheduled regression', () => {
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
-  it('switches to full homepage snapshot refresh when homepage traffic was seen recently', async () => {
+  it('switches to homepage state and artifact refresh when homepage traffic was seen recently', async () => {
     vi.mocked(wasHomepageRecentlyAccessed).mockResolvedValue(true);
 
     const env = createEnv({ dueRows: [] });
@@ -216,19 +265,25 @@ describe('scheduler/scheduled regression', () => {
     const expectedNow = Math.floor(Date.now() / 1000);
 
     await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
 
     expect(wasHomepageRecentlyAccessed).toHaveBeenCalledWith(env.DB, expectedNow);
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
+    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).not.toHaveBeenCalled();
+    expect(buildPublicHomepageState).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(buildPublicHomepagePayloadFromState).toHaveBeenCalledWith({
+      state: expect.any(Object),
+      now: expectedNow,
+      activeIncidents: [],
+      maintenanceWindows: { active: [], upcoming: [] },
+      monitorLimit: 12,
+    });
+    expect(writeHomepageStateAndArtifactJson).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
-      compute: expect.any(Function),
+      stateGeneratedAt: expectedNow,
+      stateBodyJson: expect.any(String),
+      artifactPayload: expect.objectContaining({ generated_at: expectedNow }),
     });
-    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).not.toHaveBeenCalled();
-
-    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
-    expect(refreshArgs).toBeDefined();
-    await refreshArgs?.compute();
-    expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -40,6 +40,7 @@ import {
   buildPublicHomepagePayloadFromState,
   buildPublicHomepageState,
   computePublicHomepageArtifactPayload,
+  parsePublicHomepageState,
   serializePublicHomepageState,
 } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
@@ -288,6 +289,141 @@ describe('scheduler/scheduled regression', () => {
       artifactPayload: expect.objectContaining({ generated_at: expectedNow }),
     });
     expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips homepage refresh after taking the refresh lease when state and artifact are already fresh', async () => {
+    vi.mocked(wasHomepageRecentlyAccessed).mockResolvedValue(true);
+
+    const env = createEnv({ dueRows: [] });
+    const waitUntil = vi.fn();
+    const expectedNow = Math.floor(Date.now() / 1000);
+
+    vi.mocked(readHomepageStateSnapshotJson)
+      .mockResolvedValueOnce({
+        generatedAt: expectedNow - 60,
+        bodyJson: '{}',
+      })
+      .mockResolvedValueOnce({
+        generatedAt: expectedNow,
+        bodyJson: '{}',
+      });
+    vi.mocked(readHomepageArtifactSnapshotGeneratedAt)
+      .mockResolvedValueOnce(expectedNow - 60)
+      .mockResolvedValueOnce(expectedNow);
+
+    await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+
+    expect(buildPublicHomepageState).not.toHaveBeenCalled();
+    expect(buildPublicHomepagePayloadFromState).not.toHaveBeenCalled();
+    expect(writeHomepageStateAndArtifactJson).not.toHaveBeenCalled();
+  });
+
+  it('refreshes homepage state and artifact directly from the stored homepage state snapshot', async () => {
+    vi.mocked(wasHomepageRecentlyAccessed).mockResolvedValue(true);
+
+    const env = createEnv({
+      dueRows: [
+        {
+          id: 101,
+          name: 'API',
+          type: 'http',
+          target: 'https://example.com/health',
+          interval_sec: 60,
+          timeout_ms: 5000,
+          http_method: 'GET',
+          http_headers_json: null,
+          http_body: null,
+          expected_status_json: null,
+          response_keyword: null,
+          response_keyword_mode: null,
+          response_forbidden_keyword: null,
+          response_forbidden_keyword_mode: null,
+          state_status: 'up',
+          state_last_error: null,
+          last_changed_at: 1700000000,
+          consecutive_failures: 0,
+          consecutive_successes: 3,
+        },
+      ],
+    });
+    const waitUntil = vi.fn();
+    const expectedNow = Math.floor(Date.now() / 1000);
+    const storedState = {
+      generated_at: expectedNow - 60,
+      monitor_count_total: 1,
+      site_title: 'Status Hub',
+      site_description: 'Production services',
+      site_locale: 'en',
+      site_timezone: 'UTC',
+      uptime_rating_level: 4,
+      monitors: [
+        {
+          id: 101,
+          name: 'API',
+          type: 'http',
+          group_name: 'Core',
+          interval_sec: 60,
+          created_at: expectedNow - 40 * 86400,
+          state_status: 'up',
+          last_checked_at: expectedNow - 60,
+          covered_until_at: expectedNow - 60,
+          cache: {
+            heartbeat: {
+              checked_at: [],
+              status_codes: '',
+              latency_ms: [],
+            },
+            uptime_days: {
+              day_start_at: [],
+              total_sec: [],
+              downtime_sec: [],
+              unknown_sec: [],
+              uptime_sec: [],
+            },
+          },
+        },
+      ],
+      resolved_incident_preview: null,
+      maintenance_history_preview: null,
+    };
+
+    vi.mocked(readHomepageStateSnapshotJson)
+      .mockResolvedValueOnce({
+        generatedAt: expectedNow - 60,
+        bodyJson: '{"stale":true}',
+      })
+      .mockResolvedValueOnce({
+        generatedAt: expectedNow - 60,
+        bodyJson: '{"stale":true}',
+      });
+    vi.mocked(readHomepageArtifactSnapshotGeneratedAt)
+      .mockResolvedValueOnce(expectedNow - 60)
+      .mockResolvedValueOnce(expectedNow - 60);
+    vi.mocked(parsePublicHomepageState).mockReturnValue(storedState as never);
+    vi.mocked(advancePublicHomepageStateCoverageInPlace).mockImplementation((state, now) => {
+      (state as { generated_at: number }).generated_at = now;
+    });
+
+    await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+
+    expect(parsePublicHomepageState).toHaveBeenCalledTimes(1);
+    expect(buildPublicHomepageState).not.toHaveBeenCalled();
+    expect(buildPublicHomepagePayloadFromState).toHaveBeenCalledWith({
+      state: expect.any(Object),
+      now: expectedNow,
+      activeIncidents: [],
+      maintenanceWindows: { active: [], upcoming: [] },
+      monitorLimit: 12,
+    });
+    expect(writeHomepageStateAndArtifactJson).toHaveBeenCalledWith({
+      db: env.DB,
+      now: expectedNow,
+      stateGeneratedAt: expectedNow,
+      stateBodyJson: '{}',
+      artifactPayload: expect.objectContaining({ generated_at: expectedNow }),
+    });
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -21,6 +21,7 @@ vi.mock('../src/public/homepage', () => ({
   buildPublicHomepageState: vi.fn(),
   computePublicHomepageArtifactPayload: vi.fn(),
   parsePublicHomepageState: vi.fn(),
+  serializePublicHomepageState: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
   readHomepageArtifactSnapshotGeneratedAt: vi.fn(),
@@ -39,6 +40,7 @@ import {
   buildPublicHomepagePayloadFromState,
   buildPublicHomepageState,
   computePublicHomepageArtifactPayload,
+  serializePublicHomepageState,
 } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
@@ -197,6 +199,7 @@ describe('scheduler/scheduled regression', () => {
     vi.mocked(computePublicHomepageArtifactPayload).mockResolvedValue({
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
+    vi.mocked(serializePublicHomepageState).mockReturnValue('{}');
     vi.mocked(readHomepageArtifactSnapshotGeneratedAt).mockResolvedValue(null);
     vi.mocked(readHomepageStateSnapshotJson).mockResolvedValue(null);
     vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);


### PR DESCRIPTION
## What
- move homepage refresh off the scheduler full-data path and keep only `homepage:state` + `homepage:artifact` prewarmed
- serve `/api/v1/public/homepage` from the fresh full snapshot only when it is at least as new as the state snapshot, otherwise derive from state
- add benchmark coverage for state-backed homepage paths and compact state serialization

## Why
- the previous flow still spent CPU on full homepage materialization/stringify during scheduler ticks
- once `homepage:state` existed, the route could also incorrectly skip a fresh full snapshot because it compared against a non-existent `snapshot.generated_at`
- the goal is to cut fixed Worker CPU without regressing homepage UX

## Where
- `apps/worker/src/scheduler/scheduled.ts`
- `apps/worker/src/public/homepage.ts`
- `apps/worker/src/routes/public.ts`
- `apps/worker/src/snapshots/public-homepage.ts`
- related worker tests and benchmarks

## How to verify
- `pnpm --filter @uptimer/worker lint`
- `pnpm --filter @uptimer/worker typecheck`
- `pnpm --filter @uptimer/worker test`
- `pnpm --filter @uptimer/worker bench:homepage`
- `SCHEDULER_BENCH_BASE_REF=4da30743b7e7d934dce9f8a276f087b1e51e00dc pnpm --filter @uptimer/worker bench:scheduler`

## Notes
- current scheduler bench vs `4da3074` on this branch:
  - `1000 due / no channels`: `9.838 -> 9.442`
  - `1000 due / recent homepage access`: `10.214 -> 9.662`
  - `5000 due / no channels`: `60.474 -> 55.998`
  - `5000 due / 1 webhook`: `59.329 -> 54.246`
- current homepage bench on this branch:
  - `homepage via state snapshot materialize / 1000 monitors`: median `17.913ms`
  - `homepage via direct homepage compute / 1000 monitors`: median `17.783ms`
