### PR TITLE
perf(homepage): promote rebuilt payloads into data snapshots

### DIFF
--- a/apps/worker/src/routes/admin-settings.ts
+++ b/apps/worker/src/routes/admin-settings.ts
@@ -15,6 +15,7 @@ function queuePublicHomepageSnapshotRefresh(c: { env: Env; executionCtx: Executi
       db: c.env.DB,
       now,
       compute: () => computePublicHomepagePayload(c.env.DB, Math.floor(Date.now() / 1000)),
+      force: true,
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     }),

--- a/apps/worker/src/routes/admin.ts
+++ b/apps/worker/src/routes/admin.ts
@@ -84,6 +84,7 @@ function queuePublicHomepageSnapshotRefresh(c: { env: Env; executionCtx: Executi
       db: c.env.DB,
       now,
       compute: () => computePublicHomepagePayload(c.env.DB, Math.floor(Date.now() / 1000)),
+      force: true,
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     }),

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -30,6 +30,7 @@ import {
   readStaleHomepageSnapshotArtifact,
   readStaleHomepageSnapshotArtifactJson,
   toSnapshotPayload,
+  writeHomepageDataSnapshot,
   writeStatusSnapshot,
 } from '../snapshots';
 
@@ -613,6 +614,13 @@ publicRoutes.get('/homepage', async (c) => {
     );
     const res = c.json(payload);
     applyHomepageCacheHeaders(res, statusSnapshot.age);
+
+    c.executionCtx.waitUntil(
+      writeHomepageDataSnapshot(c.env.DB, now, payload).catch((err) => {
+        console.warn('homepage snapshot: write failed', err);
+      }),
+    );
+
     return res;
   }
 
@@ -635,9 +643,14 @@ publicRoutes.get('/homepage', async (c) => {
     applyHomepageCacheHeaders(res, 0);
 
     c.executionCtx.waitUntil(
-      writeStatusSnapshot(c.env.DB, now, statusPayload).catch((err) => {
-        console.warn('public snapshot: write failed', err);
-      }),
+      Promise.all([
+        writeStatusSnapshot(c.env.DB, now, statusPayload).catch((err) => {
+          console.warn('public snapshot: write failed', err);
+        }),
+        writeHomepageDataSnapshot(c.env.DB, now, payload).catch((err) => {
+          console.warn('homepage snapshot: write failed', err);
+        }),
+      ]).then(() => undefined),
     );
 
     return res;

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -720,6 +720,33 @@ function homepageSnapshotUpsertStatement(
     .bind(key, generatedAt, bodyJson, now);
 }
 
+function homepageSnapshotPromoteStatement(
+  db: D1Database,
+  key: string,
+  generatedAt: number,
+  bodyJson: string,
+  now: number,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `
+      INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
+      VALUES (?1, ?2, ?3, ?4)
+      ON CONFLICT(key) DO UPDATE SET
+        generated_at = excluded.generated_at,
+        body_json = excluded.body_json,
+        updated_at = excluded.updated_at
+      WHERE
+        public_snapshots.generated_at < excluded.generated_at
+        OR (
+          public_snapshots.generated_at = excluded.generated_at
+          AND public_snapshots.body_json <> excluded.body_json
+        )
+    `,
+    )
+    .bind(key, generatedAt, bodyJson, now);
+}
+
 export async function writeHomepageSnapshot(
   db: D1Database,
   now: number,
@@ -739,6 +766,22 @@ export async function writeHomepageSnapshot(
       now,
     ),
   ]);
