### PR TITLE
perf(worker): make homepage CPU deterministic

### DIFF
--- a/apps/worker/src/middleware/cache-public.ts
+++ b/apps/worker/src/middleware/cache-public.ts
@@ -19,11 +19,24 @@ function buildCacheKey(url: string, origin: string | undefined): Request {
 // public endpoints can return admin-only payloads when a valid bearer token is present.
 // If a handler already set Cache-Control, we respect it (do not override).
 // This allows endpoints like `/public/status` to precisely control freshness (<= 60s).
-export function cachePublic(opts: { cacheName: string; maxAgeSeconds: number }): MiddlewareHandler {
+export function cachePublic(opts: {
+  cacheName: string;
+  maxAgeSeconds: number;
+  skipPathnames?: readonly string[];
+}): MiddlewareHandler {
   return async (c, next) => {
     if (c.req.method !== 'GET' || hasAuthorizationHeader(c.req)) {
       await next();
       return;
+    }
+
+    const skipPathnames = opts.skipPathnames ?? [];
+    if (skipPathnames.length > 0) {
+      const pathname = new URL(c.req.url).pathname;
+      if (skipPathnames.includes(pathname)) {
+        await next();
+        return;
+      }
     }
 
     const cache = await caches.open(opts.cacheName);

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -28,6 +28,7 @@ import {
   readStatusSnapshot,
   readStatusSnapshotJson,
   readStaleHomepageSnapshot,
+  readStaleHomepageSnapshotJson,
   readStaleHomepageSnapshotArtifact,
   readStaleHomepageSnapshotArtifactJson,
   toSnapshotPayload,
@@ -156,7 +157,16 @@ async function readStaleStatusSnapshot(
 export const publicRoutes = new Hono<{ Bindings: Env }>();
 
 // Cache public endpoints at the edge to improve performance on slow networks.
-publicRoutes.use('*', cachePublic({ cacheName: 'uptimer-public', maxAgeSeconds: 30 }));
+publicRoutes.use(
+  '*',
+  cachePublic({
+    cacheName: 'uptimer-public',
+    maxAgeSeconds: 30,
+    // Homepage payloads can be large; caching them via Cache API can add CPU due to body cloning.
+    // Prefer serving the precomputed D1 snapshot directly.
+    skipPathnames: ['/api/v1/public/homepage'],
+  }),
+);
 
 const latencyRangeSchema = z.enum(['24h']);
 const uptimeRangeSchema = z.enum(['24h', '7d', '30d']);
@@ -583,6 +593,16 @@ publicRoutes.get('/homepage', async (c) => {
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
+    return res;
+  }
+
+  // If the full homepage snapshot is stale, prefer serving it over recomputing in the hot path.
+  // This keeps the request CPU deterministic (compute happens via scheduled/admin refresh).
+  const stale = await readStaleHomepageSnapshotJson(c.env.DB, now);
+  if (stale) {
+    c.header('Content-Type', 'application/json; charset=utf-8');
+    const res = c.body(stale.bodyJson);
+    applyHomepageCacheHeaders(res, Math.min(60, stale.age));
     return res;
   }
 

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -21,8 +21,8 @@ import {
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
-import { computePublicHomepageArtifactPayload } from '../public/homepage';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../snapshots';
+import { computePublicHomepagePayload } from '../public/homepage';
+import { refreshPublicHomepageSnapshotIfNeeded } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -592,10 +592,10 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
   const queueHomepageRefresh = () =>
-    refreshPublicHomepageArtifactSnapshotIfNeeded({
+    refreshPublicHomepageSnapshotIfNeeded({
       db: env.DB,
       now,
-      compute: () => computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
+      compute: () => computePublicHomepagePayload(env.DB, Math.floor(Date.now() / 1000)),
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     });

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -278,8 +278,15 @@ describe('public homepage route', () => {
     expect(res.headers.get('Vary')).toContain('Origin');
   });
 
-  it('partitions cached homepage responses by Origin when app-level CORS reflection is enabled', async () => {
+  it('partitions cached homepage artifact responses by Origin when app-level CORS reflection is enabled', async () => {
     const payload = samplePayload(190);
+    const render = {
+      generated_at: payload.generated_at,
+      preload_html: '<div id="uptimer-preload">hello</div>',
+      snapshot: payload,
+      meta_title: 'Uptimer',
+      meta_description: 'All Systems Operational',
+    };
     const dbReads: string[] = [];
     vi.spyOn(Date, 'now').mockReturnValue(200_000);
 
@@ -288,10 +295,10 @@ describe('public homepage route', () => {
         match: 'from public_snapshots',
         first: (args) => {
           dbReads.push(String(args[0]));
-          return args[0] === 'homepage'
+          return args[0] === 'homepage:artifact'
             ? {
                 generated_at: payload.generated_at,
-                body_json: JSON.stringify(payload),
+                body_json: JSON.stringify(render),
               }
             : null;
         },
@@ -299,17 +306,17 @@ describe('public homepage route', () => {
     ];
 
     const first = await requestHomepageViaApp(
-      '/api/v1/public/homepage',
+      '/api/v1/public/homepage-artifact',
       handlers,
       'https://one.example.com',
     );
     const second = await requestHomepageViaApp(
-      '/api/v1/public/homepage',
+      '/api/v1/public/homepage-artifact',
       handlers,
       'https://two.example.com',
     );
     const third = await requestHomepageViaApp(
-      '/api/v1/public/homepage',
+      '/api/v1/public/homepage-artifact',
       handlers,
       'https://one.example.com',
     );
@@ -317,7 +324,7 @@ describe('public homepage route', () => {
     expect(first.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
     expect(second.headers.get('Access-Control-Allow-Origin')).toBe('https://two.example.com');
     expect(third.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
-    expect(dbReads).toEqual(['homepage', 'homepage']);
+    expect(dbReads).toEqual(['homepage:artifact', 'homepage:artifact']);
   });
 
   it('serves a bounded stale homepage snapshot instead of computing in-request', async () => {

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -16,20 +16,20 @@ vi.mock('../src/notify/webhook', () => ({
   dispatchWebhookToChannels: vi.fn(),
 }));
 vi.mock('../src/public/homepage', () => ({
-  computePublicHomepageArtifactPayload: vi.fn(),
+  computePublicHomepagePayload: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
-  refreshPublicHomepageArtifactSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { runHttpCheck } from '../src/monitor/http';
 import { runTcpCheck } from '../src/monitor/tcp';
 import { dispatchWebhookToChannels } from '../src/notify/webhook';
-import { computePublicHomepageArtifactPayload } from '../src/public/homepage';
+import { computePublicHomepagePayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../src/snapshots';
+import { refreshPublicHomepageSnapshotIfNeeded } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -137,10 +137,10 @@ describe('scheduler/scheduled regression', () => {
       uptime_rating_level: 3,
     });
     vi.mocked(dispatchWebhookToChannels).mockResolvedValue(undefined);
-    vi.mocked(computePublicHomepageArtifactPayload).mockResolvedValue({
+    vi.mocked(computePublicHomepagePayload).mockResolvedValue({
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
-    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -183,20 +183,20 @@ describe('scheduler/scheduled regression', () => {
 
     expect(acquireLease).toHaveBeenCalledWith(env.DB, 'scheduler:tick', expectedNow, 55);
     expect(readSettings).toHaveBeenCalledTimes(1);
-    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledWith({
+    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
       compute: expect.any(Function),
     });
-    const refreshArgs = vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mock.calls[0]?.[0];
+    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
-    expect(computePublicHomepageArtifactPayload).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {
-    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockRejectedValueOnce(
+    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockRejectedValueOnce(
       new Error('snapshot refresh failed'),
     );
 
@@ -289,7 +289,7 @@ describe('scheduler/scheduled regression', () => {
     expect(runArgs[stateUpsertIndex]?.[1]).toBe('up');
     expect(runArgs[stateUpsertIndex]?.[2]).toBe(expectedCheckedAt);
 
-    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Context\nWorker CPU P50 still ~27.7ms. The hottest path is typically \/api\/v1\/public\/homepage; when the full homepage snapshot is stale/missing it can fall back to in-request compute, and Cache API writes can add extra CPU (clone+put).\n\n### What\n- \/public\/homepage: prefer bounded stale full snapshot over in-request recompute; still respects fresh snapshot fast path (no JSON.parse/Zod on hit).\n- cachePublic: add `skipPathnames` and skip Cache API for \/api\/v1\/public\/homepage to avoid clone+put CPU tax on low-traffic colos.\n- scheduled tick: refresh the full homepage snapshot (writes both `homepage` + `homepage:artifact`) each minute via the existing lease guard, so request traffic stays on the cheap snapshot-read path.\n\n### Why\nKeep homepage request CPU deterministic: request path does only a D1 snapshot read + string response; heavy compute moves to scheduled/admin refresh.\n\n### Tradeoffs\nIf scheduled refresh is delayed/fails, homepage can be stale (bounded by existing MAX_STALE_SECONDS=10m) but still renders with data (no blank/loading UX).\n\n### Verify\n- `pnpm lint`\n- `pnpm typecheck`\n- `pnpm test`\n- `pnpm --filter @uptimer/worker bench:homepage`