### PR TITLE
fix: harden Pages 1101 + validate status snapshots

### DIFF
--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -98,6 +98,15 @@ function computeCacheControl(ageSeconds) {
   return `public, max-age=${maxAge}, stale-while-revalidate=${stale}, stale-if-error=${stale}`;
 }
 
+function buildHomepageCacheHit(cached, ageSeconds) {
+  // In the Cloudflare runtime, cached/fetched Responses can have immutable headers.
+  // Always rebuild before mutating.
+  const hit = new Response(cached.body, cached);
+  hit.headers.set('Cache-Control', computeCacheControl(ageSeconds));
+  hit.headers.delete(HOMEPAGE_CACHE_GENERATED_AT_HEADER);
+  return hit;
+}
+
 function upsertHeadTag(html, pattern, tag) {
   if (pattern.test(html)) {
     return html.replace(pattern, tag);
@@ -170,6 +179,11 @@ function injectStatusMetaTags(html, artifact, url) {
   return injected;
 }
 
+function buildMinimalIndexHtml(title = 'Uptimer') {
+  const escapedTitle = escapeHtml(title);
+  return `<!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${escapedTitle}</title></head><body><div id="root"></div></body></html>`;
+}
+
 async function fetchIndexHtml(env, url) {
   const indexUrl = new URL('/index.html', url);
 
@@ -220,34 +234,39 @@ async function fetchPublicHomepageArtifact(env) {
 
 export default {
   async fetch(request, env, ctx) {
-    const url = new URL(request.url);
-
-    // HTML requests: serve SPA entry for client-side routes.
-    const wantsHtml = request.method === 'GET' && acceptsHtml(request);
-
-    // Special-case the status page for HTML injection.
-    const isStatusPage = url.pathname === '/' || url.pathname === '/index.html';
-    if (wantsHtml && isStatusPage) {
-      const cacheKey = new Request(url.origin + '/', { method: 'GET' });
-      let cached = null;
+    try {
       try {
-        cached = await caches.default.match(cacheKey);
+        ctx.passThroughOnException?.();
       } catch {
-        cached = null;
+        // ignore
       }
-      const now = Math.floor(Date.now() / 1000);
-      if (cached) {
-        const cachedGeneratedAt = readGeneratedAtHeader(cached);
-        if (cachedGeneratedAt === null) {
-          return cached;
+
+      const url = new URL(request.url);
+
+      // HTML requests: serve SPA entry for client-side routes.
+      const wantsHtml = request.method === 'GET' && acceptsHtml(request);
+
+      // Special-case the status page for HTML injection.
+      const isStatusPage = url.pathname === '/' || url.pathname === '/index.html';
+      if (wantsHtml && isStatusPage) {
+        const cacheKey = new Request(url.origin + '/', { method: 'GET' });
+        let cached = null;
+        try {
+          cached = await caches.default.match(cacheKey);
+        } catch {
+          cached = null;
         }
+
+        const now = Math.floor(Date.now() / 1000);
+        if (cached) {
+          const cachedGeneratedAt = readGeneratedAtHeader(cached);
+          if (cachedGeneratedAt === null) {
+            return cached;
+          }
 
         const cachedAge = Math.max(0, now - cachedGeneratedAt);
         if (cachedAge <= SNAPSHOT_MAX_AGE_SECONDS) {
-          const hit = cached.clone();
-          hit.headers.set('Cache-Control', computeCacheControl(cachedAge));
-          hit.headers.delete(HOMEPAGE_CACHE_GENERATED_AT_HEADER);
-          return hit;
+          return buildHomepageCacheHit(cached, cachedAge);
         }
       }
 
@@ -256,9 +275,68 @@ export default {
 
       const artifact = await fetchPublicHomepageArtifact(env);
       if (!artifact) {
-        if (cached) return cached;
+        if (cached) {
+          const cachedGeneratedAt = readGeneratedAtHeader(cached);
+          if (cachedGeneratedAt === null) return cached;
+          return buildHomepageCacheHit(cached, Math.max(0, now - cachedGeneratedAt));
+        }
 
         const headers = new Headers(base.headers);
+        headers.set('Content-Type', 'text/html; charset=utf-8');
+        headers.append('Vary', 'Accept');
+        headers.delete('Location');
+
+          return new Response(html, { status: 200, headers });
+        }
+
+        const generatedAt =
+          typeof artifact.generated_at === 'number' ? artifact.generated_at : now;
+        const age = Math.max(0, now - generatedAt);
+
+        let injected = html.replace(
+          '<div id="root"></div>',
+          `${artifact.preload_html}<div id="root"></div>`,
+        );
+
+        injected = injectStatusMetaTags(injected, artifact, url);
+
+        injected = injected.replace(
+          '</head>',
+          `  ${HOMEPAGE_PRELOAD_STYLE_TAG}\n  <script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${safeJsonForInlineScript(artifact.snapshot)};</script>\n</head>`,
+        );
+
+        const headers = new Headers(base.headers);
+        headers.set('Content-Type', 'text/html; charset=utf-8');
+        headers.set('Cache-Control', computeCacheControl(age));
+        headers.append('Vary', 'Accept');
+        headers.delete('Location');
+
+        const resp = new Response(injected, { status: 200, headers });
+
+        const cacheHeaders = new Headers(headers);
+        cacheHeaders.set('Cache-Control', `public, max-age=${FALLBACK_HTML_MAX_AGE_SECONDS}`);
+        cacheHeaders.set(HOMEPAGE_CACHE_GENERATED_AT_HEADER, `${generatedAt}`);
+        cacheHeaders.delete('Set-Cookie');
+        const cacheResp = new Response(injected, { status: 200, headers: cacheHeaders });
+
+        try {
+          ctx.waitUntil(caches.default.put(cacheKey, cacheResp).catch(() => undefined));
+        } catch {
+          // Ignore cache write failures. The injected HTML response is still usable and
+          // the worker should never throw a 1101 just because the cache rejected a put.
+        }
+        return resp;
+      }
+
+      // Default: serve static assets.
+      const assetResp = await env.ASSETS.fetch(request);
+
+      // SPA fallback for client-side routes.
+      if (wantsHtml && assetResp.status === 404) {
+        const indexResp = await fetchIndexHtml(env, url);
+        const html = await indexResp.text();
+
+        const headers = new Headers(indexResp.headers);
         headers.set('Content-Type', 'text/html; charset=utf-8');
         headers.append('Vary', 'Accept');
         headers.delete('Location');
@@ -266,60 +344,63 @@ export default {
         return new Response(html, { status: 200, headers });
       }
 
-      const generatedAt = typeof artifact.generated_at === 'number' ? artifact.generated_at : now;
-      const age = Math.max(0, now - generatedAt);
-
-      let injected = html.replace(
-        '<div id="root"></div>',
-        `${artifact.preload_html}<div id="root"></div>`,
-      );
-
-      injected = injectStatusMetaTags(injected, artifact, url);
-
-      injected = injected.replace(
-        '</head>',
-        `  ${HOMEPAGE_PRELOAD_STYLE_TAG}\n  <script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${safeJsonForInlineScript(artifact.snapshot)};</script>\n</head>`,
-      );
-
-      const headers = new Headers(base.headers);
-      headers.set('Content-Type', 'text/html; charset=utf-8');
-      headers.set('Cache-Control', computeCacheControl(age));
-      headers.append('Vary', 'Accept');
-      headers.delete('Location');
-
-      const resp = new Response(injected, { status: 200, headers });
-
-      const cacheHeaders = new Headers(headers);
-      cacheHeaders.set('Cache-Control', `public, max-age=${FALLBACK_HTML_MAX_AGE_SECONDS}`);
-      cacheHeaders.set(HOMEPAGE_CACHE_GENERATED_AT_HEADER, `${generatedAt}`);
-      cacheHeaders.delete('Set-Cookie');
-      const cacheResp = new Response(injected, { status: 200, headers: cacheHeaders });
-
+      return assetResp;
+    } catch (err) {
       try {
-        ctx.waitUntil(caches.default.put(cacheKey, cacheResp).catch(() => undefined));
+        console.error('pages worker: unhandled error', err);
       } catch {
-        // Ignore cache write failures. The injected HTML response is still usable and
-        // the worker should never throw a 1101 just because the cache rejected a put.
+        // ignore
       }
-      return resp;
+
+      // Best-effort fallback for HTML navigation so we never surface a 1101.
+      try {
+        const wantsHtml = request.method === 'GET' && acceptsHtml(request);
+        const url = new URL(request.url);
+        const isStatusPage = url.pathname === '/' || url.pathname === '/index.html';
+
+        if (wantsHtml) {
+          if (isStatusPage) {
+            try {
+              const cacheKey = new Request(url.origin + '/', { method: 'GET' });
+              const cached = await caches.default.match(cacheKey);
+              if (cached) {
+                const now = Math.floor(Date.now() / 1000);
+                const cachedGeneratedAt = readGeneratedAtHeader(cached);
+                if (cachedGeneratedAt === null) return cached;
+                return buildHomepageCacheHit(cached, Math.max(0, now - cachedGeneratedAt));
+              }
+            } catch {
+              // ignore
+            }
+          }
+
+          try {
+            const indexResp = await fetchIndexHtml(env, url);
+            const html = await indexResp.text();
+            const headers = new Headers(indexResp.headers);
+            headers.set('Content-Type', 'text/html; charset=utf-8');
+            headers.append('Vary', 'Accept');
+            headers.delete('Location');
+            headers.set('Cache-Control', 'no-store');
+            return new Response(html, { status: 200, headers });
+          } catch {
+            // ignore
+          }
+
+          return new Response(buildMinimalIndexHtml('Uptimer'), {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/html; charset=utf-8',
+              'Cache-Control': 'no-store',
+              Vary: 'Accept',
+            },
+          });
+        }
+      } catch {
+        // ignore
+      }
+
+      return new Response('Internal Server Error', { status: 500 });
     }
-
-    // Default: serve static assets.
-    const assetResp = await env.ASSETS.fetch(request);
-
-    // SPA fallback for client-side routes.
-    if (wantsHtml && assetResp.status === 404) {
-      const indexResp = await fetchIndexHtml(env, url);
-      const html = await indexResp.text();
-
-      const headers = new Headers(indexResp.headers);
-      headers.set('Content-Type', 'text/html; charset=utf-8');
-      headers.append('Vary', 'Accept');
-      headers.delete('Location');
-
-      return new Response(html, { status: 200, headers });
-    }
-
-    return assetResp;
   },
 };

--- a/apps/worker/src/snapshots/public-status.ts
+++ b/apps/worker/src/snapshots/public-status.ts
@@ -22,85 +22,6 @@ function safeJsonParse(text: string): unknown | null {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function looksLikeStatusPayload(value: unknown): value is PublicStatusResponse {
-  if (!isRecord(value)) return false;
-
-  return (
-    typeof value.generated_at === 'number' &&
-    typeof value.site_title === 'string' &&
-    typeof value.overall_status === 'string' &&
-    Array.isArray(value.monitors) &&
-    Array.isArray(value.active_incidents) &&
-    isRecord(value.banner) &&
-    isRecord(value.summary) &&
-    isRecord(value.maintenance_windows)
-  );
-}
-
-function looksLikeSerializedStatusPayload(text: string): boolean {
-  const trimmed = text.trim();
-  return (
-    trimmed.startsWith('{"generated_at":') &&
-    trimmed.includes('"site_title"') &&
-    trimmed.includes('"overall_status"') &&
-    trimmed.includes('"monitors"') &&
-    trimmed.includes('"summary"') &&
-    trimmed.includes('"maintenance_windows"')
-  );
-}
-
-function looksLikeCompleteJsonObject(text: string): boolean {
-  const trimmed = text.trim();
-  if (trimmed.length < 2) return false;
-  if (trimmed[0] !== '{' || trimmed[trimmed.length - 1] !== '}') return false;
-
-  const stack: ('{' | '[')[] = [];
-  let inString = false;
-
-  for (let index = 0; index < trimmed.length; index += 1) {
-    const ch = trimmed[index] as string;
-
-    if (inString) {
-      if (ch === '\\') {
-        index += 1;
-        continue;
-      }
-      if (ch === '"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (ch === '"') {
-      inString = true;
-      continue;
-    }
-
-    if (ch === '{' || ch === '[') {
-      stack.push(ch as '{' | '[');
-      continue;
-    }
-
-    if (ch === '}' || ch === ']') {
-      const open = stack.pop();
-      if (!open) return false;
-      if (ch === '}' && open !== '{') return false;
-      if (ch === ']' && open !== '[') return false;
-
-      // The root object must end at the end of the string.
-      if (stack.length === 0 && index !== trimmed.length - 1) {
-        return false;
-      }
-    }
-  }
-
-  return !inString && stack.length === 0;
-}
-
 export async function readStatusSnapshot(
   db: D1Database,
   now: number,
@@ -123,12 +44,12 @@ export async function readStatusSnapshot(
     if (age > MAX_AGE_SECONDS) return null;
 
     const parsed = safeJsonParse(row.body_json);
-    if (looksLikeStatusPayload(parsed)) {
-      return { data: parsed, age };
+    const validated = publicStatusResponseSchema.safeParse(parsed);
+    if (!validated.success) {
+      console.warn('public snapshot: invalid payload, falling back to live');
+      return null;
     }
-
-    const data = publicStatusResponseSchema.parse(parsed);
-    return { data, age };
+    return { data: validated.data, age };
   } catch (err) {
     // Backward compatible: if the table doesn't exist yet or snapshot is invalid,
     // callers should fall back to live computation.
@@ -158,20 +79,13 @@ export async function readStatusSnapshotJson(
     const age = Math.max(0, now - row.generated_at);
     if (age > MAX_AGE_SECONDS) return null;
 
-    if (
-      looksLikeSerializedStatusPayload(row.body_json) &&
-      looksLikeCompleteJsonObject(row.body_json)
-    ) {
-      return { bodyJson: row.body_json, age };
-    }
-
     const parsed = safeJsonParse(row.body_json);
-    if (looksLikeStatusPayload(parsed)) {
-      return { bodyJson: row.body_json, age };
+    const validated = publicStatusResponseSchema.safeParse(parsed);
+    if (!validated.success) {
+      console.warn('public snapshot: invalid payload, falling back to live');
+      return null;
     }
-
-    const data = publicStatusResponseSchema.parse(parsed);
-    return { bodyJson: JSON.stringify(data), age };
+    return { bodyJson: row.body_json, age };
   } catch (err) {
     console.warn('public snapshot: read failed, falling back to live', err);
     return null;

--- a/apps/worker/test/pages-homepage-worker.test.ts
+++ b/apps/worker/test/pages-homepage-worker.test.ts
@@ -217,4 +217,24 @@ describe('pages homepage worker', () => {
     const cachedResponse = vi.mocked(put).mock.calls[0]?.[1];
     expect(cachedResponse?.headers.get('Set-Cookie')).toBeNull();
   });
+
+  it('never throws a 1101 for HTML navigations when the asset pipeline errors', async () => {
+    installDefaultCacheMock(() => undefined);
+    const env = makeEnv();
+    env.ASSETS.fetch = vi.fn(async () => {
+      throw new Error('asset fetch failed');
+    });
+
+    const res = await pageWorker.fetch(
+      new Request('https://status.example.com/', {
+        headers: { Accept: 'text/html' },
+      }),
+      env,
+      { waitUntil: vi.fn() },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    expect(await res.text()).toContain('<div id="root"></div>');
+  });
 });

--- a/apps/worker/test/snapshots-public-status.test.ts
+++ b/apps/worker/test/snapshots-public-status.test.ts
@@ -132,6 +132,32 @@ describe('snapshots/public-status', () => {
     await expect(readStatusSnapshotJson(db, now)).resolves.toBeNull();
   });
 
+  it('rejects corrupted snapshot JSON even if it matches substring heuristics', async () => {
+    const now = 200;
+    const payload = samplePayload(190);
+    const bodyJson = JSON.stringify(payload);
+    const corrupted = bodyJson.replace(
+      `"generated_at":${payload.generated_at}`,
+      `"generated_at":NaN`,
+    );
+    expect(corrupted.startsWith('{"generated_at":')).toBe(true);
+    expect(corrupted.includes('"site_title"')).toBe(true);
+    expect(corrupted.includes('"overall_status"')).toBe(true);
+    expect(corrupted.endsWith('}')).toBe(true);
+
+    const db = createFakeD1Database([
+      {
+        match: 'from public_snapshots',
+        first: () => ({
+          generated_at: payload.generated_at,
+          body_json: corrupted,
+        }),
+      },
+    ]);
+
+    await expect(readStatusSnapshotJson(db, now)).resolves.toBeNull();
+  });
+
   it('writes the normalized snapshot payload with upsert semantics', async () => {
     let boundArgs: unknown[] | null = null;
     const db = createFakeD1Database([


### PR DESCRIPTION
- Fixes: Pages homepage cached-hit path now rebuilds Response before mutating headers (avoids immutable header throws) and strips X-Uptimer-Generated-At on all client responses.
- Adds: top-level error boundary for HTML navigations; falls back to cached/index/minimal HTML instead of surfacing 1101.
- Fixes: status snapshot read path always JSON.parse + Zod-validate before serving raw body_json (no substring-only fast path).
- Tests: add corrupted-json snapshot case + asset-pipeline-throw Pages regression.