### PR TITLE
perf(homepage): refresh data snapshot via SQL

### DIFF
--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -22,7 +22,10 @@ import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
 import { computePublicHomepageArtifactPayload } from '../public/homepage';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../snapshots';
+import {
+  refreshPublicHomepageArtifactSnapshotIfNeeded,
+  refreshPublicHomepageSnapshotSqlIfNeeded,
+} from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -591,14 +594,6 @@ function queueMonitorNotification(
 export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
-  const queueHomepageRefresh = () =>
-    refreshPublicHomepageArtifactSnapshotIfNeeded({
-      db: env.DB,
-      now,
-      compute: () => computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
-    }).catch((err) => {
-      console.warn('homepage snapshot: refresh failed', err);
-    });
 
   const acquired = await acquireLease(env.DB, LOCK_NAME, now, LOCK_LEASE_SECONDS);
   if (!acquired) {
@@ -610,6 +605,33 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
     readSettings(env.DB),
     listDueMonitors(env.DB, checkedAt),
   ]);
+
+  const queueHomepageRefresh = () => {
+    const refreshNow = Math.floor(Date.now() / 1000);
+    const refreshArtifact = refreshPublicHomepageArtifactSnapshotIfNeeded({
+      db: env.DB,
+      now: refreshNow,
+      compute: () => computePublicHomepageArtifactPayload(env.DB, refreshNow),
+    }).catch((err) => {
+      console.warn('homepage artifact snapshot: refresh failed', err);
+    });
+
+    const refreshData = refreshPublicHomepageSnapshotSqlIfNeeded({
+      db: env.DB,
+      now: refreshNow,
+      settings: {
+        site_title: settings.site_title,
+        site_description: settings.site_description,
+        site_locale: settings.site_locale,
+        site_timezone: settings.site_timezone,
+        uptime_rating_level: settings.uptime_rating_level,
+      },
+    }).catch((err) => {
+      console.warn('homepage snapshot: sql refresh failed', err);
+    });
+
+    return Promise.all([refreshArtifact, refreshData]);
+  };
 
   const notify: NotifyContext | null =
     channels.length === 0

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -866,12 +866,13 @@ const HOMEPAGE_DATA_SNAPSHOT_SQL = `
         m.name,
         m.type,
         m.group_name,
-        m.group_sort_order,
-        m.sort_order,
-        m.interval_sec,
-        COALESCE(s.status, 'unknown') AS state_status,
-        s.last_checked_at,
-        CASE WHEN am.monitor_id IS NULL THEN 0 ELSE 1 END AS in_maintenance
+	        m.group_sort_order,
+	        m.sort_order,
+	        m.interval_sec,
+	        m.created_at,
+	        COALESCE(s.status, 'unknown') AS state_status,
+	        s.last_checked_at,
+	        CASE WHEN am.monitor_id IS NULL THEN 0 ELSE 1 END AS in_maintenance
       FROM monitors m
       LEFT JOIN monitor_state s ON s.monitor_id = m.id
       LEFT JOIN active_maintenance am ON am.monitor_id = m.id
@@ -950,10 +951,305 @@ const HOMEPAGE_DATA_SNAPSHOT_SQL = `
       )
       GROUP BY monitor_id
     ),
