### PR TITLE
perf(homepage): cut hot-path coordination CPU

### DIFF
--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -1,6 +1,7 @@
 const SNAPSHOT_MAX_AGE_SECONDS = 60;
 const PREFERRED_MAX_AGE_SECONDS = 30;
 const FALLBACK_HTML_MAX_AGE_SECONDS = 600;
+const HOMEPAGE_CACHE_GENERATED_AT_HEADER = 'X-Uptimer-Generated-At';
 
 function acceptsHtml(request) {
   const accept = request.headers.get('Accept') || '';
@@ -18,6 +19,13 @@ function escapeHtml(value) {
 
 function safeJsonForInlineScript(value) {
   return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function readGeneratedAtHeader(res) {
+  const raw = res.headers.get(HOMEPAGE_CACHE_GENERATED_AT_HEADER);
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function normalizeSnapshotText(value, fallback) {
@@ -221,21 +229,29 @@ export default {
     const isStatusPage = url.pathname === '/' || url.pathname === '/index.html';
     if (wantsHtml && isStatusPage) {
       const cacheKey = new Request(url.origin + '/', { method: 'GET' });
-      const fallbackCacheKey = new Request(url.origin + '/__uptimer_homepage_fallback__', {
-        method: 'GET',
-      });
       const cached = await caches.default.match(cacheKey);
-      if (cached) return cached;
+      const now = Math.floor(Date.now() / 1000);
+      if (cached) {
+        const cachedGeneratedAt = readGeneratedAtHeader(cached);
+        if (cachedGeneratedAt === null) {
+          return cached;
+        }
+
+        const cachedAge = Math.max(0, now - cachedGeneratedAt);
+        if (cachedAge <= SNAPSHOT_MAX_AGE_SECONDS) {
+          const hit = cached.clone();
+          hit.headers.set('Cache-Control', computeCacheControl(cachedAge));
+          hit.headers.delete(HOMEPAGE_CACHE_GENERATED_AT_HEADER);
+          return hit;
+        }
+      }
 
       const base = await fetchIndexHtml(env, url);
       const html = await base.text();
 
       const artifact = await fetchPublicHomepageArtifact(env);
       if (!artifact) {
-        const fallback = await caches.default.match(fallbackCacheKey);
-        if (fallback) {
-          return fallback;
-        }
+        if (cached) return cached;
 
         const headers = new Headers(base.headers);
         headers.set('Content-Type', 'text/html; charset=utf-8');
@@ -245,7 +261,6 @@ export default {
         return new Response(html, { status: 200, headers });
       }
 
-      const now = Math.floor(Date.now() / 1000);
       const generatedAt = typeof artifact.generated_at === 'number' ? artifact.generated_at : now;
       const age = Math.max(0, now - generatedAt);
 
@@ -269,16 +284,12 @@ export default {
 
       const resp = new Response(injected, { status: 200, headers });
 
-      const fallbackHeaders = new Headers(headers);
-      fallbackHeaders.set('Cache-Control', `public, max-age=${FALLBACK_HTML_MAX_AGE_SECONDS}`);
-      const fallbackResp = new Response(injected, { status: 200, headers: fallbackHeaders });
+      const cacheHeaders = new Headers(headers);
+      cacheHeaders.set('Cache-Control', `public, max-age=${FALLBACK_HTML_MAX_AGE_SECONDS}`);
+      cacheHeaders.set(HOMEPAGE_CACHE_GENERATED_AT_HEADER, `${generatedAt}`);
+      const cacheResp = new Response(injected, { status: 200, headers: cacheHeaders });
 
-      ctx.waitUntil(
-        Promise.all([
-          caches.default.put(cacheKey, resp.clone()),
-          caches.default.put(fallbackCacheKey, fallbackResp),
-        ]),
-      );
+      ctx.waitUntil(caches.default.put(cacheKey, cacheResp));
       return resp;
     }
 

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -26,6 +26,7 @@ import {
   readHomepageSnapshotArtifactJson,
   readHomepageSnapshotJson,
   readStatusSnapshot,
+  readStatusSnapshotJson,
   readStaleHomepageSnapshot,
   readStaleHomepageSnapshotArtifact,
   readStaleHomepageSnapshotArtifactJson,
@@ -540,24 +541,11 @@ publicRoutes.get('/status', async (c) => {
     return applyPrivateNoStore(c.json(payload));
   }
 
-  const snapshot = await readStatusSnapshot(c.env.DB, now);
+  const snapshot = await readStatusSnapshotJson(c.env.DB, now);
   if (snapshot) {
-    const res = c.json(snapshot.data);
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(snapshot.bodyJson);
     applyStatusCacheHeaders(res, snapshot.age);
-
-    // If we're close to the freshness boundary, trigger a background refresh.
-    if (snapshot.age >= 30) {
-      c.executionCtx.waitUntil(
-        (async () => {
-          const refreshedAt = Math.floor(Date.now() / 1000);
-          const payload = await computePublicStatusPayload(c.env.DB, refreshedAt);
-          await writeStatusSnapshot(c.env.DB, refreshedAt, payload);
-        })().catch((err) => {
-          console.warn('public snapshot: refresh failed', err);
-        }),
-      );
-    }
-
     return res;
   }
   try {

--- a/apps/worker/src/snapshots/public-status.ts
+++ b/apps/worker/src/snapshots/public-status.ts
@@ -48,8 +48,57 @@ function looksLikeSerializedStatusPayload(text: string): boolean {
     trimmed.includes('"site_title"') &&
     trimmed.includes('"overall_status"') &&
     trimmed.includes('"monitors"') &&
-    trimmed.includes('"summary"')
+    trimmed.includes('"summary"') &&
+    trimmed.includes('"maintenance_windows"')
   );
+}
+
+function looksLikeCompleteJsonObject(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < 2) return false;
+  if (trimmed[0] !== '{' || trimmed[trimmed.length - 1] !== '}') return false;
+
+  const stack: ('{' | '[')[] = [];
+  let inString = false;
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const ch = trimmed[index] as string;
+
+    if (inString) {
+      if (ch === '\\') {
+        index += 1;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (ch === '{' || ch === '[') {
+      stack.push(ch as '{' | '[');
+      continue;
+    }
+
+    if (ch === '}' || ch === ']') {
+      const open = stack.pop();
+      if (!open) return false;
+      if (ch === '}' && open !== '{') return false;
+      if (ch === ']' && open !== '[') return false;
+
+      // The root object must end at the end of the string.
+      if (stack.length === 0 && index !== trimmed.length - 1) {
+        return false;
+      }
+    }
+  }
+
+  return !inString && stack.length === 0;
 }
 
 export async function readStatusSnapshot(
@@ -109,13 +158,16 @@ export async function readStatusSnapshotJson(
     const age = Math.max(0, now - row.generated_at);
     if (age > MAX_AGE_SECONDS) return null;
 
-    if (looksLikeSerializedStatusPayload(row.body_json)) {
+    if (
+      looksLikeSerializedStatusPayload(row.body_json) &&
+      looksLikeCompleteJsonObject(row.body_json)
+    ) {
       return { bodyJson: row.body_json, age };
     }
 
     const parsed = safeJsonParse(row.body_json);
     if (looksLikeStatusPayload(parsed)) {
-      return { bodyJson: JSON.stringify(parsed), age };
+      return { bodyJson: row.body_json, age };
     }
 
     const data = publicStatusResponseSchema.parse(parsed);

--- a/apps/worker/src/snapshots/public-status.ts
+++ b/apps/worker/src/snapshots/public-status.ts
@@ -22,6 +22,36 @@ function safeJsonParse(text: string): unknown | null {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function looksLikeStatusPayload(value: unknown): value is PublicStatusResponse {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.generated_at === 'number' &&
+    typeof value.site_title === 'string' &&
+    typeof value.overall_status === 'string' &&
+    Array.isArray(value.monitors) &&
+    Array.isArray(value.active_incidents) &&
+    isRecord(value.banner) &&
+    isRecord(value.summary) &&
+    isRecord(value.maintenance_windows)
+  );
+}
+
+function looksLikeSerializedStatusPayload(text: string): boolean {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith('{"generated_at":') &&
+    trimmed.includes('"site_title"') &&
+    trimmed.includes('"overall_status"') &&
+    trimmed.includes('"monitors"') &&
+    trimmed.includes('"summary"')
+  );
+}
+
 export async function readStatusSnapshot(
   db: D1Database,
   now: number,
@@ -44,11 +74,53 @@ export async function readStatusSnapshot(
     if (age > MAX_AGE_SECONDS) return null;
 
     const parsed = safeJsonParse(row.body_json);
+    if (looksLikeStatusPayload(parsed)) {
+      return { data: parsed, age };
+    }
+
     const data = publicStatusResponseSchema.parse(parsed);
     return { data, age };
   } catch (err) {
     // Backward compatible: if the table doesn't exist yet or snapshot is invalid,
     // callers should fall back to live computation.
+    console.warn('public snapshot: read failed, falling back to live', err);
+    return null;
+  }
+}
+
+export async function readStatusSnapshotJson(
+  db: D1Database,
+  now: number,
+): Promise<{ bodyJson: string; age: number } | null> {
+  try {
+    const row = await db
+      .prepare(
+        `
+        SELECT generated_at, body_json
+        FROM public_snapshots
+        WHERE key = ?1
+      `,
+      )
+      .bind(SNAPSHOT_KEY)
+      .first<{ generated_at: number; body_json: string }>();
+
+    if (!row) return null;
+
+    const age = Math.max(0, now - row.generated_at);
+    if (age > MAX_AGE_SECONDS) return null;
+
+    if (looksLikeSerializedStatusPayload(row.body_json)) {
+      return { bodyJson: row.body_json, age };
+    }
+
+    const parsed = safeJsonParse(row.body_json);
+    if (looksLikeStatusPayload(parsed)) {
+      return { bodyJson: JSON.stringify(parsed), age };
+    }
+
+    const data = publicStatusResponseSchema.parse(parsed);
+    return { bodyJson: JSON.stringify(data), age };
+  } catch (err) {
     console.warn('public snapshot: read failed, falling back to live', err);
     return null;
   }

--- a/apps/worker/test/pages-homepage-worker.test.ts
+++ b/apps/worker/test/pages-homepage-worker.test.ts
@@ -72,6 +72,49 @@ describe('pages homepage worker', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('recomputes cache-control on cache hit with generated-at header', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-17T00:01:00.000Z'));
+
+    try {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const generatedAt = nowSec - 10;
+
+      installDefaultCacheMock((request) =>
+        request.url === 'https://status.example.com/'
+          ? new Response('<html>cached homepage</html>', {
+              status: 200,
+              headers: {
+                'X-Uptimer-Generated-At': String(generatedAt),
+                'Cache-Control': 'public, max-age=600',
+              },
+            })
+          : undefined,
+      );
+      const env = makeEnv();
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as never;
+
+      const res = await pageWorker.fetch(
+        new Request('https://status.example.com/', {
+          headers: { Accept: 'text/html' },
+        }),
+        env,
+        { waitUntil: vi.fn() },
+      );
+
+      expect(await res.text()).toContain('cached homepage');
+      expect(res.headers.get('X-Uptimer-Generated-At')).toBeNull();
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, max-age=30, stale-while-revalidate=20, stale-if-error=20',
+      );
+      expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('falls back to the cached injected homepage when snapshot fetch fails', async () => {
     installDefaultCacheMock((request) =>
       request.url === 'https://status.example.com/'

--- a/apps/worker/test/pages-homepage-worker.test.ts
+++ b/apps/worker/test/pages-homepage-worker.test.ts
@@ -74,8 +74,11 @@ describe('pages homepage worker', () => {
 
   it('falls back to the cached injected homepage when snapshot fetch fails', async () => {
     installDefaultCacheMock((request) =>
-      request.url === 'https://status.example.com/__uptimer_homepage_fallback__'
-        ? new Response('<html>fallback homepage</html>', { status: 200 })
+      request.url === 'https://status.example.com/'
+        ? new Response('<html>fallback homepage</html>', {
+            status: 200,
+            headers: { 'X-Uptimer-Generated-At': '0' },
+          })
         : undefined,
     );
     const env = makeEnv();
@@ -94,7 +97,7 @@ describe('pages homepage worker', () => {
     expect(await res.text()).toContain('fallback homepage');
   });
 
-  it('injects the precomputed homepage artifact and updates both html caches on success', async () => {
+  it('injects the precomputed homepage artifact and updates the html cache on success', async () => {
     const { put } = installDefaultCacheMock(() => undefined);
     const env = makeEnv();
     globalThis.fetch = vi.fn(async () =>
@@ -122,6 +125,6 @@ describe('pages homepage worker', () => {
     expect(html).toContain('__UPTIMER_INITIAL_HOMEPAGE__');
     expect(html).not.toContain('__UPTIMER_INITIAL_STATUS__');
     expect(html).toContain('artifact preload');
-    expect(put).toHaveBeenCalledTimes(2);
+    expect(put).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/worker/test/snapshots-public-status.test.ts
+++ b/apps/worker/test/snapshots-public-status.test.ts
@@ -6,6 +6,7 @@ import {
   getSnapshotKey,
   getSnapshotMaxAgeSeconds,
   readStatusSnapshot,
+  readStatusSnapshotJson,
   toSnapshotPayload,
   writeStatusSnapshot,
 } from '../src/snapshots/public-status';
@@ -88,6 +89,47 @@ describe('snapshots/public-status', () => {
     await expect(readStatusSnapshot(invalidJsonDb, 200)).resolves.toBeNull();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  it('serves the raw snapshot JSON when it looks complete', async () => {
+    const now = 200;
+    const payload = samplePayload(190);
+    const bodyJson = JSON.stringify(payload);
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: () => ({
+          generated_at: payload.generated_at,
+          body_json: bodyJson,
+        }),
+      },
+    ]);
+
+    await expect(readStatusSnapshotJson(db, now)).resolves.toEqual({
+      bodyJson,
+      age: 10,
+    });
+  });
+
+  it('rejects truncated snapshot JSON even if it matches the fast-path heuristic', async () => {
+    const now = 200;
+    const payload = samplePayload(190);
+    const bodyJson = JSON.stringify(payload);
+    const truncated = bodyJson.slice(0, -1);
+    expect(truncated.startsWith('{"generated_at":')).toBe(true);
+    expect(truncated.includes('"site_title"')).toBe(true);
+
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: () => ({
+          generated_at: payload.generated_at,
+          body_json: truncated,
+        }),
+      },
+    ]);
+
+    await expect(readStatusSnapshotJson(db, now)).resolves.toBeNull();
   });
 
   it('writes the normalized snapshot payload with upsert semantics', async () => {


### PR DESCRIPTION
**What**
- Pages Worker: HTML 注入缓存只维护 1 份（`/`），用 `X-Uptimer-Generated-At` 在命中时计算 age 并动态回写 `Cache-Control`；同时减少每次刷新时的 `caches.default.put` 次数并保留 API 失败时回退到旧 HTML。 
- Worker: `/api/v1/public/status` 命中 `public_snapshots.status` 时直接回传原始 JSON（不再 `JSON.parse + Zod.parse + JSON.stringify`），并移除命中时 `age>=30` 的热路径后台 refresh。

**Why**
- 目标是压低真实线上首页链路 P50 CPU：减少 Pages 热路径的 cache 协调/写入成本；减少 Worker 热路径的 JSON/Zod 解析与再序列化成本；避免在高频命中路径触发额外后台计算。

**Where**
- `apps/web/public/_worker.js`
- `apps/worker/src/snapshots/public-status.ts`
- `apps/worker/src/routes/public.ts`
- `apps/worker/test/pages-homepage-worker.test.ts`

**How to verify**
- 本地：`pnpm lint && pnpm typecheck && pnpm test`；`pnpm --filter @uptimer/worker bench:homepage`
- 线上：关注 Pages Worker `/`（HTML）与 Worker `/api/v1/public/status` 的 Workers Metrics CPU P50（并确认首屏注入数据与 API 失败回退仍正常）

Commits: d1594ad, 2631255