+}
+
+export async function writeHomepageDataSnapshot(
+  db: D1Database,
+  now: number,
+  payload: PublicHomepageResponse,
+): Promise<void> {
+  const dataBodyJson = JSON.stringify(payload);
+
+  await homepageSnapshotPromoteStatement(
+    db,
+    SNAPSHOT_KEY,
+    payload.generated_at,
+    dataBodyJson,
+    now,
+  ).run();
 }
 
 export async function writeHomepageArtifactSnapshot(
@@ -799,9 +842,11 @@ export async function refreshPublicHomepageSnapshotIfNeeded(opts: {
   db: D1Database;
   now: number;
   compute: () => Promise<unknown>;
+  force?: boolean;
 }): Promise<boolean> {
+  const force = opts.force ?? false;
   const generatedAt = await readHomepageSnapshotGeneratedAt(opts.db);
-  if (generatedAt !== null && isSameMinute(generatedAt, opts.now)) {
+  if (!force && generatedAt !== null && isSameMinute(generatedAt, opts.now)) {
     return false;
   }
 
@@ -811,7 +856,7 @@ export async function refreshPublicHomepageSnapshotIfNeeded(opts: {
   }
 
   const latestGeneratedAt = await readHomepageSnapshotGeneratedAt(opts.db);
-  if (latestGeneratedAt !== null && isSameMinute(latestGeneratedAt, opts.now)) {
+  if (!force && latestGeneratedAt !== null && isSameMinute(latestGeneratedAt, opts.now)) {
     return false;
   }
 

--- a/apps/worker/test/admin-settings-homepage-refresh.test.ts
+++ b/apps/worker/test/admin-settings-homepage-refresh.test.ts
@@ -72,5 +72,11 @@ describe('admin settings homepage snapshot refresh', () => {
     expect(waitUntil).toHaveBeenCalledTimes(1);
     await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
     expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
+      db: env.DB,
+      now: expect.any(Number),
+      compute: expect.any(Function),
+      force: true,
+    });
   });
 });

--- a/apps/worker/test/public-homepage-downgrade-guard.test.ts
+++ b/apps/worker/test/public-homepage-downgrade-guard.test.ts
@@ -197,7 +197,7 @@ describe('public homepage downgrade guard', () => {
 
   it('still upgrades to computed homepage data when the live status payload is healthy', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(260_000);
-    let statusSnapshotWrites = 0;
+    const snapshotWrites: string[] = [];
     computePublicStatusPayload.mockResolvedValue({
       generated_at: 260,
       site_title: 'Status Hub',
@@ -242,8 +242,8 @@ describe('public homepage downgrade guard', () => {
       },
       {
         match: 'insert into public_snapshots',
-        run: () => {
-          statusSnapshotWrites += 1;
+        run: (args) => {
+          snapshotWrites.push(String(args[0]));
           return 1;
         },
       },
@@ -270,6 +270,6 @@ describe('public homepage downgrade guard', () => {
       },
     });
     expect(computePublicStatusPayload).toHaveBeenCalledOnce();
-    expect(statusSnapshotWrites).toBe(1);
+    expect(snapshotWrites).toEqual(['status', 'homepage']);
   });
 });

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -34,6 +34,10 @@ function installCacheMock(store: CacheStore) {
 }
 
 async function requestHomepage(handlers: FakeD1QueryHandler[]) {
+  return requestHomepageWithWaitUntil(handlers).then(({ response }) => response);
+}
+
+async function requestHomepageWithWaitUntil(handlers: FakeD1QueryHandler[]) {
   const env = {
     DB: createFakeD1Database(handlers),
     ADMIN_TOKEN: 'test-admin-token',
@@ -44,11 +48,14 @@ async function requestHomepage(handlers: FakeD1QueryHandler[]) {
   app.notFound(handleNotFound);
   app.route('/api/v1/public', publicRoutes);
 
-  return app.fetch(
+  const waitUntil = vi.fn();
+  const response = await app.fetch(
     new Request('https://status.example.com/api/v1/public/homepage'),
     env,
-    { waitUntil: vi.fn() } as unknown as ExecutionContext,
+    { waitUntil } as unknown as ExecutionContext,
   );
+
+  return { response, waitUntil };
 }
 
 async function requestHomepageArtifact(handlers: FakeD1QueryHandler[]) {
@@ -344,8 +351,9 @@ describe('public homepage route', () => {
   it('falls back to the fresh public status snapshot when the full homepage snapshot is missing', async () => {
     const now = 200;
     vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+    const snapshotWrites: Array<{ key: unknown; generatedAt: unknown }> = [];
 
-    const res = await requestHomepage([
+    const { response: res, waitUntil } = await requestHomepageWithWaitUntil([
       {
         match: 'from public_snapshots',
         first: (args) =>
@@ -425,6 +433,13 @@ describe('public homepage route', () => {
         match: 'from maintenance_windows',
         all: () => [],
       },
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          snapshotWrites.push({ key: args[0], generatedAt: args[1] });
+          return { meta: { changes: 1 } };
+        },
+      },
     ]);
 
     expect(res.status).toBe(200);
@@ -443,6 +458,9 @@ describe('public homepage route', () => {
         },
       ],
     });
+    expect(waitUntil.mock.calls.length).toBeGreaterThanOrEqual(1);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+    expect(snapshotWrites).toEqual([{ key: 'homepage', generatedAt: 190 }]);
   });
 
   it('returns 503 when no homepage snapshot is available', async () => {

--- a/apps/worker/test/snapshots-public-homepage.test.ts
+++ b/apps/worker/test/snapshots-public-homepage.test.ts
@@ -18,6 +18,7 @@ import {
   readStaleHomepageSnapshotArtifact,
   refreshPublicHomepageSnapshotIfNeeded,
   toHomepageSnapshotPayload,
+  writeHomepageDataSnapshot,
   writeHomepageArtifactSnapshot,
   writeHomepageSnapshot,
 } from '../src/snapshots/public-homepage';
@@ -272,6 +273,28 @@ describe('snapshots/public-homepage', () => {
     ]);
   });
 
+  it('writes data-only homepage snapshots without rebuilding the artifact row', async () => {
+    const boundArgs: unknown[][] = [];
+    let normalizedSql = '';
+    const db = createFakeD1Database([
+      {
+        match: 'insert into public_snapshots',
+        run: (args, sql) => {
+          boundArgs.push(args);
+          normalizedSql = sql;
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    const payload = samplePayload(280);
+    await writeHomepageDataSnapshot(db, 300, payload);
+
+    expect(boundArgs).toEqual([['homepage', 280, JSON.stringify(payload), 300]]);
+    expect(normalizedSql).toContain('public_snapshots.generated_at < excluded.generated_at');
+    expect(normalizedSql).toContain('public_snapshots.body_json <> excluded.body_json');
+  });
+
   it('applies bounded cache headers for homepage payloads', () => {
     const fresh = new Response('ok');
     applyHomepageCacheHeaders(fresh, 10);
@@ -358,6 +381,53 @@ describe('snapshots/public-homepage', () => {
     expect(writtenArgs).toEqual([
       ['homepage', now, JSON.stringify(storedData), now],
       ['homepage:artifact', now, JSON.stringify(storedRender), now],
+    ]);
+  });
+
+  it('forces a refresh within the same minute while still using the refresh lease', async () => {
+    vi.mocked(acquireLease).mockResolvedValue(true);
+
+    let readCount = 0;
+    const writtenArgs: unknown[][] = [];
+    const now = 1_728_000_045;
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: (args) => {
+          if (args[0] !== 'homepage') {
+            return null;
+          }
+          readCount += 1;
+          if (readCount <= 2) {
+            return {
+              generated_at: 1_728_000_031,
+              body_json: JSON.stringify(samplePayload(1_728_000_031)),
+            };
+          }
+          return {
+            generated_at: now,
+            body_json: JSON.stringify(samplePayload(now)),
+          };
+        },
+      },
+      {
+        match: 'insert into public_snapshots',
+        run: (args) => {
+          writtenArgs.push(args);
+          return { meta: { changes: 1 } };
+        },
+      },
+    ]);
+
+    const compute = vi.fn(async () => samplePayload(now));
+    const refreshed = await refreshPublicHomepageSnapshotIfNeeded({ db, now, compute, force: true });
+
+    expect(refreshed).toBe(true);
+    expect(acquireLease).toHaveBeenCalledWith(db, 'snapshot:homepage:refresh', now, 55);
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(writtenArgs).toEqual([
+      ['homepage', now, JSON.stringify(samplePayload(now)), now],
+      ['homepage:artifact', now, JSON.stringify(buildHomepageRenderArtifact(samplePayload(now))), now],
     ]);
   });
 


### PR DESCRIPTION
## What
- Promote rebuilt full homepage payloads into the `homepage` data snapshot when `/api/v1/public/homepage` already has to assemble them from a fresh `status` snapshot or live status compute.
- Keep admin-triggered homepage refreshes on the lease-protected refresh path, but allow them to bypass only the same-minute short-circuit via `force: true`.
- Add regression coverage for monotonic homepage snapshot promotion, downgrade-guard writes, and forced admin refresh behavior.

## Why
- Reduce repeat homepage hot-path coordination without degrading homepage UX or falling back to request-time live loading.
- Avoid stale snapshot writeback and avoid the no-lease admin refresh thrash that showed up during adversarial review.
- Preserve the scheduler artifact-refresh path close to baseline while still letting homepage requests promote already-built full payloads into the cheapest read path.

## Where
- `apps/worker/src/routes/public.ts`
- `apps/worker/src/snapshots/public-homepage.ts`
- `apps/worker/src/routes/admin.ts`
- `apps/worker/src/routes/admin-settings.ts`
- `apps/worker/test/public-homepage-routes.test.ts`
- `apps/worker/test/public-homepage-downgrade-guard.test.ts`
- `apps/worker/test/snapshots-public-homepage.test.ts`
- `apps/worker/test/admin-settings-homepage-refresh.test.ts`

## How to verify
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @uptimer/worker bench:homepage`
- `pnpm --filter @uptimer/worker bench:scheduler`

## Notes
- Local `bench:homepage` remains noisy, so the meaningful success criterion is still deployed Cloudflare Workers CPU on the real homepage path.
- Final local `bench:scheduler` comparison was roughly flat to slightly negative versus the baseline (`-0.6%`, `-2.7%`, `-1.5%` across the three scenarios), which is acceptable here because the scheduler hot path was not the target and no new scheduler-specific coordination layer was added.