+    rollup_meta AS (
+      SELECT
+        ?1 AS now_sec,
+        (CAST(?1 / 86400 AS INTEGER) * 86400) AS today_start,
+        (SELECT MIN(created_at) FROM presentation) AS earliest_created_at
+    ),
     rollup_range AS (
       SELECT
-        (CAST(?1 / 86400 AS INTEGER) * 86400) AS end_day_start,
-        (CAST(?1 / 86400 AS INTEGER) * 86400) - (30 * 86400) AS start_day_start
+        now_sec,
+        today_start AS end_day_start,
+        today_start,
+        range_start_at,
+        CASE
+          WHEN now_sec > today_start AND today_start >= range_start_at THEN 1
+          ELSE 0
+        END AS needs_today
+      FROM (
+        SELECT
+          now_sec,
+          today_start,
+          CASE
+            WHEN earliest_created_at IS NULL THEN now_sec - (30 * 86400)
+            WHEN (now_sec - (30 * 86400)) > earliest_created_at THEN (now_sec - (30 * 86400))
+            ELSE earliest_created_at
+          END AS range_start_at
+        FROM rollup_meta
+      )
+    ),
+    max_interval AS (
+      SELECT COALESCE(MAX(interval_sec), 0) AS max_interval_sec
+      FROM presentation
+    ),
+    checks_window AS (
+      SELECT
+        CASE
+          WHEN rr.today_start - (mi.max_interval_sec * 2) > 0
+          THEN rr.today_start - (mi.max_interval_sec * 2)
+          ELSE 0
+        END AS checks_start
+      FROM rollup_range rr
+      CROSS JOIN max_interval mi
+    ),
+    today_base AS (
+      SELECT
+        p.id AS monitor_id,
+        p.interval_sec,
+        p.created_at,
+        p.last_checked_at,
+        rr.now_sec,
+        rr.today_start,
+        rr.needs_today,
+        cw.checks_start AS checks_window_start,
+        CASE
+          WHEN p.created_at > rr.today_start THEN p.created_at
+          ELSE rr.today_start
+        END AS monitor_start
+      FROM presentation p
+      CROSS JOIN rollup_range rr
+      CROSS JOIN checks_window cw
+    ),
+    today_first_checks AS (
+      SELECT
+        c.monitor_id,
+        MIN(c.checked_at) AS first_check_at
+      FROM check_results c
+      JOIN today_base t ON t.monitor_id = c.monitor_id
+      WHERE t.needs_today = 1
+        AND c.checked_at >= t.monitor_start
+        AND c.checked_at < t.now_sec
+      GROUP BY c.monitor_id
+    ),
+    today_effective_start AS (
+      SELECT
+        t.monitor_id,
+        t.interval_sec,
+        t.created_at,
+        t.last_checked_at,
+        t.now_sec,
+        t.today_start,
+        t.needs_today,
+        t.monitor_start,
+        CASE
+          WHEN t.needs_today = 0 THEN NULL
+          WHEN t.created_at <= t.today_start THEN t.today_start
+          ELSE COALESCE(
+            fc.first_check_at,
+            CASE
+              WHEN t.last_checked_at IS NULL THEN NULL
+              ELSE t.monitor_start
+            END
+          )
+        END AS effective_start,
+        CASE
+          WHEN t.created_at > t.today_start THEN t.monitor_start
+          ELSE t.checks_window_start
+        END AS checks_start
+      FROM today_base t
+      LEFT JOIN today_first_checks fc ON fc.monitor_id = t.monitor_id
+    ),
+    today_checks AS (
+      SELECT
+        c.monitor_id,
+        c.id AS check_id,
+        c.checked_at,
+        CASE
+          WHEN c.status IN ('up', 'down', 'maintenance') THEN 'known'
+          ELSE 'unknown'
+        END AS status
+      FROM check_results c
+      JOIN today_effective_start t ON t.monitor_id = c.monitor_id
+      WHERE t.needs_today = 1
+        AND t.effective_start IS NOT NULL
+        AND c.checked_at >= t.checks_start
+        AND c.checked_at < t.now_sec
+    ),
+    today_prev_check AS (
+      SELECT monitor_id, checked_at, status
+      FROM (
+        SELECT
+          c.monitor_id,
+          c.checked_at,
+          c.status,
+          ROW_NUMBER() OVER (
+            PARTITION BY c.monitor_id
+            ORDER BY c.checked_at DESC, c.check_id DESC
+          ) AS rn
+        FROM today_checks c
+        JOIN today_effective_start t ON t.monitor_id = c.monitor_id
+        WHERE c.checked_at < t.effective_start
+      )
+      WHERE rn = 1
+    ),
+    today_checks_after AS (
+      SELECT
+        c.monitor_id,
+        c.check_id,
+        c.checked_at,
+        c.status,
+        LEAD(c.checked_at) OVER (
+          PARTITION BY c.monitor_id
+          ORDER BY c.checked_at, c.check_id
+        ) AS next_checked_at
+      FROM today_checks c
+      JOIN today_effective_start t ON t.monitor_id = c.monitor_id
+      WHERE c.checked_at >= t.effective_start
+    ),
+    today_first_after AS (
+      SELECT
+        monitor_id,
+        MIN(checked_at) AS first_after_at
+      FROM today_checks_after
+      GROUP BY monitor_id
+    ),
+    today_start_segments AS (
+      SELECT
+        t.monitor_id,
+        t.interval_sec,
+        t.effective_start AS seg_start,
+        COALESCE(fa.first_after_at, t.now_sec) AS seg_end,
+        pc.checked_at AS last_check_at,
+        pc.status AS last_status
+      FROM today_effective_start t
+      LEFT JOIN today_prev_check pc ON pc.monitor_id = t.monitor_id
+      LEFT JOIN today_first_after fa ON fa.monitor_id = t.monitor_id
+      WHERE t.needs_today = 1
+        AND t.effective_start IS NOT NULL
+    ),
+    today_check_segments AS (
+      SELECT
+        ca.monitor_id,
+        t.interval_sec,
+        ca.checked_at AS seg_start,
+        COALESCE(ca.next_checked_at, t.now_sec) AS seg_end,
+        ca.checked_at AS last_check_at,
+        ca.status AS last_status
+      FROM today_checks_after ca
+      JOIN today_effective_start t ON t.monitor_id = ca.monitor_id
+      WHERE t.needs_today = 1
+        AND t.effective_start IS NOT NULL
+    ),
+    today_segments AS (
+      SELECT * FROM today_start_segments
+      UNION ALL
+      SELECT * FROM today_check_segments
+    ),
+    today_unknown_intervals AS (
+      SELECT
+        monitor_id,
+        CASE
+          WHEN seg_end <= seg_start THEN NULL
+          WHEN last_check_at IS NULL THEN seg_start
+          WHEN last_status = 'unknown' THEN seg_start
+          WHEN seg_start >= last_check_at + interval_sec * 2 THEN seg_start
+          WHEN seg_end > last_check_at + interval_sec * 2 THEN last_check_at + interval_sec * 2
+          ELSE NULL
+        END AS unknown_start,
+        seg_end AS unknown_end
+      FROM today_segments
+      WHERE seg_end > seg_start
+    ),
+    today_unknown_total AS (
+      SELECT
+        monitor_id,
+        SUM(unknown_end - unknown_start) AS unknown_sec
+      FROM today_unknown_intervals
+      WHERE unknown_start IS NOT NULL
+        AND unknown_end > unknown_start
+      GROUP BY monitor_id
+    ),
+    today_outage_intervals AS (
+      SELECT
+        o.monitor_id,
+        CASE
+          WHEN o.started_at > t.effective_start THEN o.started_at
+          ELSE t.effective_start
+        END AS start_at,
+        CASE
+          WHEN COALESCE(o.ended_at, t.now_sec) < t.now_sec THEN COALESCE(o.ended_at, t.now_sec)
+          ELSE t.now_sec
+        END AS end_at
+      FROM outages o
+      JOIN today_effective_start t ON t.monitor_id = o.monitor_id
+      WHERE t.needs_today = 1
+        AND t.effective_start IS NOT NULL
+        AND o.started_at < t.now_sec
+        AND (o.ended_at IS NULL OR o.ended_at > t.effective_start)
+    ),
+    today_downtime_total AS (
+      SELECT
+        monitor_id,
+        SUM(end_at - start_at) AS downtime_sec
+      FROM today_outage_intervals
+      WHERE end_at > start_at
+      GROUP BY monitor_id
+    ),
+    today_unknown_downtime_overlap AS (
+      SELECT
+        u.monitor_id,
+        SUM(
+          CASE
+            WHEN u.unknown_end <= d.start_at OR d.end_at <= u.unknown_start THEN 0
+            ELSE
+              (CASE WHEN u.unknown_end < d.end_at THEN u.unknown_end ELSE d.end_at END) -
+              (CASE WHEN u.unknown_start > d.start_at THEN u.unknown_start ELSE d.start_at END)
+          END
+        ) AS overlap_sec
+      FROM today_unknown_intervals u
+      JOIN today_outage_intervals d ON d.monitor_id = u.monitor_id
+      WHERE u.unknown_start IS NOT NULL
+        AND u.unknown_end > u.unknown_start
+        AND d.end_at > d.start_at
+      GROUP BY u.monitor_id
+    ),
+    today_totals_raw AS (
+      SELECT
+        t.monitor_id,
+        t.today_start AS day_start_at,
+        CASE
+          WHEN t.effective_start IS NULL OR t.now_sec <= t.effective_start THEN 0
+          ELSE t.now_sec - t.effective_start
+        END AS total_sec,
+        COALESCE(d.downtime_sec, 0) AS downtime_sec,
+        CASE
+          WHEN (COALESCE(u.unknown_sec, 0) - COALESCE(o.overlap_sec, 0)) > 0
+          THEN (COALESCE(u.unknown_sec, 0) - COALESCE(o.overlap_sec, 0))
+          ELSE 0
+        END AS unknown_sec
+      FROM today_effective_start t
+      LEFT JOIN today_downtime_total d ON d.monitor_id = t.monitor_id
+      LEFT JOIN today_unknown_total u ON u.monitor_id = t.monitor_id
+      LEFT JOIN today_unknown_downtime_overlap o ON o.monitor_id = t.monitor_id
+      WHERE t.needs_today = 1
+    ),
+    today_totals AS (
+      SELECT
+        monitor_id,
+        day_start_at,
+        downtime_sec,
+        unknown_sec,
+        CASE
+          WHEN total_sec <= 0 THEN NULL
+          ELSE CAST(
+            round(
+              (
+                CASE
+                  WHEN (downtime_sec + unknown_sec) >= total_sec THEN 0
+                  ELSE total_sec - (downtime_sec + unknown_sec)
+                END
+              ) * 100000.0 / total_sec
+            ) AS INTEGER
+          )
+        END AS uptime_pct_milli,
+        total_sec,
+        CASE
+          WHEN total_sec <= 0 THEN 0
+          WHEN (downtime_sec + unknown_sec) >= total_sec THEN 0
+          ELSE total_sec - (downtime_sec + unknown_sec)
+        END AS uptime_sec
+      FROM today_totals_raw
     ),
     rollup_rows AS (
       SELECT
@@ -971,8 +1267,18 @@ const HOMEPAGE_DATA_SNAPSHOT_SQL = `
       FROM monitor_daily_rollups r
       JOIN rollup_range rr
       WHERE r.monitor_id IN (SELECT id FROM presentation)
-        AND r.day_start_at >= rr.start_day_start
+        AND r.day_start_at >= rr.range_start_at
         AND r.day_start_at < rr.end_day_start
+      UNION ALL
+      SELECT
+        monitor_id,
+        day_start_at,
+        downtime_sec,
+        unknown_sec,
+        uptime_pct_milli,
+        total_sec,
+        uptime_sec
+      FROM today_totals
     ),
     rollup AS (
       SELECT
@@ -1082,7 +1388,7 @@ const HOMEPAGE_DATA_SNAPSHOT_SQL = `
           )
         )
       ORDER BY started_at DESC, id DESC
-      LIMIT 20
+      LIMIT 5
     ),
     active_incidents_json AS (
       SELECT json_group_array(
@@ -1130,7 +1436,7 @@ const HOMEPAGE_DATA_SNAPSHOT_SQL = `
           )
         )
       ORDER BY mw.starts_at ASC, mw.id ASC
-      LIMIT 20
+      LIMIT 3
     ),
     active_maintenance_json AS (
       SELECT json_group_array(
@@ -1177,7 +1483,7 @@ const HOMEPAGE_DATA_SNAPSHOT_SQL = `
           )
         )
       ORDER BY mw.starts_at ASC, mw.id ASC
