### PR TITLE
fix(pages): avoid 1101 on html cache failures

### DIFF
--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -229,7 +229,12 @@ export default {
     const isStatusPage = url.pathname === '/' || url.pathname === '/index.html';
     if (wantsHtml && isStatusPage) {
       const cacheKey = new Request(url.origin + '/', { method: 'GET' });
-      const cached = await caches.default.match(cacheKey);
+      let cached = null;
+      try {
+        cached = await caches.default.match(cacheKey);
+      } catch {
+        cached = null;
+      }
       const now = Math.floor(Date.now() / 1000);
       if (cached) {
         const cachedGeneratedAt = readGeneratedAtHeader(cached);
@@ -287,9 +292,15 @@ export default {
       const cacheHeaders = new Headers(headers);
       cacheHeaders.set('Cache-Control', `public, max-age=${FALLBACK_HTML_MAX_AGE_SECONDS}`);
       cacheHeaders.set(HOMEPAGE_CACHE_GENERATED_AT_HEADER, `${generatedAt}`);
+      cacheHeaders.delete('Set-Cookie');
       const cacheResp = new Response(injected, { status: 200, headers: cacheHeaders });
 
-      ctx.waitUntil(caches.default.put(cacheKey, cacheResp));
+      try {
+        ctx.waitUntil(caches.default.put(cacheKey, cacheResp).catch(() => undefined));
+      } catch {
+        // Ignore cache write failures. The injected HTML response is still usable and
+        // the worker should never throw a 1101 just because the cache rejected a put.
+      }
       return resp;
     }
 

--- a/apps/worker/test/pages-homepage-worker.test.ts
+++ b/apps/worker/test/pages-homepage-worker.test.ts
@@ -4,8 +4,13 @@ import pageWorker from '../../web/public/_worker.js';
 
 type CacheMatcher = (request: Request) => Response | undefined;
 
-function installDefaultCacheMock(match: CacheMatcher) {
-  const put = vi.fn(async () => undefined);
+function installDefaultCacheMock(
+  match: CacheMatcher,
+  opts: { putImpl?: (request: Request, response: Response) => Promise<void> | void } = {},
+) {
+  const put = vi.fn(async (request: Request, response: Response) => {
+    await opts.putImpl?.(request, response);
+  });
 
   Object.defineProperty(globalThis, 'caches', {
     configurable: true,
@@ -169,5 +174,47 @@ describe('pages homepage worker', () => {
     expect(html).not.toContain('__UPTIMER_INITIAL_STATUS__');
     expect(html).toContain('artifact preload');
     expect(put).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when the html cache put fails and strips set-cookie from cached response', async () => {
+    const { put } = installDefaultCacheMock(() => undefined, {
+      putImpl: () => {
+        throw new Error('cache rejected put');
+      },
+    });
+    const env = makeEnv();
+    env.ASSETS.fetch = vi.fn(async () => new Response('<!doctype html><html><head></head><body><div id="root"></div></body></html>', {
+      status: 200,
+      headers: { 'Set-Cookie': 'cf=1' },
+    }));
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          generated_at: 1_728_000_000,
+          preload_html: '<div id="uptimer-preload"><main>artifact preload</main></div>',
+          snapshot: { site_title: 'Status Hub' },
+          meta_title: 'Status Hub',
+          meta_description: 'Production',
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+
+    const res = await pageWorker.fetch(
+      new Request('https://status.example.com/', {
+        headers: { Accept: 'text/html' },
+      }),
+      env,
+      { waitUntil: vi.fn((promise) => promise) },
+    );
+
+    const html = await res.text();
+    expect(html).toContain('__UPTIMER_INITIAL_HOMEPAGE__');
+    expect(html).toContain('artifact preload');
+    expect(put).toHaveBeenCalledTimes(1);
+
+    const cachedResponse = vi.mocked(put).mock.calls[0]?.[1];
+    expect(cachedResponse?.headers.get('Set-Cookie')).toBeNull();
   });
 });


### PR DESCRIPTION
Problem: intermittent Cloudflare 1101 on status page refresh.

Likely cause: Pages Worker throws when Cache API match/put fails (e.g. response carries Set-Cookie or Cache API rejects/throws).

Changes:
- Wrap caches.default.match/put in try/catch so cache failures never crash the worker.
- Strip Set-Cookie from the cached HTML response.
- Add a test that simulates cache put throwing and asserts the worker still returns injected HTML.

Verification:
- pnpm lint
- pnpm --filter @uptimer/worker test