### PR TITLE
revert(worker): stop scheduled full homepage refresh

### DIFF
--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -162,9 +162,6 @@ publicRoutes.use(
   cachePublic({
     cacheName: 'uptimer-public',
     maxAgeSeconds: 30,
-    // Homepage payloads can be large; caching them via Cache API can add CPU due to body cloning.
-    // Prefer serving the precomputed D1 snapshot directly.
-    skipPathnames: ['/api/v1/public/homepage'],
   }),
 );
 

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -28,7 +28,6 @@ import {
   readStatusSnapshot,
   readStatusSnapshotJson,
   readStaleHomepageSnapshot,
-  readStaleHomepageSnapshotJson,
   readStaleHomepageSnapshotArtifact,
   readStaleHomepageSnapshotArtifactJson,
   toSnapshotPayload,
@@ -590,16 +589,6 @@ publicRoutes.get('/homepage', async (c) => {
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
-    return res;
-  }
-
-  // If the full homepage snapshot is stale, prefer serving it over recomputing in the hot path.
-  // This keeps the request CPU deterministic (compute happens via scheduled/admin refresh).
-  const stale = await readStaleHomepageSnapshotJson(c.env.DB, now);
-  if (stale) {
-    c.header('Content-Type', 'application/json; charset=utf-8');
-    const res = c.body(stale.bodyJson);
-    applyHomepageCacheHeaders(res, Math.min(60, stale.age));
     return res;
   }
 

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -21,8 +21,8 @@ import {
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
-import { computePublicHomepagePayload } from '../public/homepage';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../snapshots';
+import { computePublicHomepageArtifactPayload } from '../public/homepage';
+import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -592,10 +592,10 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
   const queueHomepageRefresh = () =>
-    refreshPublicHomepageSnapshotIfNeeded({
+    refreshPublicHomepageArtifactSnapshotIfNeeded({
       db: env.DB,
       now,
-      compute: () => computePublicHomepagePayload(env.DB, Math.floor(Date.now() / 1000)),
+      compute: () => computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     });

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -278,15 +278,8 @@ describe('public homepage route', () => {
     expect(res.headers.get('Vary')).toContain('Origin');
   });
 
-  it('partitions cached homepage artifact responses by Origin when app-level CORS reflection is enabled', async () => {
+  it('partitions cached homepage responses by Origin when app-level CORS reflection is enabled', async () => {
     const payload = samplePayload(190);
-    const render = {
-      generated_at: payload.generated_at,
-      preload_html: '<div id="uptimer-preload">hello</div>',
-      snapshot: payload,
-      meta_title: 'Uptimer',
-      meta_description: 'All Systems Operational',
-    };
     const dbReads: string[] = [];
     vi.spyOn(Date, 'now').mockReturnValue(200_000);
 
@@ -295,10 +288,10 @@ describe('public homepage route', () => {
         match: 'from public_snapshots',
         first: (args) => {
           dbReads.push(String(args[0]));
-          return args[0] === 'homepage:artifact'
+          return args[0] === 'homepage'
             ? {
                 generated_at: payload.generated_at,
-                body_json: JSON.stringify(render),
+                body_json: JSON.stringify(payload),
               }
             : null;
         },
@@ -306,17 +299,17 @@ describe('public homepage route', () => {
     ];
 
     const first = await requestHomepageViaApp(
-      '/api/v1/public/homepage-artifact',
+      '/api/v1/public/homepage',
       handlers,
       'https://one.example.com',
     );
     const second = await requestHomepageViaApp(
-      '/api/v1/public/homepage-artifact',
+      '/api/v1/public/homepage',
       handlers,
       'https://two.example.com',
     );
     const third = await requestHomepageViaApp(
-      '/api/v1/public/homepage-artifact',
+      '/api/v1/public/homepage',
       handlers,
       'https://one.example.com',
     );
@@ -324,7 +317,7 @@ describe('public homepage route', () => {
     expect(first.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
     expect(second.headers.get('Access-Control-Allow-Origin')).toBe('https://two.example.com');
     expect(third.headers.get('Access-Control-Allow-Origin')).toBe('https://one.example.com');
-    expect(dbReads).toEqual(['homepage:artifact', 'homepage:artifact']);
+    expect(dbReads).toEqual(['homepage', 'homepage']);
   });
 
   it('serves a bounded stale homepage snapshot instead of computing in-request', async () => {

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -320,27 +320,6 @@ describe('public homepage route', () => {
     expect(dbReads).toEqual(['homepage', 'homepage']);
   });
 
-  it('serves a bounded stale homepage snapshot instead of computing in-request', async () => {
-    const payload = samplePayload(100);
-    vi.spyOn(Date, 'now').mockReturnValue(200_000);
-
-    const res = await requestHomepage([
-      {
-        match: 'from public_snapshots',
-        first: () => ({
-          generated_at: payload.generated_at,
-          body_json: JSON.stringify(payload),
-        }),
-      },
-    ]);
-
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual(payload);
-    expect(res.headers.get('Cache-Control')).toBe(
-      'public, max-age=0, stale-while-revalidate=0, stale-if-error=0',
-    );
-  });
-
   it('falls back to the fresh public status snapshot when the full homepage snapshot is missing', async () => {
     const now = 200;
     vi.spyOn(Date, 'now').mockReturnValue(now * 1000);

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -16,20 +16,20 @@ vi.mock('../src/notify/webhook', () => ({
   dispatchWebhookToChannels: vi.fn(),
 }));
 vi.mock('../src/public/homepage', () => ({
-  computePublicHomepagePayload: vi.fn(),
+  computePublicHomepageArtifactPayload: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
-  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageArtifactSnapshotIfNeeded: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { runHttpCheck } from '../src/monitor/http';
 import { runTcpCheck } from '../src/monitor/tcp';
 import { dispatchWebhookToChannels } from '../src/notify/webhook';
-import { computePublicHomepagePayload } from '../src/public/homepage';
+import { computePublicHomepageArtifactPayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../src/snapshots';
+import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -137,10 +137,10 @@ describe('scheduler/scheduled regression', () => {
       uptime_rating_level: 3,
     });
     vi.mocked(dispatchWebhookToChannels).mockResolvedValue(undefined);
-    vi.mocked(computePublicHomepagePayload).mockResolvedValue({
+    vi.mocked(computePublicHomepageArtifactPayload).mockResolvedValue({
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -183,20 +183,20 @@ describe('scheduler/scheduled regression', () => {
 
     expect(acquireLease).toHaveBeenCalledWith(env.DB, 'scheduler:tick', expectedNow, 55);
     expect(readSettings).toHaveBeenCalledTimes(1);
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
+    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
       compute: expect.any(Function),
     });
-    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
+    const refreshArgs = vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
-    expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(computePublicHomepageArtifactPayload).toHaveBeenCalledWith(env.DB, expectedNow);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockRejectedValueOnce(
+    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockRejectedValueOnce(
       new Error('snapshot refresh failed'),
     );
 
@@ -289,7 +289,7 @@ describe('scheduler/scheduled regression', () => {
     expect(runArgs[stateUpsertIndex]?.[1]).toBe('up');
     expect(runArgs[stateUpsertIndex]?.[2]).toBe(expectedCheckedAt);
 
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Context: Cloudflare Workers CPU P50 regressed to ~30ms after #57.

What
- Stop refreshing the full homepage snapshot in scheduled tick; refresh artifact-only again.
- Restore Cache API caching for /api/v1/public/homepage.
- Remove stale homepage snapshot fast-path short-circuit.

Why
- Scheduled full snapshot compute adds a steady high-CPU invocation every minute, which can dominate aggregated Workers CPU P50.
- Cache API + existing snapshot fallback paths avoid extra D1/read/parse work on hot requests.

Where
- apps/worker/src/scheduler/scheduled.ts
- apps/worker/src/routes/public.ts
- apps/worker/test/public-homepage-routes.test.ts
- apps/worker/test/scheduled.test.ts

How to verify
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm --filter @uptimer/worker bench:scheduler