-      LIMIT 20
+      LIMIT 5
     ),
     upcoming_maintenance_json AS (
       SELECT json_group_array(

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -10,6 +10,7 @@ const SNAPSHOT_ARTIFACT_KEY = 'homepage:artifact';
 const MAX_AGE_SECONDS = 60;
 const MAX_STALE_SECONDS = 10 * 60;
 const REFRESH_LOCK_NAME = 'snapshot:homepage:refresh';
+const REFRESH_DATA_SQL_LOCK_NAME = 'snapshot:homepage:data:refresh';
 const MAX_BOOTSTRAP_MONITORS = 12;
 
 const SPLIT_SNAPSHOT_VERSION = 3;
@@ -840,5 +841,607 @@ export async function refreshPublicHomepageArtifactSnapshotIfNeeded(opts: {
   }
 
   await refreshPublicHomepageArtifactSnapshot(opts);
+  return true;
+}
+
+type HomepageSnapshotSiteSettings = {
+  site_title: string;
+  site_description: string;
+  site_locale: 'auto' | 'en' | 'zh-CN' | 'zh-TW' | 'ja' | 'es';
+  site_timezone: string;
+  uptime_rating_level: 1 | 2 | 3 | 4 | 5;
+};
+
+const HOMEPAGE_DATA_SNAPSHOT_SQL = `
+  WITH
+    active_maintenance AS (
+      SELECT DISTINCT mwm.monitor_id
+      FROM maintenance_window_monitors mwm
+      JOIN maintenance_windows mw ON mw.id = mwm.maintenance_window_id
+      WHERE mw.starts_at <= ?1 AND mw.ends_at > ?1
+    ),
+    visible_monitors AS (
+      SELECT
+        m.id,
+        m.name,
+        m.type,
+        m.group_name,
+        m.group_sort_order,
+        m.sort_order,
+        m.interval_sec,
+        COALESCE(s.status, 'unknown') AS state_status,
+        s.last_checked_at,
+        CASE WHEN am.monitor_id IS NULL THEN 0 ELSE 1 END AS in_maintenance
+      FROM monitors m
+      LEFT JOIN monitor_state s ON s.monitor_id = m.id
+      LEFT JOIN active_maintenance am ON am.monitor_id = m.id
+      WHERE m.is_active = 1
+        AND m.show_on_status_page = 1
+    ),
+    presentation AS (
+      SELECT
+        vm.*,
+        CASE
+          WHEN in_maintenance = 1 OR state_status = 'maintenance' THEN 'maintenance'
+          WHEN state_status = 'paused' THEN 'paused'
+          WHEN state_status = 'down'
+            AND last_checked_at IS NOT NULL
+            AND ?1 - last_checked_at <= interval_sec * 2
+          THEN 'down'
+          WHEN state_status = 'up'
+            AND last_checked_at IS NOT NULL
+            AND ?1 - last_checked_at <= interval_sec * 2
+          THEN 'up'
+          ELSE 'unknown'
+        END AS status
+      FROM visible_monitors vm
+    ),
+    summary AS (
+      SELECT
+        COUNT(*) AS monitor_count_total,
+        COALESCE(SUM(status = 'up'), 0) AS up,
+        COALESCE(SUM(status = 'down'), 0) AS down,
+        COALESCE(SUM(status = 'maintenance'), 0) AS maintenance,
+        COALESCE(SUM(status = 'paused'), 0) AS paused,
+        COALESCE(SUM(status = 'unknown'), 0) AS unknown
+      FROM presentation
+    ),
+    overall AS (
+      SELECT
+        CASE
+          WHEN down > 0 THEN 'down'
+          WHEN unknown > 0 THEN 'unknown'
+          WHEN maintenance > 0 THEN 'maintenance'
+          WHEN up > 0 THEN 'up'
+          WHEN paused > 0 THEN 'paused'
+          ELSE 'unknown'
+        END AS overall_status
+      FROM summary
+    ),
+    hb_rows AS (
+      SELECT
+        cr.monitor_id,
+        cr.checked_at,
+        cr.latency_ms,
+        CASE cr.status
+          WHEN 'up' THEN 'u'
+          WHEN 'down' THEN 'd'
+          WHEN 'maintenance' THEN 'm'
+          ELSE 'x'
+        END AS code,
+        ROW_NUMBER() OVER (
+          PARTITION BY cr.monitor_id
+          ORDER BY cr.checked_at DESC, cr.id DESC
+        ) AS rn
+      FROM check_results cr
+      WHERE cr.monitor_id IN (SELECT id FROM presentation)
+    ),
+    hb AS (
+      SELECT
+        monitor_id,
+        json_group_array(checked_at) AS checked_at_json,
+        json_group_array(latency_ms) AS latency_json,
+        group_concat(code, '') AS status_codes
+      FROM (
+        SELECT monitor_id, checked_at, latency_ms, code
+        FROM hb_rows
+        WHERE rn <= 60
+        ORDER BY monitor_id, checked_at DESC, rn ASC
+      )
+      GROUP BY monitor_id
+    ),
+    rollup_range AS (
+      SELECT
+        (CAST(?1 / 86400 AS INTEGER) * 86400) AS end_day_start,
+        (CAST(?1 / 86400 AS INTEGER) * 86400) - (30 * 86400) AS start_day_start
+    ),
+    rollup_rows AS (
+      SELECT
+        r.monitor_id,
+        r.day_start_at,
+        r.downtime_sec,
+        r.unknown_sec,
+        CASE
+          WHEN r.total_sec > 0
+          THEN CAST(round((r.uptime_sec * 100000.0) / r.total_sec) AS INTEGER)
+          ELSE NULL
+        END AS uptime_pct_milli,
+        r.total_sec,
+        r.uptime_sec
+      FROM monitor_daily_rollups r
+      JOIN rollup_range rr
+      WHERE r.monitor_id IN (SELECT id FROM presentation)
+        AND r.day_start_at >= rr.start_day_start
+        AND r.day_start_at < rr.end_day_start
+    ),
+    rollup AS (
+      SELECT
+        monitor_id,
+        json_group_array(day_start_at) AS day_start_at_json,
+        json_group_array(downtime_sec) AS downtime_sec_json,
+        json_group_array(unknown_sec) AS unknown_sec_json,
+        json_group_array(uptime_pct_milli) AS uptime_pct_milli_json,
+        SUM(total_sec) AS total_sec_sum,
+        SUM(uptime_sec) AS uptime_sec_sum
+      FROM (
+        SELECT *
+        FROM rollup_rows
+        ORDER BY monitor_id, day_start_at
+      )
+      GROUP BY monitor_id
+    ),
+    monitor_cards AS (
+      SELECT
+        p.id,
+        json_object(
+          'id', p.id,
+          'name', p.name,
+          'type', CASE WHEN p.type = 'tcp' THEN 'tcp' ELSE 'http' END,
+          'group_name',
+            CASE
+              WHEN p.group_name IS NULL OR trim(p.group_name) = '' THEN NULL
+              ELSE trim(p.group_name)
+            END,
+          'status', p.status,
+          'is_stale',
+            CASE
+              WHEN p.in_maintenance = 1 OR p.state_status IN ('paused', 'maintenance')
+              THEN json('false')
+              WHEN p.last_checked_at IS NULL THEN json('true')
+              WHEN ?1 - p.last_checked_at > p.interval_sec * 2 THEN json('true')
+              ELSE json('false')
+            END,
+          'last_checked_at', p.last_checked_at,
+          'heartbeat_strip', json_object(
+            'checked_at', json(COALESCE(hb.checked_at_json, '[]')),
+            'status_codes', COALESCE(hb.status_codes, ''),
+            'latency_ms', json(COALESCE(hb.latency_json, '[]'))
+          ),
+          'uptime_30d',
+            CASE
+              WHEN rollup.total_sec_sum IS NULL OR rollup.total_sec_sum = 0 THEN NULL
+              ELSE json_object(
+                'uptime_pct',
+                  (rollup.uptime_sec_sum * 100.0) / rollup.total_sec_sum
+              )
+            END,
+          'uptime_day_strip', json_object(
+            'day_start_at', json(COALESCE(rollup.day_start_at_json, '[]')),
+            'downtime_sec', json(COALESCE(rollup.downtime_sec_json, '[]')),
+            'unknown_sec', json(COALESCE(rollup.unknown_sec_json, '[]')),
+            'uptime_pct_milli', json(COALESCE(rollup.uptime_pct_milli_json, '[]'))
+          )
+        ) AS monitor_json
+      FROM presentation p
+      LEFT JOIN hb ON hb.monitor_id = p.id
+      LEFT JOIN rollup ON rollup.monitor_id = p.id
+      ORDER BY
+        p.group_sort_order ASC,
+        lower(
+          CASE
+            WHEN p.group_name IS NULL OR trim(p.group_name) = '' THEN 'Ungrouped'
+            ELSE trim(p.group_name)
+          END
+        ) ASC,
+        p.sort_order ASC,
+        p.id ASC
+    ),
+    monitors_json AS (
+      SELECT json_group_array(json(monitor_json)) AS monitors
+      FROM monitor_cards
+    ),
+    visible_active_incidents AS (
+      SELECT
+        id,
+        title,
+        status,
+        impact,
+        message,
+        started_at,
+        resolved_at,
+        CASE impact
+          WHEN 'critical' THEN 3
+          WHEN 'major' THEN 2
+          WHEN 'minor' THEN 1
+          ELSE 0
+        END AS impact_rank
+      FROM incidents
+      WHERE status != 'resolved'
+        AND (
+          NOT EXISTS (
+            SELECT 1
+            FROM incident_monitors scoped_links
+            WHERE scoped_links.incident_id = incidents.id
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM incident_monitors scoped_links
+            JOIN monitors scoped_monitors ON scoped_monitors.id = scoped_links.monitor_id
+            WHERE scoped_links.incident_id = incidents.id
+              AND scoped_monitors.show_on_status_page = 1
+          )
+        )
+      ORDER BY started_at DESC, id DESC
+      LIMIT 20
+    ),
+    active_incidents_json AS (
+      SELECT json_group_array(
+        json_object(
+          'id', id,
+          'title', title,
+          'status', status,
+          'impact', impact,
+          'message', message,
+          'started_at', started_at,
+          'resolved_at', resolved_at
+        )
+      ) AS incidents
+      FROM visible_active_incidents
+    ),
+    active_maintenance_windows AS (
+      SELECT
+        mw.id,
+        mw.title,
+        mw.message,
+        mw.starts_at,
+        mw.ends_at,
+        (
+          SELECT json_group_array(mwm.monitor_id)
+          FROM maintenance_window_monitors mwm
+          JOIN monitors m2 ON m2.id = mwm.monitor_id
+          WHERE mwm.maintenance_window_id = mw.id
+            AND m2.show_on_status_page = 1
+          ORDER BY mwm.monitor_id
+        ) AS monitor_ids
+      FROM maintenance_windows mw
+      WHERE mw.starts_at <= ?1 AND mw.ends_at > ?1
+        AND (
+          NOT EXISTS (
+            SELECT 1
+            FROM maintenance_window_monitors scoped_links
+            WHERE scoped_links.maintenance_window_id = mw.id
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM maintenance_window_monitors scoped_links
+            JOIN monitors scoped_monitors ON scoped_monitors.id = scoped_links.monitor_id
+            WHERE scoped_links.maintenance_window_id = mw.id
+              AND scoped_monitors.show_on_status_page = 1
+          )
+        )
+      ORDER BY mw.starts_at ASC, mw.id ASC
+      LIMIT 20
+    ),
+    active_maintenance_json AS (
+      SELECT json_group_array(
+        json_object(
+          'id', id,
+          'title', title,
+          'message', message,
+          'starts_at', starts_at,
+          'ends_at', ends_at,
+          'monitor_ids', json(COALESCE(monitor_ids, '[]'))
+        )
+      ) AS windows
+      FROM active_maintenance_windows
+    ),
+    upcoming_maintenance_windows AS (
+      SELECT
+        mw.id,
+        mw.title,
+        mw.message,
+        mw.starts_at,
+        mw.ends_at,
+        (
+          SELECT json_group_array(mwm.monitor_id)
+          FROM maintenance_window_monitors mwm
+          JOIN monitors m2 ON m2.id = mwm.monitor_id
+          WHERE mwm.maintenance_window_id = mw.id
+            AND m2.show_on_status_page = 1
+          ORDER BY mwm.monitor_id
+        ) AS monitor_ids
+      FROM maintenance_windows mw
+      WHERE mw.starts_at > ?1
+        AND (
+          NOT EXISTS (
+            SELECT 1
+            FROM maintenance_window_monitors scoped_links
+            WHERE scoped_links.maintenance_window_id = mw.id
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM maintenance_window_monitors scoped_links
+            JOIN monitors scoped_monitors ON scoped_monitors.id = scoped_links.monitor_id
+            WHERE scoped_links.maintenance_window_id = mw.id
+              AND scoped_monitors.show_on_status_page = 1
+          )
+        )
+      ORDER BY mw.starts_at ASC, mw.id ASC
+      LIMIT 20
+    ),
+    upcoming_maintenance_json AS (
+      SELECT json_group_array(
+        json_object(
+          'id', id,
+          'title', title,
+          'message', message,
+          'starts_at', starts_at,
+          'ends_at', ends_at,
+          'monitor_ids', json(COALESCE(monitor_ids, '[]'))
+        )
+      ) AS windows
+      FROM upcoming_maintenance_windows
+    ),
+    resolved_incident_preview_json AS (
+      SELECT json_object(
+        'id', id,
+        'title', title,
+        'status', status,
+        'impact', impact,
+        'message', message,
+        'started_at', started_at,
+        'resolved_at', resolved_at
+      ) AS incident
+      FROM incidents
+      WHERE status = 'resolved'
+        AND (
+          NOT EXISTS (
+            SELECT 1
+            FROM incident_monitors scoped_links
+            WHERE scoped_links.incident_id = incidents.id
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM incident_monitors scoped_links
+            JOIN monitors scoped_monitors ON scoped_monitors.id = scoped_links.monitor_id
+            WHERE scoped_links.incident_id = incidents.id
+              AND scoped_monitors.show_on_status_page = 1
+          )
+        )
+      ORDER BY id DESC
+      LIMIT 1
+    ),
+    maintenance_history_preview_json AS (
+      SELECT json_object(
+        'id', mw.id,
+        'title', mw.title,
+        'message', mw.message,
+        'starts_at', mw.starts_at,
+        'ends_at', mw.ends_at,
+        'monitor_ids', json(COALESCE(mw.monitor_ids, '[]'))
+      ) AS window
+      FROM (
+        SELECT
+          mw.id,
+          mw.title,
+          mw.message,
+          mw.starts_at,
+          mw.ends_at,
+          (
+            SELECT json_group_array(mwm.monitor_id)
+            FROM maintenance_window_monitors mwm
+            JOIN monitors m2 ON m2.id = mwm.monitor_id
+            WHERE mwm.maintenance_window_id = mw.id
+              AND m2.show_on_status_page = 1
+            ORDER BY mwm.monitor_id
+          ) AS monitor_ids
+        FROM maintenance_windows mw
+        WHERE mw.ends_at <= ?1
+          AND (
+            NOT EXISTS (
+              SELECT 1
+              FROM maintenance_window_monitors scoped_links
+              WHERE scoped_links.maintenance_window_id = mw.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM maintenance_window_monitors scoped_links
+              JOIN monitors scoped_monitors ON scoped_monitors.id = scoped_links.monitor_id
+              WHERE scoped_links.maintenance_window_id = mw.id
+                AND scoped_monitors.show_on_status_page = 1
+            )
+          )
+        ORDER BY mw.id DESC
+        LIMIT 1
+      ) mw
+    ),
+    banner_json AS (
+      SELECT
+        CASE
+          WHEN (SELECT COUNT(*) FROM visible_active_incidents) > 0
+          THEN (
+            WITH max_rank AS (
+              SELECT COALESCE(MAX(impact_rank), 0) AS r
+              FROM visible_active_incidents
+            ),
+            top_inc AS (
+              SELECT id, title, status, impact
+              FROM visible_active_incidents
+              ORDER BY started_at DESC, id DESC
+              LIMIT 1
+            )
+            SELECT json_object(
+              'source', 'incident',
+              'status',
+                CASE
+                  WHEN (SELECT r FROM max_rank) >= 2 THEN 'major_outage'
+                  WHEN (SELECT r FROM max_rank) = 1 THEN 'partial_outage'
+                  ELSE 'operational'
+                END,
+              'title',
+                CASE
+                  WHEN (SELECT r FROM max_rank) >= 2 THEN 'Major Outage'
+                  WHEN (SELECT r FROM max_rank) = 1 THEN 'Partial Outage'
+                  ELSE 'Incident'
+                END,
+              'incident', (
+                SELECT json_object(
+                  'id', id,
+                  'title', title,
+                  'status', status,
+                  'impact', impact
+                )
+                FROM top_inc
+              )
+            )
+          )
+          WHEN (SELECT down FROM summary) > 0
+          THEN json_object(
+            'source', 'monitors',
+            'status',
+              CASE
+                WHEN (SELECT monitor_count_total FROM summary) = 0 THEN 'partial_outage'
+                WHEN (CAST((SELECT down FROM summary) AS REAL) / (SELECT monitor_count_total FROM summary)) >= 0.3
+                THEN 'major_outage'
+                ELSE 'partial_outage'
+              END,
+            'title',
+              CASE
+                WHEN (SELECT monitor_count_total FROM summary) > 0
+                  AND (CAST((SELECT down FROM summary) AS REAL) / (SELECT monitor_count_total FROM summary)) >= 0.3
+                THEN 'Major Outage'
+                ELSE 'Partial Outage'
+              END,
+            'down_ratio',
+              CASE
+                WHEN (SELECT monitor_count_total FROM summary) = 0 THEN 0
+                ELSE (CAST((SELECT down FROM summary) AS REAL) / (SELECT monitor_count_total FROM summary))
+              END
+          )
+          WHEN (SELECT unknown FROM summary) > 0
+          THEN json_object(
+            'source', 'monitors',
+            'status', 'unknown',
+            'title', 'Status Unknown'
+          )
+          WHEN (SELECT COUNT(*) FROM active_maintenance_windows) > 0
+          THEN (
+            WITH top_mw AS (
+              SELECT id, title, starts_at, ends_at
+              FROM active_maintenance_windows
+              ORDER BY starts_at ASC, id ASC
+              LIMIT 1
+            )
+            SELECT json_object(
+              'source', 'maintenance',
+              'status', 'maintenance',
+              'title', 'Maintenance',
+              'maintenance_window', (
+                SELECT json_object(
+                  'id', id,
+                  'title', title,
+                  'starts_at', starts_at,
+                  'ends_at', ends_at
+                )
+                FROM top_mw
+              )
+            )
+          )
+          WHEN (SELECT maintenance FROM summary) > 0
+          THEN json_object(
+            'source', 'monitors',
+            'status', 'maintenance',
+            'title', 'Maintenance'
+          )
+          ELSE json_object(
+            'source', 'monitors',
+            'status', 'operational',
+            'title', 'All Systems Operational'
+          )
+        END AS banner
+    ),
+    homepage_json AS (
+      SELECT json_object(
+        'generated_at', ?1,
+        'bootstrap_mode', 'full',
+        'monitor_count_total', (SELECT monitor_count_total FROM summary),
+        'site_title', ?2,
+        'site_description', ?3,
+        'site_locale', ?4,
+        'site_timezone', ?5,
+        'uptime_rating_level', ?6,
+        'overall_status', (SELECT overall_status FROM overall),
+        'banner', json((SELECT banner FROM banner_json)),
+        'summary', json_object(
+          'up', (SELECT up FROM summary),
+          'down', (SELECT down FROM summary),
+          'maintenance', (SELECT maintenance FROM summary),
+          'paused', (SELECT paused FROM summary),
+          'unknown', (SELECT unknown FROM summary)
+        ),
+        'monitors', json(COALESCE((SELECT monitors FROM monitors_json), '[]')),
+        'active_incidents', json(COALESCE((SELECT incidents FROM active_incidents_json), '[]')),
+        'maintenance_windows', json_object(
+          'active', json(COALESCE((SELECT windows FROM active_maintenance_json), '[]')),
+          'upcoming', json(COALESCE((SELECT windows FROM upcoming_maintenance_json), '[]'))
+        ),
+        'resolved_incident_preview', json((SELECT incident FROM resolved_incident_preview_json)),
+        'maintenance_history_preview', json((SELECT window FROM maintenance_history_preview_json))
+      ) AS body_json
+    )
+  INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
+  SELECT '${SNAPSHOT_KEY}', ?1, body_json, ?1
+  FROM homepage_json
+  WHERE 1 = 1
+  ON CONFLICT(key) DO UPDATE SET
+    generated_at = excluded.generated_at,
+    body_json = excluded.body_json,
+    updated_at = excluded.updated_at
+`;
+
+export const __testOnly_homepageDataSnapshotSql = HOMEPAGE_DATA_SNAPSHOT_SQL;
+
+export async function refreshPublicHomepageSnapshotSqlIfNeeded(opts: {
+  db: D1Database;
+  now: number;
+  settings: HomepageSnapshotSiteSettings;
+}): Promise<boolean> {
+  const generatedAt = await readHomepageSnapshotGeneratedAt(opts.db);
+  if (generatedAt !== null && isSameMinute(generatedAt, opts.now)) {
+    return false;
+  }
+
+  const acquired = await acquireLease(opts.db, REFRESH_DATA_SQL_LOCK_NAME, opts.now, 55);
+  if (!acquired) {
+    return false;
+  }
+
+  const latestGeneratedAt = await readHomepageSnapshotGeneratedAt(opts.db);
+  if (latestGeneratedAt !== null && isSameMinute(latestGeneratedAt, opts.now)) {
+    return false;
+  }
+
+  await opts.db
+    .prepare(HOMEPAGE_DATA_SNAPSHOT_SQL)
+    .bind(
+      opts.now,
+      opts.settings.site_title,
+      opts.settings.site_description,
+      opts.settings.site_locale,
+      opts.settings.site_timezone,
+      opts.settings.uptime_rating_level,
+    )
+    .run();
+
   return true;
 }

--- a/apps/worker/test/homepage-snapshot-sql.test.ts
+++ b/apps/worker/test/homepage-snapshot-sql.test.ts
@@ -78,12 +78,12 @@ function seedScenario(db: DatabaseSync, now: number): void {
         created_at, updated_at
       )
       VALUES
-        (1, 'API', 'http', 'https://api.example.com', 60, 10000, 'Core', 0, 0, 1, 1, ?1, ?1),
-        (2, 'Website', 'http', 'https://example.com', 60, 10000, 'Core', 0, 1, 1, 1, ?1, ?1),
-        (3, 'DB', 'tcp', 'db.example.com:5432', 60, 10000, 'Backend', 1, 0, 1, 1, ?1, ?1),
-        (4, 'Hidden', 'http', 'https://hidden.example.com', 60, 10000, NULL, 0, 0, 0, 1, ?1, ?1)
+        (1, 'API', 'http', 'https://api.example.com', 60, 10000, 'Core', 0, 0, 1, 1, ?, ?),
+        (2, 'Website', 'http', 'https://example.com', 60, 10000, 'Core', 0, 1, 1, 1, ?, ?),
+        (3, 'DB', 'tcp', 'db.example.com:5432', 60, 10000, 'Backend', 1, 0, 1, 1, ?, ?),
+        (4, 'Hidden', 'http', 'https://hidden.example.com', 60, 10000, NULL, 0, 0, 0, 1, ?, ?)
     `,
-  ).run(createdAt);
+  ).run(createdAt, createdAt, createdAt, createdAt, createdAt, createdAt, createdAt, createdAt);
 
   db.prepare(
     `
@@ -92,26 +92,26 @@ function seedScenario(db: DatabaseSync, now: number): void {
         last_error, consecutive_failures, consecutive_successes
       )
       VALUES
-        (1, 'up', ?1, ?1, 120, NULL, 0, 10),
-        (2, 'down', ?1, ?1, NULL, 'timeout', 3, 0),
-        (3, 'up', ?2, ?2, 80, NULL, 0, 10),
-        (4, 'up', ?1, ?1, 50, NULL, 0, 10)
+        (1, 'up', ?, ?, 120, NULL, 0, 10),
+        (2, 'down', ?, ?, NULL, 'timeout', 3, 0),
+        (3, 'up', ?, ?, 80, NULL, 0, 10),
+        (4, 'up', ?, ?, 50, NULL, 0, 10)
     `,
-  ).run(now - 30, now - 10_000);
+  ).run(now - 30, now - 30, now - 30, now - 30, now - 10_000, now - 10_000, now - 30, now - 30);
 
   for (let index = 1; index <= 5; index += 1) {
     const checkedAt = now - 30 - index * 60;
     db.prepare(
       `
         INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, attempt)
-        VALUES (1, ?1, 'up', ?2, 1)
+        VALUES (1, ?, 'up', ?, 1)
       `,
     ).run(checkedAt, 100 + index);
 
     db.prepare(
       `
         INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, attempt)
