### PR TITLE
[codex] guard homepage fallback reuse by deploy

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/stamp-pages-worker.mjs",
     "preview": "vite preview",
     "lint": "pnpm -w exec eslint --config eslint.config.mjs apps/web",
     "typecheck": "pnpm -w exec tsc -p apps/web/tsconfig.json --noEmit"

--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -1,6 +1,14 @@
 const SNAPSHOT_MAX_AGE_SECONDS = 60;
 const PREFERRED_MAX_AGE_SECONDS = 30;
 const FALLBACK_HTML_MAX_AGE_SECONDS = 600;
+const FALLBACK_REUSE_MAX_AGE_SECONDS = 2 * 60;
+const FALLBACK_GENERATED_AT_HEADER = 'x-uptimer-generated-at';
+const FALLBACK_DEPLOY_ID_HEADER = 'x-uptimer-deploy-id';
+const DEPLOY_ID_SENTINEL = '__UPTIMER_DEPLOY_ID__';
+const FALLBACK_DEPLOY_ID = '__UPTIMER_DEPLOY_ID__';
+
+const FALLBACK_BOOTSTRAP_FLAG_TAG =
+  '<script>globalThis.__UPTIMER_BOOTSTRAP_FALLBACK__=true;</script>';
 
 function acceptsHtml(request) {
   const accept = request.headers.get('Accept') || '';
@@ -90,10 +98,70 @@ function computeCacheControl(ageSeconds) {
   return `public, max-age=${maxAge}, stale-while-revalidate=${stale}, stale-if-error=${stale}`;
 }
 
+function readCurrentDeployId() {
+  const override = globalThis.__UPTIMER_DEPLOY_ID__;
+  if (typeof override === 'string' && override.length > 0) {
+    return override;
+  }
+  return FALLBACK_DEPLOY_ID;
+}
+
+function hasCurrentDeployId() {
+  return readCurrentDeployId() !== DEPLOY_ID_SENTINEL;
+}
+
+function isSameDeployFallback(response) {
+  if (!hasCurrentDeployId()) return false;
+  return response.headers.get(FALLBACK_DEPLOY_ID_HEADER) === readCurrentDeployId();
+}
+
+function readFallbackGeneratedAt(response) {
+  const raw = response.headers.get(FALLBACK_GENERATED_AT_HEADER);
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isReusableFallback(response, now) {
+  if (!isSameDeployFallback(response)) return false;
+  const generatedAt = readFallbackGeneratedAt(response);
+  if (generatedAt === null) return false;
+  return Math.max(0, now - generatedAt) <= FALLBACK_REUSE_MAX_AGE_SECONDS;
+}
+
+function shouldWarmPrimaryCache(response, now) {
+  const generatedAt = readFallbackGeneratedAt(response);
+  if (generatedAt === null) return false;
+  return Math.max(0, now - generatedAt) < SNAPSHOT_MAX_AGE_SECONDS;
+}
+
+function toClientFallbackResponse(response, now) {
+  const headers = new Headers(response.headers);
+  const generatedAt = readFallbackGeneratedAt(response);
+  headers.delete(FALLBACK_GENERATED_AT_HEADER);
+  headers.delete(FALLBACK_DEPLOY_ID_HEADER);
+
+  if (generatedAt === null) {
+    headers.set('Cache-Control', 'no-store');
+  } else {
+    headers.set('Cache-Control', computeCacheControl(Math.max(0, now - generatedAt)));
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 function upsertHeadTag(html, pattern, tag) {
   if (pattern.test(html)) {
     return html.replace(pattern, tag);
   }
+  return html.replace('</head>', `  ${tag}\n</head>`);
+}
+
+function injectHeadTag(html, tag) {
   return html.replace('</head>', `  ${tag}\n</head>`);
 }
 
@@ -227,14 +295,23 @@ export default {
       const cached = await caches.default.match(cacheKey);
       if (cached) return cached;
 
+      const now = Math.floor(Date.now() / 1000);
+      const fallback = await caches.default.match(fallbackCacheKey);
+      if (fallback && isReusableFallback(fallback, now)) {
+        const clientFallback = toClientFallbackResponse(fallback, now);
+        if (shouldWarmPrimaryCache(fallback, now)) {
+          ctx.waitUntil(caches.default.put(cacheKey, clientFallback.clone()));
+        }
+        return clientFallback;
+      }
+
       const base = await fetchIndexHtml(env, url);
       const html = await base.text();
 
       const artifact = await fetchPublicHomepageArtifact(env);
       if (!artifact) {
-        const fallback = await caches.default.match(fallbackCacheKey);
-        if (fallback) {
-          return fallback;
+        if (fallback && isSameDeployFallback(fallback)) {
+          return toClientFallbackResponse(fallback, now);
         }
 
         const headers = new Headers(base.headers);
@@ -245,7 +322,6 @@ export default {
         return new Response(html, { status: 200, headers });
       }
 
-      const now = Math.floor(Date.now() / 1000);
       const generatedAt = typeof artifact.generated_at === 'number' ? artifact.generated_at : now;
       const age = Math.max(0, now - generatedAt);
 
@@ -264,6 +340,8 @@ export default {
       const headers = new Headers(base.headers);
       headers.set('Content-Type', 'text/html; charset=utf-8');
       headers.set('Cache-Control', computeCacheControl(age));
+      headers.set(FALLBACK_GENERATED_AT_HEADER, String(generatedAt));
+      headers.set(FALLBACK_DEPLOY_ID_HEADER, readCurrentDeployId());
       headers.append('Vary', 'Accept');
       headers.delete('Location');
 
@@ -271,7 +349,13 @@ export default {
 
       const fallbackHeaders = new Headers(headers);
       fallbackHeaders.set('Cache-Control', `public, max-age=${FALLBACK_HTML_MAX_AGE_SECONDS}`);
-      const fallbackResp = new Response(injected, { status: 200, headers: fallbackHeaders });
+      const fallbackResp = new Response(
+        injectHeadTag(injected, FALLBACK_BOOTSTRAP_FLAG_TAG),
+        {
+          status: 200,
+          headers: fallbackHeaders,
+        },
+      );
 
       ctx.waitUntil(
         Promise.all([

--- a/apps/web/scripts/stamp-pages-worker.mjs
+++ b/apps/web/scripts/stamp-pages-worker.mjs
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(scriptDir, '..', 'dist');
+const workerPath = resolve(distDir, '_worker.js');
+const indexPath = resolve(distDir, 'index.html');
+
+const indexHtml = await readFile(indexPath, 'utf8');
+const workerSource = await readFile(workerPath, 'utf8');
+
+const scriptMatch = indexHtml.match(/<script[^>]+type="module"[^>]+src="([^"]+)"/i);
+if (!scriptMatch?.[1]) {
+  throw new Error('Failed to locate the dist module script for Pages worker stamping');
+}
+
+const stylesheetMatch = indexHtml.match(/<link[^>]+rel="stylesheet"[^>]+href="([^"]+)"/i);
+const deploySeed = [scriptMatch[1], stylesheetMatch?.[1] ?? ''].join('|');
+const deployId = createHash('sha256').update(deploySeed).digest('hex').slice(0, 16);
+
+const stampedSource = workerSource.replace(
+  "const FALLBACK_DEPLOY_ID = '__UPTIMER_DEPLOY_ID__';",
+  `const FALLBACK_DEPLOY_ID = '${deployId}';`,
+);
+
+if (stampedSource === workerSource) {
+  throw new Error('Failed to stamp dist/_worker.js with the current deploy id');
+}
+
+await writeFile(workerPath, stampedSource, 'utf8');
+console.log(`Stamped dist/_worker.js with deploy id ${deployId}`);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -14,6 +14,7 @@ import './styles.css';
 declare global {
   var __UPTIMER_INITIAL_HOMEPAGE__: PublicHomepageResponse | undefined;
   var __UPTIMER_INITIAL_STATUS__: StatusResponse | undefined;
+  var __UPTIMER_BOOTSTRAP_FALLBACK__: boolean | undefined;
 }
 
 const LS_PUBLIC_HOMEPAGE_KEY = 'uptimer_public_homepage_snapshot_v1';

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -372,9 +372,14 @@ export function StatusPage() {
     staleTime: 60_000,
     refetchInterval: 60_000,
     // Keep a recent injected homepage bootstrap stable through the current monitor window.
-    // Immediate mount refetch can temporarily downgrade recent artifact data to UNKNOWN
-    // before the next scheduled check has refreshed monitor_state/snapshots.
+    // Fallback HTML can be older than the active query freshness window; force a single
+    // mount refresh, then return to the normal anti-downgrade guard.
     refetchOnMount: (query) => {
+      if (globalThis.__UPTIMER_BOOTSTRAP_FALLBACK__) {
+        globalThis.__UPTIMER_BOOTSTRAP_FALLBACK__ = false;
+        return 'always';
+      }
+
       const data = query.state.data as PublicHomepageResponse | undefined;
       if (!data || typeof data.generated_at !== 'number') {
         return true;

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -22,6 +22,7 @@ import {
 } from '../public/visibility';
 import {
   applyHomepageCacheHeaders,
+  readHomepageSnapshotArtifact,
   applyStatusCacheHeaders,
   readHomepageSnapshotArtifactJson,
   readHomepageSnapshotJson,
@@ -598,21 +599,39 @@ publicRoutes.get('/homepage', async (c) => {
     return res;
   }
 
-  const historyPreviewsPromise = readHomepageHistoryPreviews(c.env.DB, now).catch((err) => {
-    console.warn('public homepage: preview read failed', err);
-    return {
-      resolvedIncidentPreview: null,
-      maintenanceHistoryPreview: null,
-    };
-  });
+  let historyPreviewsPromise:
+    | Promise<{
+        resolvedIncidentPreview: Awaited<
+          ReturnType<typeof readHomepageHistoryPreviews>
+        >['resolvedIncidentPreview'];
+        maintenanceHistoryPreview: Awaited<
+          ReturnType<typeof readHomepageHistoryPreviews>
+        >['maintenanceHistoryPreview'];
+      }>
+    | null = null;
+  const getHistoryPreviews = () =>
+    (historyPreviewsPromise ??= readHomepageHistoryPreviews(c.env.DB, now).catch((err) => {
+      console.warn('public homepage: preview read failed', err);
+      return {
+        resolvedIncidentPreview: null,
+        maintenanceHistoryPreview: null,
+      };
+    }));
   const statusSnapshot = await readStatusSnapshot(c.env.DB, now);
   if (statusSnapshot) {
     const payload = homepageFromStatusPayload(
       statusSnapshot.data,
-      await historyPreviewsPromise,
+      await getHistoryPreviews(),
     );
     const res = c.json(payload);
     applyHomepageCacheHeaders(res, statusSnapshot.age);
+    return res;
+  }
+
+  const fullArtifactSnapshot = await readHomepageSnapshotArtifact(c.env.DB, now);
+  if (fullArtifactSnapshot?.data.snapshot.bootstrap_mode === 'full') {
+    const res = c.json(fullArtifactSnapshot.data.snapshot);
+    applyHomepageCacheHeaders(res, fullArtifactSnapshot.age);
     return res;
   }
 
@@ -630,7 +649,7 @@ publicRoutes.get('/homepage', async (c) => {
       return res;
     }
 
-    const payload = homepageFromStatusPayload(statusPayload, await historyPreviewsPromise);
+    const payload = homepageFromStatusPayload(statusPayload, await getHistoryPreviews());
     const res = c.json(payload);
     applyHomepageCacheHeaders(res, 0);
 
@@ -655,7 +674,7 @@ publicRoutes.get('/homepage', async (c) => {
     if (staleStatus) {
       const payload = homepageFromStatusPayload(
         toSnapshotPayload(staleStatus.data),
-        await historyPreviewsPromise.catch(() => ({
+        await getHistoryPreviews().catch(() => ({
           resolvedIncidentPreview: null,
           maintenanceHistoryPreview: null,
         })),

--- a/apps/worker/test/pages-homepage-worker.test.ts
+++ b/apps/worker/test/pages-homepage-worker.test.ts
@@ -22,6 +22,18 @@ function installDefaultCacheMock(match: CacheMatcher) {
   return { put };
 }
 
+function setDeployId(value: string | undefined) {
+  if (value === undefined) {
+    delete (globalThis as { __UPTIMER_DEPLOY_ID__?: string }).__UPTIMER_DEPLOY_ID__;
+    return;
+  }
+
+  Object.defineProperty(globalThis, '__UPTIMER_DEPLOY_ID__', {
+    configurable: true,
+    value,
+  });
+}
+
 function makeEnv(indexHtml = '<!doctype html><html><head></head><body><div id="root"></div></body></html>') {
   return {
     ASSETS: {
@@ -34,6 +46,7 @@ function makeEnv(indexHtml = '<!doctype html><html><head></head><body><div id="r
 describe('pages homepage worker', () => {
   const originalCaches = (globalThis as { caches?: unknown }).caches;
   const originalFetch = globalThis.fetch;
+  const originalDeployId = (globalThis as { __UPTIMER_DEPLOY_ID__?: string }).__UPTIMER_DEPLOY_ID__;
 
   afterEach(() => {
     if (originalCaches === undefined) {
@@ -46,6 +59,7 @@ describe('pages homepage worker', () => {
     }
 
     globalThis.fetch = originalFetch;
+    setDeployId(originalDeployId);
     vi.restoreAllMocks();
   });
 
@@ -73,9 +87,16 @@ describe('pages homepage worker', () => {
   });
 
   it('falls back to the cached injected homepage when snapshot fetch fails', async () => {
+    setDeployId('deploy-a');
     installDefaultCacheMock((request) =>
       request.url === 'https://status.example.com/__uptimer_homepage_fallback__'
-        ? new Response('<html>fallback homepage</html>', { status: 200 })
+        ? new Response('<html>fallback homepage</html>', {
+            status: 200,
+            headers: {
+              'x-uptimer-generated-at': '1728000000',
+              'x-uptimer-deploy-id': 'deploy-a',
+            },
+          })
         : undefined,
     );
     const env = makeEnv();
@@ -94,7 +115,161 @@ describe('pages homepage worker', () => {
     expect(await res.text()).toContain('fallback homepage');
   });
 
+  it('serves a recent cached fallback homepage before calling the homepage API', async () => {
+    setDeployId('deploy-a');
+    const { put } = installDefaultCacheMock((request) =>
+      request.url === 'https://status.example.com/__uptimer_homepage_fallback__'
+        ? new Response('<html>fallback homepage</html>', {
+            status: 200,
+            headers: {
+              'Cache-Control': 'public, max-age=600',
+              'x-uptimer-generated-at': '1728000000',
+              'x-uptimer-deploy-id': 'deploy-a',
+            },
+          })
+        : undefined,
+    );
+    const env = makeEnv();
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as never;
+    vi.spyOn(Date, 'now').mockReturnValue(1_728_000_030_000);
+
+    const res = await pageWorker.fetch(
+      new Request('https://status.example.com/', {
+        headers: { Accept: 'text/html' },
+      }),
+      env,
+      { waitUntil: vi.fn() },
+    );
+
+    expect(await res.text()).toContain('fallback homepage');
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, max-age=30, stale-while-revalidate=0, stale-if-error=0',
+    );
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(put).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores stale fallback html and fetches a fresh homepage artifact', async () => {
+    setDeployId('deploy-a');
+    installDefaultCacheMock((request) =>
+      request.url === 'https://status.example.com/__uptimer_homepage_fallback__'
+        ? new Response('<html>fallback homepage</html>', {
+            status: 200,
+            headers: {
+              'Cache-Control': 'public, max-age=600',
+              'x-uptimer-generated-at': '1727999700',
+              'x-uptimer-deploy-id': 'deploy-a',
+            },
+          })
+        : undefined,
+    );
+    const env = makeEnv();
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          generated_at: 1_728_000_000,
+          preload_html: '<div id="uptimer-preload"><main>artifact preload</main></div>',
+          snapshot: { site_title: 'Status Hub' },
+          meta_title: 'Status Hub',
+          meta_description: 'Production',
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+    vi.spyOn(Date, 'now').mockReturnValue(1_728_000_030_000);
+
+    const res = await pageWorker.fetch(
+      new Request('https://status.example.com/', {
+        headers: { Accept: 'text/html' },
+      }),
+      env,
+      { waitUntil: vi.fn((promise) => promise) },
+    );
+
+    expect(await res.text()).toContain('artifact preload');
+    expect(env.ASSETS.fetch).toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalled();
+  });
+
+  it('ignores reusable fallback html from a previous deploy and fetches a fresh homepage artifact', async () => {
+    setDeployId('deploy-b');
+    installDefaultCacheMock((request) =>
+      request.url === 'https://status.example.com/__uptimer_homepage_fallback__'
+        ? new Response('<html>fallback homepage</html>', {
+            status: 200,
+            headers: {
+              'Cache-Control': 'public, max-age=600',
+              'x-uptimer-generated-at': '1728000000',
+              'x-uptimer-deploy-id': 'deploy-a',
+            },
+          })
+        : undefined,
+    );
+    const env = makeEnv();
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          generated_at: 1_728_000_000,
+          preload_html: '<div id="uptimer-preload"><main>artifact preload</main></div>',
+          snapshot: { site_title: 'Status Hub' },
+          meta_title: 'Status Hub',
+          meta_description: 'Production',
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+    vi.spyOn(Date, 'now').mockReturnValue(1_728_000_030_000);
+
+    const res = await pageWorker.fetch(
+      new Request('https://status.example.com/', {
+        headers: { Accept: 'text/html' },
+      }),
+      env,
+      { waitUntil: vi.fn((promise) => promise) },
+    );
+
+    expect(await res.text()).toContain('artifact preload');
+    expect(env.ASSETS.fetch).toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalled();
+  });
+
+  it('returns the current base html when artifact fetch fails and fallback html is from a previous deploy', async () => {
+    setDeployId('deploy-b');
+    installDefaultCacheMock((request) =>
+      request.url === 'https://status.example.com/__uptimer_homepage_fallback__'
+        ? new Response('<html>fallback homepage</html>', {
+            status: 200,
+            headers: {
+              'Cache-Control': 'public, max-age=600',
+              'x-uptimer-generated-at': '1728000000',
+              'x-uptimer-deploy-id': 'deploy-a',
+            },
+          })
+        : undefined,
+    );
+    const env = makeEnv('<!doctype html><html><head></head><body><div id="root">base html</div></body></html>');
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('network failed');
+    }) as never;
+    vi.spyOn(Date, 'now').mockReturnValue(1_728_000_030_000);
+
+    const res = await pageWorker.fetch(
+      new Request('https://status.example.com/', {
+        headers: { Accept: 'text/html' },
+      }),
+      env,
+      { waitUntil: vi.fn() },
+    );
+
+    const html = await res.text();
+    expect(html).toContain('base html');
+    expect(html).not.toContain('fallback homepage');
+  });
+
   it('injects the precomputed homepage artifact and updates both html caches on success', async () => {
+    setDeployId('deploy-a');
     const { put } = installDefaultCacheMock(() => undefined);
     const env = makeEnv();
     globalThis.fetch = vi.fn(async () =>
@@ -122,6 +297,7 @@ describe('pages homepage worker', () => {
     expect(html).toContain('__UPTIMER_INITIAL_HOMEPAGE__');
     expect(html).not.toContain('__UPTIMER_INITIAL_STATUS__');
     expect(html).toContain('artifact preload');
+    expect(html).not.toContain('__UPTIMER_BOOTSTRAP_FALLBACK__');
     expect(put).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -445,6 +445,34 @@ describe('public homepage route', () => {
     });
   });
 
+  it('serves a fresh full artifact snapshot when the raw homepage snapshot is missing', async () => {
+    const payload = samplePayload(190);
+    const render = {
+      generated_at: payload.generated_at,
+      preload_html: '<div id="uptimer-preload">hello</div>',
+      snapshot: payload,
+      meta_title: 'Uptimer',
+      meta_description: 'All Systems Operational',
+    };
+    vi.spyOn(Date, 'now').mockReturnValue(200_000);
+
+    const res = await requestHomepage([
+      {
+        match: 'from public_snapshots',
+        first: (args) =>
+          args[0] === 'homepage:artifact'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify(render),
+              }
+            : null,
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(payload);
+  });
+
   it('returns 503 when no homepage snapshot is available', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(200_000);
 


### PR DESCRIPTION
## What changed
- made Pages homepage fallback reuse deploy-aware so a cold colo cannot serve the previous deploy's HTML shell for up to 2 minutes
- kept the worker-side `/api/v1/public/homepage` fast path that serves a fresh full artifact snapshot when the raw homepage snapshot is missing
- forced fallback bootstraps to do a single immediate background refresh, then return to the existing anti-downgrade guard

## Why
The previous revision of this optimization reused cached fallback HTML before loading the current `index.html`, which could cross deploy boundaries and serve stale Vite asset hashes after a Pages rollout. It also relied on `refetchOnMount: true`, which does not force a refresh for fresh TanStack Query data.

## Impact
- keeps the lower-CPU homepage cold paths while removing the deploy-window HTML mismatch risk
- avoids repeating the same Pages cache miss work by warming the primary cache from a recent same-deploy fallback hit
- preserves UX by showing immediate data and correcting fallback data in the background

## Root cause
Homepage cold-path optimizations were treating fallback freshness as only a function of snapshot time. In practice, the HTML shell also depends on the current frontend build, so reuse has to be scoped to the active deploy.

## Validation
- `pnpm --filter @uptimer/web build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @uptimer/worker exec vitest run --config vitest.config.ts test/pages-homepage-worker.test.ts test/public-homepage-routes.test.ts`
- `pnpm --filter @uptimer/worker bench:homepage`