-        VALUES (2, ?1, ?2, ?3, 1)
+        VALUES (2, ?, ?, ?, 1)
       `,
     ).run(checkedAt, index === 1 ? 'down' : 'up', 200 + index);
 
@@ -119,7 +119,7 @@ function seedScenario(db: DatabaseSync, now: number): void {
     db.prepare(
       `
         INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, attempt)
-        VALUES (3, ?1, 'up', ?2, 1)
+        VALUES (3, ?, 'up', ?, 1)
       `,
     ).run(checkedAtDb, 50 + index);
   }
@@ -135,21 +135,37 @@ function seedScenario(db: DatabaseSync, now: number): void {
         created_at, updated_at
       )
       VALUES
-        (1, ?1, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 100, 100, 110, '[]', ?3, ?3),
-        (1, ?2, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 100, 100, 110, '[]', ?3, ?3),
-        (2, ?1, 86400, 3600, 0, 82800, 1440, 1380, 60, 0, 0, 150, 150, 200, '[]', ?3, ?3),
-        (2, ?2, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 150, 150, 200, '[]', ?3, ?3),
-        (3, ?1, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 50, 50, 60, '[]', ?3, ?3)
+        (1, ?, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 100, 100, 110, '[]', ?, ?),
+        (1, ?, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 100, 100, 110, '[]', ?, ?),
+        (2, ?, 86400, 3600, 0, 82800, 1440, 1380, 60, 0, 0, 150, 150, 200, '[]', ?, ?),
+        (2, ?, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 150, 150, 200, '[]', ?, ?),
+        (3, ?, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 50, 50, 60, '[]', ?, ?)
     `,
-  ).run(day1, day2, now);
+  ).run(
+    day1,
+    now,
+    now,
+    day2,
+    now,
+    now,
+    day1,
+    now,
+    now,
+    day2,
+    now,
+    now,
+    day1,
+    now,
+    now,
+  );
 
   // Active maintenance window (visible)
   db.prepare(
     `
       INSERT INTO maintenance_windows (id, title, message, starts_at, ends_at, created_at)
-      VALUES (1, 'Deploy', 'Deploying', ?1, ?2, ?1)
+      VALUES (1, 'Deploy', 'Deploying', ?, ?, ?)
     `,
-  ).run(now - 1000, now + 1000);
+  ).run(now - 1000, now + 1000, now - 1000);
   db.prepare(
     `
       INSERT INTO maintenance_window_monitors (maintenance_window_id, monitor_id)
@@ -161,9 +177,9 @@ function seedScenario(db: DatabaseSync, now: number): void {
   db.prepare(
     `
       INSERT INTO maintenance_windows (id, title, message, starts_at, ends_at, created_at)
-      VALUES (2, 'Past Maint', 'Done', ?1, ?2, ?1)
+      VALUES (2, 'Past Maint', 'Done', ?, ?, ?)
     `,
-  ).run(now - 100_000, now - 99_000);
+  ).run(now - 100_000, now - 99_000, now - 100_000);
   db.prepare(
     `
       INSERT INTO maintenance_window_monitors (maintenance_window_id, monitor_id)
@@ -173,9 +189,9 @@ function seedScenario(db: DatabaseSync, now: number): void {
   db.prepare(
     `
       INSERT INTO maintenance_windows (id, title, message, starts_at, ends_at, created_at)
-      VALUES (3, 'Hidden Maint', 'Ignore', ?1, ?2, ?1)
+      VALUES (3, 'Hidden Maint', 'Ignore', ?, ?, ?)
     `,
-  ).run(now - 200_000, now - 199_000);
+  ).run(now - 200_000, now - 199_000, now - 200_000);
   db.prepare(
     `
       INSERT INTO maintenance_window_monitors (maintenance_window_id, monitor_id)
@@ -188,13 +204,13 @@ function seedScenario(db: DatabaseSync, now: number): void {
     `
       INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
       VALUES
-        (1, 'Incident 1', 'investigating', 'minor', 'Investigating', ?1, NULL),
-        (2, 'Incident 2', 'investigating', 'none', 'Investigating', ?2, NULL),
-        (3, 'Incident 3', 'investigating', 'minor', 'Investigating', ?3, NULL),
-        (4, 'Incident 4', 'investigating', 'major', 'Investigating', ?4, NULL),
-        (5, 'Incident 5', 'investigating', 'critical', 'Investigating', ?5, NULL),
-        (6, 'Incident 6', 'investigating', 'minor', 'Investigating', ?6, NULL),
-        (7, 'Incident 7', 'investigating', 'none', 'Investigating', ?7, NULL)
+        (1, 'Incident 1', 'investigating', 'minor', 'Investigating', ?, NULL),
+        (2, 'Incident 2', 'investigating', 'none', 'Investigating', ?, NULL),
+        (3, 'Incident 3', 'investigating', 'minor', 'Investigating', ?, NULL),
+        (4, 'Incident 4', 'investigating', 'major', 'Investigating', ?, NULL),
+        (5, 'Incident 5', 'investigating', 'critical', 'Investigating', ?, NULL),
+        (6, 'Incident 6', 'investigating', 'minor', 'Investigating', ?, NULL),
+        (7, 'Incident 7', 'investigating', 'none', 'Investigating', ?, NULL)
     `,
   ).run(
     now - 2000 + 1,
@@ -210,13 +226,13 @@ function seedScenario(db: DatabaseSync, now: number): void {
   db.prepare(
     `
       INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
-      VALUES (20, 'Minor Issue', 'resolved', 'minor', 'Resolved', ?1, ?2)
+      VALUES (20, 'Minor Issue', 'resolved', 'minor', 'Resolved', ?, ?)
     `,
   ).run(now - 20_000, now - 19_000);
   db.prepare(
     `
       INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
-      VALUES (21, 'Hidden Issue', 'resolved', 'critical', 'Hidden', ?1, ?2)
+      VALUES (21, 'Hidden Issue', 'resolved', 'critical', 'Hidden', ?, ?)
     `,
   ).run(now - 30_000, now - 29_000);
   db.prepare(

--- a/apps/worker/test/homepage-snapshot-sql.test.ts
+++ b/apps/worker/test/homepage-snapshot-sql.test.ts
@@ -15,11 +15,36 @@ import { __testOnly_homepageDataSnapshotSql } from '../src/snapshots/public-home
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
 
+function toSqlLiteral(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`Non-finite SQL number: ${value}`);
+    }
+    return String(value);
+  }
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'boolean') return value ? '1' : '0';
+  const text = String(value);
+  return `'${text.replace(/'/g, "''")}'`;
+}
+
+function interpolateSql(sql: string, args: unknown[]): string {
+  let anonymousIndex = 0;
+  return sql.replace(/\?(\d+)?/g, (_match, digits: string | undefined) => {
+    const index = digits ? Number.parseInt(digits, 10) - 1 : anonymousIndex++;
+    const value = args[index];
+    if (index < 0 || index >= args.length) {
+      throw new RangeError(`Missing SQL bind param at index ${index + 1}`);
+    }
+    return toSqlLiteral(value);
+  });
+}
+
 function createD1FromSqlite(db: DatabaseSync): D1Database {
   return {
     prepare(sql: string) {
       let boundArgs: unknown[] = [];
-      const stmt = db.prepare(sql);
 
       const api = {
         bind(...args: unknown[]) {
@@ -27,15 +52,18 @@ function createD1FromSqlite(db: DatabaseSync): D1Database {
           return api;
         },
         async first<T>(): Promise<T | null> {
-          const row = stmt.get(...boundArgs) as T | undefined;
+          const expandedSql = boundArgs.length > 0 ? interpolateSql(sql, boundArgs) : sql;
+          const row = db.prepare(expandedSql).get() as T | undefined;
           return row ?? null;
         },
         async all<T>(): Promise<{ results: T[] }> {
-          const rows = stmt.all(...boundArgs) as T[] | undefined;
+          const expandedSql = boundArgs.length > 0 ? interpolateSql(sql, boundArgs) : sql;
+          const rows = db.prepare(expandedSql).all() as T[] | undefined;
           return { results: rows ?? [] };
         },
         async run(): Promise<{ meta: { changes: number } }> {
-          const result = stmt.run(...boundArgs) as { changes?: number } | undefined;
+          const expandedSql = boundArgs.length > 0 ? interpolateSql(sql, boundArgs) : sql;
+          const result = db.prepare(expandedSql).run() as { changes?: number } | undefined;
           return { meta: { changes: result?.changes ?? 0 } };
         },
       };
@@ -250,13 +278,15 @@ describe('homepage snapshot SQL refresh', () => {
     applyMigrations(db);
     seedScenario(db, now);
 
-    db.prepare(__testOnly_homepageDataSnapshotSql).run(
-      now,
-      'Uptimer',
-      '',
-      'auto',
-      'UTC',
-      3,
+    db.exec(
+      interpolateSql(__testOnly_homepageDataSnapshotSql, [
+        now,
+        'Uptimer',
+        '',
+        'auto',
+        'UTC',
+        3,
+      ]),
     );
 
     const row = db

--- a/apps/worker/test/homepage-snapshot-sql.test.ts
+++ b/apps/worker/test/homepage-snapshot-sql.test.ts
@@ -5,10 +5,45 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { publicHomepageResponseSchema } from '../src/schemas/public-homepage';
+import { computePublicStatusPayload } from '../src/public/status';
+import {
+  homepageFromStatusPayload,
+  readHomepageHistoryPreviews,
+} from '../src/public/homepage';
 import { __testOnly_homepageDataSnapshotSql } from '../src/snapshots/public-homepage';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+
+function createD1FromSqlite(db: DatabaseSync): D1Database {
+  return {
+    prepare(sql: string) {
+      let boundArgs: unknown[] = [];
+      const stmt = db.prepare(sql);
+
+      const api = {
+        bind(...args: unknown[]) {
+          boundArgs = args;
+          return api;
+        },
+        async first<T>(): Promise<T | null> {
+          const row = stmt.get(...boundArgs) as T | undefined;
+          return row ?? null;
+        },
+        async all<T>(): Promise<{ results: T[] }> {
+          const rows = stmt.all(...boundArgs) as T[] | undefined;
+          return { results: rows ?? [] };
+        },
+        async run(): Promise<{ meta: { changes: number } }> {
+          const result = stmt.run(...boundArgs) as { changes?: number } | undefined;
+          return { meta: { changes: result?.changes ?? 0 } };
+        },
+      };
+
+      return api;
+    },
+  } as unknown as D1Database;
+}
 
 function applyMigrations(db: DatabaseSync): void {
   const migrationsDir = join(process.cwd(), 'migrations');
@@ -152,33 +187,42 @@ function seedScenario(db: DatabaseSync, now: number): void {
   db.prepare(
     `
       INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
-      VALUES (1, 'Major Outage', 'investigating', 'major', 'Investigating', ?1, NULL)
+      VALUES
+        (1, 'Incident 1', 'investigating', 'minor', 'Investigating', ?1, NULL),
+        (2, 'Incident 2', 'investigating', 'none', 'Investigating', ?2, NULL),
+        (3, 'Incident 3', 'investigating', 'minor', 'Investigating', ?3, NULL),
+        (4, 'Incident 4', 'investigating', 'major', 'Investigating', ?4, NULL),
+        (5, 'Incident 5', 'investigating', 'critical', 'Investigating', ?5, NULL),
+        (6, 'Incident 6', 'investigating', 'minor', 'Investigating', ?6, NULL),
+        (7, 'Incident 7', 'investigating', 'none', 'Investigating', ?7, NULL)
     `,
-  ).run(now - 1200);
-  db.prepare(
-    `
-      INSERT INTO incident_monitors (incident_id, monitor_id)
-      VALUES (1, 1)
-    `,
-  ).run();
+  ).run(
+    now - 2000 + 1,
+    now - 2000 + 2,
+    now - 2000 + 3,
+    now - 2000 + 4,
+    now - 2000 + 5,
+    now - 2000 + 6,
+    now - 2000 + 7,
+  );
 
   // Resolved incident previews: one visible (no links), one hidden-only
   db.prepare(
     `
       INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
-      VALUES (2, 'Minor Issue', 'resolved', 'minor', 'Resolved', ?1, ?2)
+      VALUES (20, 'Minor Issue', 'resolved', 'minor', 'Resolved', ?1, ?2)
     `,
   ).run(now - 20_000, now - 19_000);
   db.prepare(
     `
       INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
-      VALUES (3, 'Hidden Issue', 'resolved', 'critical', 'Hidden', ?1, ?2)
+      VALUES (21, 'Hidden Issue', 'resolved', 'critical', 'Hidden', ?1, ?2)
     `,
   ).run(now - 30_000, now - 29_000);
   db.prepare(
     `
       INSERT INTO incident_monitors (incident_id, monitor_id)
-      VALUES (3, 4)
+      VALUES (21, 4)
     `,
   ).run();
 }
@@ -208,12 +252,69 @@ describe('homepage snapshot SQL refresh', () => {
 
     const parsed = JSON.parse(row?.body_json ?? 'null') as unknown;
     const validated = publicHomepageResponseSchema.parse(parsed);
+    const todayStartAt = Math.floor(now / 86_400) * 86_400;
 
     expect(validated.generated_at).toBe(now);
     expect(validated.monitors.length).toBe(3);
     expect(validated.monitors.find((m) => m.id === 3)?.is_stale).toBe(true);
     expect(validated.banner.source).toBe('incident');
+    expect(validated.banner.status).toBe('major_outage');
+    expect(validated.banner.incident?.id).toBe(7);
+    expect(validated.active_incidents.map((it) => it.id)).toEqual([7, 6, 5, 4, 3]);
+    for (const monitor of validated.monitors) {
+      expect(monitor.uptime_day_strip.day_start_at.at(-1)).toBe(todayStartAt);
+    }
     expect(validated.maintenance_history_preview?.title).toBe('Past Maint');
     expect(validated.resolved_incident_preview?.title).toBe('Minor Issue');
+
+    const d1 = createD1FromSqlite(db);
+    return Promise.all([
+      computePublicStatusPayload(d1, now),
+      readHomepageHistoryPreviews(d1, now),
+    ]).then(([statusPayload, previews]) => {
+      const expected = publicHomepageResponseSchema.parse(
+        homepageFromStatusPayload(statusPayload, previews),
+      );
+
+      expect(validated.generated_at).toBe(expected.generated_at);
+      expect(validated.monitor_count_total).toBe(expected.monitor_count_total);
+      expect(validated.site_title).toBe(expected.site_title);
+      expect(validated.site_description).toBe(expected.site_description);
+      expect(validated.site_locale).toBe(expected.site_locale);
+      expect(validated.site_timezone).toBe(expected.site_timezone);
+      expect(validated.uptime_rating_level).toBe(expected.uptime_rating_level);
+      expect(validated.overall_status).toBe(expected.overall_status);
+      expect(validated.banner).toEqual(expected.banner);
+      expect(validated.summary).toEqual(expected.summary);
+      expect(validated.active_incidents).toEqual(expected.active_incidents);
+      expect(validated.maintenance_windows).toEqual(expected.maintenance_windows);
+      expect(validated.resolved_incident_preview).toEqual(expected.resolved_incident_preview);
+      expect(validated.maintenance_history_preview).toEqual(expected.maintenance_history_preview);
+
+      expect(validated.monitors.length).toBe(expected.monitors.length);
+      for (let index = 0; index < validated.monitors.length; index += 1) {
+        const actualMonitor = validated.monitors[index];
+        const expectedMonitor = expected.monitors[index];
+        expect(actualMonitor?.id).toBe(expectedMonitor?.id);
+        expect(actualMonitor?.name).toBe(expectedMonitor?.name);
+        expect(actualMonitor?.type).toBe(expectedMonitor?.type);
+        expect(actualMonitor?.group_name).toBe(expectedMonitor?.group_name);
+        expect(actualMonitor?.status).toBe(expectedMonitor?.status);
+        expect(actualMonitor?.is_stale).toBe(expectedMonitor?.is_stale);
+        expect(actualMonitor?.last_checked_at).toBe(expectedMonitor?.last_checked_at);
+        expect(actualMonitor?.heartbeat_strip).toEqual(expectedMonitor?.heartbeat_strip);
+        expect(actualMonitor?.uptime_day_strip).toEqual(expectedMonitor?.uptime_day_strip);
+
+        if (actualMonitor?.uptime_30d === null || expectedMonitor?.uptime_30d === null) {
+          expect(actualMonitor?.uptime_30d).toBeNull();
+          expect(expectedMonitor?.uptime_30d).toBeNull();
+        } else {
+          expect(actualMonitor?.uptime_30d.uptime_pct).toBeCloseTo(
+            expectedMonitor?.uptime_30d.uptime_pct ?? 0,
+            6,
+          );
+        }
+      }
+    });
   });
 });

--- a/apps/worker/test/homepage-snapshot-sql.test.ts
+++ b/apps/worker/test/homepage-snapshot-sql.test.ts
@@ -1,0 +1,219 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { publicHomepageResponseSchema } from '../src/schemas/public-homepage';
+import { __testOnly_homepageDataSnapshotSql } from '../src/snapshots/public-homepage';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+
+function applyMigrations(db: DatabaseSync): void {
+  const migrationsDir = join(process.cwd(), 'migrations');
+  const files = [
+    '0001_init.sql',
+    '0002_incident_maintenance_scopes.sql',
+    '0003_daily_rollups.sql',
+    '0004_public_snapshots.sql',
+    '0005_uptime_rating_setting.sql',
+    '0006_settings_phase12.sql',
+    '0007_monitor_group_sort.sql',
+    '0008_monitor_group_manual_order.sql',
+    '0009_monitor_status_page_visibility.sql',
+    '0010_http_response_match_modes.sql',
+  ];
+
+  for (const file of files) {
+    db.exec(readFileSync(join(migrationsDir, file), 'utf8'));
+  }
+}
+
+function seedScenario(db: DatabaseSync, now: number): void {
+  const createdAt = now - 40 * 86_400;
+
+  db.prepare(
+    `
+      INSERT INTO monitors (
+        id, name, type, target,
+        interval_sec, timeout_ms,
+        group_name, group_sort_order, sort_order,
+        show_on_status_page, is_active,
+        created_at, updated_at
+      )
+      VALUES
+        (1, 'API', 'http', 'https://api.example.com', 60, 10000, 'Core', 0, 0, 1, 1, ?1, ?1),
+        (2, 'Website', 'http', 'https://example.com', 60, 10000, 'Core', 0, 1, 1, 1, ?1, ?1),
+        (3, 'DB', 'tcp', 'db.example.com:5432', 60, 10000, 'Backend', 1, 0, 1, 1, ?1, ?1),
+        (4, 'Hidden', 'http', 'https://hidden.example.com', 60, 10000, NULL, 0, 0, 0, 1, ?1, ?1)
+    `,
+  ).run(createdAt);
+
+  db.prepare(
+    `
+      INSERT INTO monitor_state (
+        monitor_id, status, last_checked_at, last_changed_at, last_latency_ms,
+        last_error, consecutive_failures, consecutive_successes
+      )
+      VALUES
+        (1, 'up', ?1, ?1, 120, NULL, 0, 10),
+        (2, 'down', ?1, ?1, NULL, 'timeout', 3, 0),
+        (3, 'up', ?2, ?2, 80, NULL, 0, 10),
+        (4, 'up', ?1, ?1, 50, NULL, 0, 10)
+    `,
+  ).run(now - 30, now - 10_000);
+
+  for (let index = 1; index <= 5; index += 1) {
+    const checkedAt = now - 30 - index * 60;
+    db.prepare(
+      `
+        INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, attempt)
+        VALUES (1, ?1, 'up', ?2, 1)
+      `,
+    ).run(checkedAt, 100 + index);
+
+    db.prepare(
+      `
+        INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, attempt)
+        VALUES (2, ?1, ?2, ?3, 1)
+      `,
+    ).run(checkedAt, index === 1 ? 'down' : 'up', 200 + index);
+
+    const checkedAtDb = now - 10_000 - index * 60;
+    db.prepare(
+      `
+        INSERT INTO check_results (monitor_id, checked_at, status, latency_ms, attempt)
+        VALUES (3, ?1, 'up', ?2, 1)
+      `,
+    ).run(checkedAtDb, 50 + index);
+  }
+
+  const day1 = now - 3 * 86_400;
+  const day2 = now - 2 * 86_400;
+  db.prepare(
+    `
+      INSERT INTO monitor_daily_rollups (
+        monitor_id, day_start_at, total_sec, downtime_sec, unknown_sec, uptime_sec,
+        checks_total, checks_up, checks_down, checks_unknown, checks_maintenance,
+        avg_latency_ms, p50_latency_ms, p95_latency_ms, latency_histogram_json,
+        created_at, updated_at
+      )
+      VALUES
+        (1, ?1, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 100, 100, 110, '[]', ?3, ?3),
+        (1, ?2, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 100, 100, 110, '[]', ?3, ?3),
+        (2, ?1, 86400, 3600, 0, 82800, 1440, 1380, 60, 0, 0, 150, 150, 200, '[]', ?3, ?3),
+        (2, ?2, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 150, 150, 200, '[]', ?3, ?3),
+        (3, ?1, 86400, 0, 0, 86400, 1440, 1440, 0, 0, 0, 50, 50, 60, '[]', ?3, ?3)
+    `,
+  ).run(day1, day2, now);
+
+  // Active maintenance window (visible)
+  db.prepare(
+    `
+      INSERT INTO maintenance_windows (id, title, message, starts_at, ends_at, created_at)
+      VALUES (1, 'Deploy', 'Deploying', ?1, ?2, ?1)
+    `,
+  ).run(now - 1000, now + 1000);
+  db.prepare(
+    `
+      INSERT INTO maintenance_window_monitors (maintenance_window_id, monitor_id)
+      VALUES (1, 2)
+    `,
+  ).run();
+
+  // Historical maintenance window previews: one visible, one hidden-only
+  db.prepare(
+    `
+      INSERT INTO maintenance_windows (id, title, message, starts_at, ends_at, created_at)
+      VALUES (2, 'Past Maint', 'Done', ?1, ?2, ?1)
+    `,
+  ).run(now - 100_000, now - 99_000);
+  db.prepare(
+    `
+      INSERT INTO maintenance_window_monitors (maintenance_window_id, monitor_id)
+      VALUES (2, 1)
+    `,
+  ).run();
+  db.prepare(
+    `
+      INSERT INTO maintenance_windows (id, title, message, starts_at, ends_at, created_at)
+      VALUES (3, 'Hidden Maint', 'Ignore', ?1, ?2, ?1)
+    `,
+  ).run(now - 200_000, now - 199_000);
+  db.prepare(
+    `
+      INSERT INTO maintenance_window_monitors (maintenance_window_id, monitor_id)
+      VALUES (3, 4)
+    `,
+  ).run();
+
+  // Active incident (visible)
+  db.prepare(
+    `
+      INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
+      VALUES (1, 'Major Outage', 'investigating', 'major', 'Investigating', ?1, NULL)
+    `,
+  ).run(now - 1200);
+  db.prepare(
+    `
+      INSERT INTO incident_monitors (incident_id, monitor_id)
+      VALUES (1, 1)
+    `,
+  ).run();
+
+  // Resolved incident previews: one visible (no links), one hidden-only
+  db.prepare(
+    `
+      INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
+      VALUES (2, 'Minor Issue', 'resolved', 'minor', 'Resolved', ?1, ?2)
+    `,
+  ).run(now - 20_000, now - 19_000);
+  db.prepare(
+    `
+      INSERT INTO incidents (id, title, status, impact, message, started_at, resolved_at)
+      VALUES (3, 'Hidden Issue', 'resolved', 'critical', 'Hidden', ?1, ?2)
+    `,
+  ).run(now - 30_000, now - 29_000);
+  db.prepare(
+    `
+      INSERT INTO incident_monitors (incident_id, monitor_id)
+      VALUES (3, 4)
+    `,
+  ).run();
+}
+
+describe('homepage snapshot SQL refresh', () => {
+  it('produces a schema-valid homepage snapshot row', () => {
+    const now = 1_800_000_000;
+    const db = new DatabaseSync(':memory:');
+    applyMigrations(db);
+    seedScenario(db, now);
+
+    db.prepare(__testOnly_homepageDataSnapshotSql).run(
+      now,
+      'Uptimer',
+      '',
+      'auto',
+      'UTC',
+      3,
+    );
+
+    const row = db
+      .prepare(`SELECT generated_at, body_json FROM public_snapshots WHERE key = 'homepage'`)
+      .get() as { generated_at: number; body_json: string } | undefined;
+
+    expect(row?.generated_at).toBe(now);
+    expect(typeof row?.body_json).toBe('string');
+
+    const parsed = JSON.parse(row?.body_json ?? 'null') as unknown;
+    const validated = publicHomepageResponseSchema.parse(parsed);
+
+    expect(validated.generated_at).toBe(now);
+    expect(validated.monitors.length).toBe(3);
+    expect(validated.monitors.find((m) => m.id === 3)?.is_stale).toBe(true);
+    expect(validated.banner.source).toBe('incident');
+    expect(validated.maintenance_history_preview?.title).toBe('Past Maint');
+    expect(validated.resolved_incident_preview?.title).toBe('Minor Issue');
+  });
+});

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -20,6 +20,7 @@ vi.mock('../src/public/homepage', () => ({
 }));
 vi.mock('../src/snapshots', () => ({
   refreshPublicHomepageArtifactSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageSnapshotSqlIfNeeded: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
@@ -29,7 +30,10 @@ import { dispatchWebhookToChannels } from '../src/notify/webhook';
 import { computePublicHomepageArtifactPayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../src/snapshots';
+import {
+  refreshPublicHomepageArtifactSnapshotIfNeeded,
+  refreshPublicHomepageSnapshotSqlIfNeeded,
+} from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -141,6 +145,7 @@ describe('scheduler/scheduled regression', () => {
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
     vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageSnapshotSqlIfNeeded).mockResolvedValue(false);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -188,6 +193,17 @@ describe('scheduler/scheduled regression', () => {
       now: expectedNow,
       compute: expect.any(Function),
     });
+    expect(refreshPublicHomepageSnapshotSqlIfNeeded).toHaveBeenCalledWith({
+      db: env.DB,
+      now: expectedNow,
+      settings: {
+        site_title: 'Uptimer',
+        site_description: '',
+        site_locale: 'auto',
+        site_timezone: 'UTC',
+        uptime_rating_level: 3,
+      },
+    });
     const refreshArgs = vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
@@ -211,7 +227,7 @@ describe('scheduler/scheduled regression', () => {
       await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
 
       expect(warnSpy).toHaveBeenCalledWith(
-        'homepage snapshot: refresh failed',
+        'homepage artifact snapshot: refresh failed',
         expect.any(Error),
       );
     } finally {
@@ -290,6 +306,7 @@ describe('scheduler/scheduled regression', () => {
     expect(runArgs[stateUpsertIndex]?.[2]).toBe(expectedCheckedAt);
 
     expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageSnapshotSqlIfNeeded).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Goal: reduce real Workers CPU on the homepage path without changing payload/UX.

Changes:
- Generate the /api/v1/public/homepage data snapshot via a single D1/SQLite SQL (JSON1 + window funcs) instead of TS-side assembly.
- Prewarm the data snapshot in scheduled tick (in parallel with existing homepage:artifact refresh).
- Align SQL output with current TS semantics (today partial uptime, rangeStart clamp, incident/maintenance limits).
- Add a parity test that computes the TS homepage payload from the same seeded SQLite DB and asserts SQL snapshot equivalence.

Verification:
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm --filter @uptimer/worker bench:homepage
- pnpm --filter @uptimer/worker bench:scheduler
