### PR TITLE
perf(scheduler): split homepage refresh + SELF binding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -270,7 +270,14 @@ jobs:
           if not replaced:
               raise SystemExit(f'No [[d1_databases]] block found with binding = "{d1_binding}".')
 
-          dst.write_text("".join(out), encoding="utf-8")
+          final = "".join(out)
+
+          # Optional optimization: create a self service binding so the scheduler can
+          # offload snapshot refresh into a separate invocation without public HTTP self-fetch.
+          if 'binding = "SELF"' not in final:
+              final = final.rstrip() + f'\n\n[[services]]\nbinding = "SELF"\nservice = "{worker_name}"\n'
+
+          dst.write_text(final, encoding="utf-8")
           print(f"Wrote {dst}")
           PY
 
@@ -303,16 +310,6 @@ jobs:
             echo "WORKER_URL=$worker_url" >> "$GITHUB_ENV"
             echo "worker_url=$worker_url" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Upsert Worker secret for self origin (best-effort)
-        if: ${{ steps.deploy_worker.outputs.worker_url != '' }}
-        shell: bash
-        working-directory: apps/worker
-        run: |
-          set -euo pipefail
-          printf '%s' "$WORKER_URL" | pnpm exec wrangler secret put UPTIMER_SELF_ORIGIN --name "$WORKER_NAME" --config "$WRANGLER_CI_CONFIG"
-        env:
-          WORKER_URL: ${{ steps.deploy_worker.outputs.worker_url }}
 
       - name: Warm public status snapshot (best-effort)
         if: ${{ steps.deploy_worker.outputs.worker_url != '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,6 +304,16 @@ jobs:
             echo "worker_url=$worker_url" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Upsert Worker secret for self origin (best-effort)
+        if: ${{ steps.deploy_worker.outputs.worker_url != '' }}
+        shell: bash
+        working-directory: apps/worker
+        run: |
+          set -euo pipefail
+          printf '%s' "$WORKER_URL" | pnpm exec wrangler secret put UPTIMER_SELF_ORIGIN --name "$WORKER_NAME" --config "$WRANGLER_CI_CONFIG"
+        env:
+          WORKER_URL: ${{ steps.deploy_worker.outputs.worker_url }}
+
       - name: Warm public status snapshot (best-effort)
         if: ${{ steps.deploy_worker.outputs.worker_url != '' }}
         shell: bash

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -2,9 +2,8 @@ export interface Env {
   DB: D1Database;
   ADMIN_TOKEN: string;
 
-  // Dev/prod deploy helper: Workers.dev origin for this Worker (e.g. https://<name>.<subdomain>.workers.dev).
-  // Used by the scheduler to self-invoke internal refresh endpoints to split CPU budget across invocations.
-  UPTIMER_SELF_ORIGIN?: string;
+  // Optional internal service binding to self (configured by CI deploy).
+  SELF?: Fetcher;
 
   // Optional dev-only trace secret. If set, trace headers are honored only when
   // callers present `X-Uptimer-Trace-Token`.

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -2,6 +2,15 @@ export interface Env {
   DB: D1Database;
   ADMIN_TOKEN: string;
 
+  // Dev/prod deploy helper: Workers.dev origin for this Worker (e.g. https://<name>.<subdomain>.workers.dev).
+  // Used by the scheduler to self-invoke internal refresh endpoints to split CPU budget across invocations.
+  UPTIMER_SELF_ORIGIN?: string;
+
+  // Optional dev-only trace secret. If set, trace headers are honored only when
+  // callers present `X-Uptimer-Trace-Token`.
+  UPTIMER_TRACE_TOKEN?: string;
+  TRACE_TOKEN?: string;
+
   // In-memory, per-instance rate limit for admin endpoints.
   // Keep optional so older deployments don't break.
   ADMIN_RATE_LIMIT_MAX?: string;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,7 +1,55 @@
 import type { Env } from './env';
 
+async function handleInternalHomepageRefresh(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const token = (await request.text()).trim();
+  if (!env.ADMIN_TOKEN || token !== env.ADMIN_TOKEN) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  try {
+    const [{ computePublicHomepagePayload }, { refreshPublicHomepageSnapshotIfNeeded }] =
+      await Promise.all([import('./public/homepage'), import('./snapshots')]);
+    const refreshed = await refreshPublicHomepageSnapshotIfNeeded({
+      db: env.DB,
+      now,
+      compute: () => computePublicHomepagePayload(env.DB, now),
+    });
+
+    const res = new Response(JSON.stringify({ ok: true, refreshed }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+    return res;
+  } catch (err) {
+    console.warn('internal refresh: homepage failed', err);
+    return new Response(JSON.stringify({ ok: false }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
+}
+
 export default {
   fetch: async (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
+    const url = new URL(request.url);
+    if (url.pathname === '/api/v1/internal/refresh/homepage') {
+      return handleInternalHomepageRefresh(request, env);
+    }
+
     const mod = await import('./fetch-handler');
     return mod.handleFetch(request, env, ctx);
   },

--- a/apps/worker/src/monitor/http.ts
+++ b/apps/worker/src/monitor/http.ts
@@ -45,6 +45,16 @@ async function fetchWithTimeout(
   timeoutMs: number,
   init: RequestInit,
 ): Promise<Response> {
+  // Prefer AbortSignal.timeout when available (avoids setTimeout + event listener overhead).
+  const timeoutFn = (AbortSignal as unknown as { timeout?: (ms: number) => AbortSignal }).timeout;
+  const isWorkersRuntime =
+    typeof navigator !== 'undefined' &&
+    typeof navigator.userAgent === 'string' &&
+    navigator.userAgent === 'Cloudflare-Workers';
+  if (isWorkersRuntime && !init.signal && typeof timeoutFn === 'function') {
+    return fetch(url, { ...init, signal: timeoutFn(timeoutMs) });
+  }
+
   const controller = new AbortController();
 
   // If the caller also passes a signal, forward abort.

--- a/apps/worker/src/scheduler/lock.ts
+++ b/apps/worker/src/scheduler/lock.ts
@@ -6,17 +6,22 @@ export async function acquireLease(
 ): Promise<boolean> {
   const expiresAt = now + leaseSeconds;
 
-  const r = await db
-    .prepare(
-      `
-      INSERT INTO locks (name, expires_at)
-      VALUES (?1, ?2)
-      ON CONFLICT(name) DO UPDATE SET expires_at = excluded.expires_at
-      WHERE locks.expires_at <= ?3
-    `,
-    )
-    .bind(name, expiresAt, now)
-    .run();
+  const cached = acquireLeaseStatementByDb.get(db);
+  const statement = cached ?? db.prepare(ACQUIRE_LEASE_SQL);
+  if (!cached) {
+    acquireLeaseStatementByDb.set(db, statement);
+  }
+
+  const r = await statement.bind(name, expiresAt, now).run();
 
   return (r.meta.changes ?? 0) > 0;
 }
+
+const ACQUIRE_LEASE_SQL = `
+  INSERT INTO locks (name, expires_at)
+  VALUES (?1, ?2)
+  ON CONFLICT(name) DO UPDATE SET expires_at = excluded.expires_at
+  WHERE locks.expires_at <= ?3
+`;
+
+const acquireLeaseStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -33,33 +33,27 @@ const PERSIST_BATCH_SIZE = 25;
 // Look back a bit so maintenance start/end notifications are not missed if a tick is delayed.
 const MAINTENANCE_EVENT_LOOKBACK_SECONDS = 10 * 60;
 
-function normalizeSelfOrigin(value: string | undefined): string | null {
-  const trimmed = value?.trim() ?? '';
-  if (!trimmed) return null;
-
-  let out = trimmed;
-  while (out.endsWith('/')) out = out.slice(0, -1);
-  if (!out.startsWith('http://') && !out.startsWith('https://')) return null;
-  return out;
-}
-
-async function refreshHomepageSnapshotViaSelfFetch(env: Env): Promise<void> {
-  const origin = normalizeSelfOrigin(env.UPTIMER_SELF_ORIGIN);
-  if (!origin || !env.ADMIN_TOKEN) {
-    throw new Error('UPTIMER_SELF_ORIGIN or ADMIN_TOKEN missing');
+async function refreshHomepageSnapshotViaService(env: Env): Promise<void> {
+  if (!env.SELF) {
+    throw new Error('SELF service binding missing');
+  }
+  if (!env.ADMIN_TOKEN) {
+    throw new Error('ADMIN_TOKEN missing');
   }
 
-  const res = await fetch(`${origin}/api/v1/internal/refresh/homepage`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'text/plain; charset=utf-8',
-    },
-    cache: 'no-store',
-    body: env.ADMIN_TOKEN,
-  });
+  const res = await env.SELF.fetch(
+    new Request('http://internal/api/v1/internal/refresh/homepage', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+      body: env.ADMIN_TOKEN,
+    }),
+  );
+
   if (!res.ok) {
     const text = await res.text().catch(() => '');
-    throw new Error(`self refresh failed: HTTP ${res.status} ${text}`.trim());
+    throw new Error(`service refresh failed: HTTP ${res.status} ${text}`.trim());
   }
 }
 
@@ -710,11 +704,13 @@ function queueMonitorNotification(
 export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
-  const shouldSelfRefresh = normalizeSelfOrigin(env.UPTIMER_SELF_ORIGIN) !== null && !!env.ADMIN_TOKEN;
   const queueHomepageRefresh = () =>
-    shouldSelfRefresh
-      ? refreshHomepageSnapshotViaSelfFetch(env).catch((err) => {
-          console.warn('homepage snapshot: self refresh failed', err);
+    env.SELF
+      ? refreshHomepageSnapshotViaService(env).catch(async (err) => {
+          console.warn('homepage snapshot: service refresh failed', err);
+          await refreshHomepageSnapshotInline(env, now).catch((fallbackErr) => {
+            console.warn('homepage snapshot: refresh failed', fallbackErr);
+          });
         })
       : refreshHomepageSnapshotInline(env, now).catch((err) => {
           console.warn('homepage snapshot: refresh failed', err);

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -35,6 +35,15 @@ const PERSIST_BATCH_SIZE = 25;
 // Look back a bit so maintenance start/end notifications are not missed if a tick is delayed.
 const MAINTENANCE_EVENT_LOOKBACK_SECONDS = 10 * 60;
 
+type CachedMonitorHttpJson = {
+  http_headers_json: string | null;
+  expected_status_json: string | null;
+  httpHeaders: Record<string, string> | null;
+  expectedStatus: number[] | null;
+};
+
+const cachedMonitorHttpJsonById = new Map<number, CachedMonitorHttpJson>();
+
 type DueMonitorRow = {
   id: number;
   name: string;
@@ -413,16 +422,31 @@ async function runDueMonitor(
           attempts: 1,
         };
       } else {
-        const httpHeaders = parseDbJsonNullable(httpHeadersJsonSchema, row.http_headers_json, {
-          field: 'http_headers_json',
-        });
-        const expectedStatus = parseDbJsonNullable(
-          expectedStatusJsonSchema,
-          row.expected_status_json,
-          {
-            field: 'expected_status_json',
-          },
-        );
+        const cached = cachedMonitorHttpJsonById.get(row.id);
+        const cachedMatches =
+          cached &&
+          cached.http_headers_json === row.http_headers_json &&
+          cached.expected_status_json === row.expected_status_json;
+
+        const httpHeaders = cachedMatches
+          ? cached.httpHeaders
+          : parseDbJsonNullable(httpHeadersJsonSchema, row.http_headers_json, {
+              field: 'http_headers_json',
+            });
+        const expectedStatus = cachedMatches
+          ? cached.expectedStatus
+          : parseDbJsonNullable(expectedStatusJsonSchema, row.expected_status_json, {
+              field: 'expected_status_json',
+            });
+
+        if (!cachedMatches) {
+          cachedMonitorHttpJsonById.set(row.id, {
+            http_headers_json: row.http_headers_json,
+            expected_status_json: row.expected_status_json,
+            httpHeaders,
+            expectedStatus,
+          });
+        }
 
         outcome = await runHttpCheck({
           url: row.target,

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -21,9 +21,8 @@ import {
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
-import { homepageFromStatusPayload, readHomepageHistoryPreviews } from '../public/homepage';
-import { computePublicStatusPayload } from '../public/status';
-import { refreshPublicHomepageSnapshotIfNeeded, writeStatusSnapshot } from '../snapshots';
+import { computePublicHomepagePayload } from '../public/homepage';
+import { refreshPublicHomepageSnapshotIfNeeded } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -622,12 +621,7 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
       db: env.DB,
       now,
       compute: async () => {
-        const statusPayload = await computePublicStatusPayload(env.DB, now);
-        await writeStatusSnapshot(env.DB, now, statusPayload);
-        return homepageFromStatusPayload(
-          statusPayload,
-          await readHomepageHistoryPreviews(env.DB, now),
-        );
+        return computePublicHomepagePayload(env.DB, now);
       },
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -21,8 +21,9 @@ import {
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
-import { computePublicHomepageArtifactPayload } from '../public/homepage';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../snapshots';
+import { homepageFromStatusPayload, readHomepageHistoryPreviews } from '../public/homepage';
+import { computePublicStatusPayload } from '../public/status';
+import { refreshPublicHomepageSnapshotIfNeeded, writeStatusSnapshot } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -592,10 +593,17 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
   const queueHomepageRefresh = () =>
-    refreshPublicHomepageArtifactSnapshotIfNeeded({
+    refreshPublicHomepageSnapshotIfNeeded({
       db: env.DB,
       now,
-      compute: () => computePublicHomepageArtifactPayload(env.DB, Math.floor(Date.now() / 1000)),
+      compute: async () => {
+        const statusPayload = await computePublicStatusPayload(env.DB, now);
+        await writeStatusSnapshot(env.DB, now, statusPayload);
+        return homepageFromStatusPayload(
+          statusPayload,
+          await readHomepageHistoryPreviews(env.DB, now),
+        );
+      },
     }).catch((err) => {
       console.warn('homepage snapshot: refresh failed', err);
     });

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -779,10 +779,36 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
     }
   }
 
+  let httpCount = 0;
+  let tcpCount = 0;
+  let assertionCount = 0;
+  let attemptTotal = 0;
+  let downCount = 0;
+  let unknownCount = 0;
+  for (const monitor of completed) {
+    attemptTotal += monitor.outcome.attempts;
+    if (monitor.outcome.status === 'down') downCount += 1;
+    else if (monitor.outcome.status === 'unknown') unknownCount += 1;
+
+    if (monitor.row.type === 'http') {
+      httpCount += 1;
+      if (monitor.row.response_keyword || monitor.row.response_forbidden_keyword) {
+        assertionCount += 1;
+      }
+    } else if (monitor.row.type === 'tcp') {
+      tcpCount += 1;
+    }
+  }
+
   if (rejected.length > 0) {
-    console.error(`scheduled: ${rejected.length}/${settled.length} monitors failed`, rejected[0]);
+    console.error(
+      `scheduled: ${rejected.length}/${settled.length} monitors failed at ${checkedAt} attempts=${attemptTotal} http=${httpCount} tcp=${tcpCount} assertions=${assertionCount} down=${downCount} unknown=${unknownCount}`,
+      rejected[0],
+    );
   } else {
-    console.log(`scheduled: processed ${settled.length} monitors at ${checkedAt}`);
+    console.log(
+      `scheduled: processed ${settled.length} monitors at ${checkedAt} attempts=${attemptTotal} http=${httpCount} tcp=${tcpCount} assertions=${assertionCount} down=${downCount} unknown=${unknownCount}`,
+    );
   }
 
   ctx.waitUntil(queueHomepageRefresh());

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -22,7 +22,7 @@ import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
 import { computePublicHomepagePayload } from '../public/homepage';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../snapshots';
+import { refreshPublicHomepageSnapshot } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -641,7 +641,7 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
   const queueHomepageRefresh = () =>
-    refreshPublicHomepageSnapshotIfNeeded({
+    refreshPublicHomepageSnapshot({
       db: env.DB,
       now,
       compute: async () => {

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -81,6 +81,103 @@ type NotifyContext = {
   channels: WebhookChannelWithMeta[];
 };
 
+const listActiveWebhookChannelsStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
+const listDueMonitorsStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
+const persistStatementTemplatesByDb = new WeakMap<D1Database, PersistStatementTemplates>();
+const activeWebhookChannelsCacheByDb = new WeakMap<
+  D1Database,
+  { fetchedAtMs: number; channels: WebhookChannelWithMeta[] }
+>();
+
+const LIST_ACTIVE_WEBHOOK_CHANNELS_SQL = `
+  SELECT id, name, config_json, created_at
+  FROM notification_channels
+  WHERE is_active = 1 AND type = 'webhook'
+  ORDER BY id
+`;
+const ACTIVE_WEBHOOK_CHANNELS_CACHE_TTL_MS = 2 * 60_000;
+
+const LIST_DUE_MONITORS_SQL = `
+  SELECT
+    m.id,
+    m.name,
+    m.type,
+    m.target,
+    m.interval_sec,
+    m.timeout_ms,
+    m.http_method,
+    m.http_headers_json,
+    m.http_body,
+    m.expected_status_json,
+    m.response_keyword,
+    m.response_keyword_mode,
+    m.response_forbidden_keyword,
+    m.response_forbidden_keyword_mode,
+    s.status AS state_status,
+    s.last_error AS state_last_error,
+    s.last_changed_at,
+    s.consecutive_failures,
+    s.consecutive_successes
+  FROM monitors m
+  LEFT JOIN monitor_state s ON s.monitor_id = m.id
+  WHERE m.is_active = 1
+    AND (s.status IS NULL OR s.status != 'paused')
+    AND (s.last_checked_at IS NULL OR s.last_checked_at <= ?1 - m.interval_sec)
+  ORDER BY m.id
+`;
+
+const PERSIST_STATEMENTS_SQL = {
+  insertCheckResult: `
+    INSERT INTO check_results (
+      monitor_id,
+      checked_at,
+      status,
+      latency_ms,
+      http_status,
+      error,
+      location,
+      attempt
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+  `,
+  upsertMonitorState: `
+    INSERT INTO monitor_state (
+      monitor_id,
+      status,
+      last_checked_at,
+      last_changed_at,
+      last_latency_ms,
+      last_error,
+      consecutive_failures,
+      consecutive_successes
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+    ON CONFLICT(monitor_id) DO UPDATE SET
+      status = excluded.status,
+      last_checked_at = excluded.last_checked_at,
+      last_changed_at = excluded.last_changed_at,
+      last_latency_ms = excluded.last_latency_ms,
+      last_error = excluded.last_error,
+      consecutive_failures = excluded.consecutive_failures,
+      consecutive_successes = excluded.consecutive_successes
+  `,
+  openOutageIfMissing: `
+    INSERT INTO outages (monitor_id, started_at, ended_at, initial_error, last_error)
+    SELECT ?1, ?2, NULL, ?3, ?4
+    WHERE NOT EXISTS (
+      SELECT 1 FROM outages WHERE monitor_id = ?5 AND ended_at IS NULL
+    )
+  `,
+  closeOutage: `
+    UPDATE outages
+    SET ended_at = ?1
+    WHERE monitor_id = ?2 AND ended_at IS NULL
+  `,
+  updateOutageLastError: `
+    UPDATE outages
+    SET last_error = ?1
+    WHERE monitor_id = ?2 AND ended_at IS NULL
+  `,
+} as const;
+
 type CompletedDueMonitor = {
   row: DueMonitorRow;
   checkedAt: number;
@@ -93,23 +190,31 @@ type CompletedDueMonitor = {
 };
 
 async function listActiveWebhookChannels(db: D1Database): Promise<WebhookChannelWithMeta[]> {
-  const { results } = await db
-    .prepare(
-      `
-      SELECT id, name, config_json, created_at
-      FROM notification_channels
-      WHERE is_active = 1 AND type = 'webhook'
-      ORDER BY id
-    `,
-    )
-    .all<ActiveWebhookChannelRow>();
+  const cachedResult = activeWebhookChannelsCacheByDb.get(db);
+  if (
+    cachedResult &&
+    Date.now() - cachedResult.fetchedAtMs < ACTIVE_WEBHOOK_CHANNELS_CACHE_TTL_MS
+  ) {
+    return cachedResult.channels;
+  }
 
-  return (results ?? []).map((r) => ({
+  const cached = listActiveWebhookChannelsStatementByDb.get(db);
+  const statement = cached ?? db.prepare(LIST_ACTIVE_WEBHOOK_CHANNELS_SQL);
+  if (!cached) {
+    listActiveWebhookChannelsStatementByDb.set(db, statement);
+  }
+
+  const { results } = await statement.all<ActiveWebhookChannelRow>();
+
+  const channels = (results ?? []).map((r) => ({
     id: r.id,
     name: r.name,
     config: parseDbJson(webhookChannelConfigSchema, r.config_json, { field: 'config_json' }),
     created_at: r.created_at,
   }));
+
+  activeWebhookChannelsCacheByDb.set(db, { fetchedAtMs: Date.now(), channels });
+  return channels;
 }
 
 async function listMaintenanceSuppressedMonitorIds(
@@ -267,39 +372,13 @@ function toMonitorStatus(value: string | null): MonitorStatus | null {
 }
 
 async function listDueMonitors(db: D1Database, checkedAt: number): Promise<DueMonitorRow[]> {
-  const { results } = await db
-    .prepare(
-      `
-      SELECT
-        m.id,
-        m.name,
-        m.type,
-        m.target,
-        m.interval_sec,
-        m.timeout_ms,
-        m.http_method,
-        m.http_headers_json,
-        m.http_body,
-        m.expected_status_json,
-        m.response_keyword,
-        m.response_keyword_mode,
-        m.response_forbidden_keyword,
-        m.response_forbidden_keyword_mode,
-        s.status AS state_status,
-        s.last_error AS state_last_error,
-        s.last_changed_at,
-        s.consecutive_failures,
-        s.consecutive_successes
-      FROM monitors m
-      LEFT JOIN monitor_state s ON s.monitor_id = m.id
-      WHERE m.is_active = 1
-        AND (s.status IS NULL OR s.status != 'paused')
-        AND (s.last_checked_at IS NULL OR s.last_checked_at <= ?1 - m.interval_sec)
-      ORDER BY m.id
-    `,
-    )
-    .bind(checkedAt)
-    .all<DueMonitorRow>();
+  const cached = listDueMonitorsStatementByDb.get(db);
+  const statement = cached ?? db.prepare(LIST_DUE_MONITORS_SQL);
+  if (!cached) {
+    listDueMonitorsStatementByDb.set(db, statement);
+  }
+
+  const { results } = await statement.bind(checkedAt).all<DueMonitorRow>();
 
   return results ?? [];
 }
@@ -501,67 +580,17 @@ async function persistCompletedMonitors(
   db: D1Database,
   completed: CompletedDueMonitor[],
 ): Promise<void> {
-  const templates: PersistStatementTemplates = {
-    insertCheckResult: db.prepare(
-      `
-      INSERT INTO check_results (
-        monitor_id,
-        checked_at,
-        status,
-        latency_ms,
-        http_status,
-        error,
-        location,
-        attempt
-      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-    `,
-    ),
-    upsertMonitorState: db.prepare(
-      `
-      INSERT INTO monitor_state (
-        monitor_id,
-        status,
-        last_checked_at,
-        last_changed_at,
-        last_latency_ms,
-        last_error,
-        consecutive_failures,
-        consecutive_successes
-      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-      ON CONFLICT(monitor_id) DO UPDATE SET
-        status = excluded.status,
-        last_checked_at = excluded.last_checked_at,
-        last_changed_at = excluded.last_changed_at,
-        last_latency_ms = excluded.last_latency_ms,
-        last_error = excluded.last_error,
-        consecutive_failures = excluded.consecutive_failures,
-        consecutive_successes = excluded.consecutive_successes
-    `,
-    ),
-    openOutageIfMissing: db.prepare(
-      `
-      INSERT INTO outages (monitor_id, started_at, ended_at, initial_error, last_error)
-      SELECT ?1, ?2, NULL, ?3, ?4
-      WHERE NOT EXISTS (
-        SELECT 1 FROM outages WHERE monitor_id = ?5 AND ended_at IS NULL
-      )
-    `,
-    ),
-    closeOutage: db.prepare(
-      `
-      UPDATE outages
-      SET ended_at = ?1
-      WHERE monitor_id = ?2 AND ended_at IS NULL
-    `,
-    ),
-    updateOutageLastError: db.prepare(
-      `
-      UPDATE outages
-      SET last_error = ?1
-      WHERE monitor_id = ?2 AND ended_at IS NULL
-    `,
-    ),
+  const cached = persistStatementTemplatesByDb.get(db);
+  const templates = cached ?? {
+    insertCheckResult: db.prepare(PERSIST_STATEMENTS_SQL.insertCheckResult),
+    upsertMonitorState: db.prepare(PERSIST_STATEMENTS_SQL.upsertMonitorState),
+    openOutageIfMissing: db.prepare(PERSIST_STATEMENTS_SQL.openOutageIfMissing),
+    closeOutage: db.prepare(PERSIST_STATEMENTS_SQL.closeOutage),
+    updateOutageLastError: db.prepare(PERSIST_STATEMENTS_SQL.updateOutageLastError),
   };
+  if (!cached) {
+    persistStatementTemplatesByDb.set(db, templates);
+  }
 
   for (let i = 0; i < completed.length; i += PERSIST_BATCH_SIZE) {
     const chunk = completed.slice(i, i + PERSIST_BATCH_SIZE);

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -21,8 +21,6 @@ import {
 import { runTcpCheck } from '../monitor/tcp';
 import type { CheckOutcome } from '../monitor/types';
 import { dispatchWebhookToChannels, type WebhookChannel } from '../notify/webhook';
-import { computePublicHomepagePayload } from '../public/homepage';
-import { refreshPublicHomepageSnapshot } from '../snapshots';
 import { readSettings } from '../settings';
 import { acquireLease } from './lock';
 
@@ -34,6 +32,49 @@ const PERSIST_BATCH_SIZE = 25;
 
 // Look back a bit so maintenance start/end notifications are not missed if a tick is delayed.
 const MAINTENANCE_EVENT_LOOKBACK_SECONDS = 10 * 60;
+
+function normalizeSelfOrigin(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? '';
+  if (!trimmed) return null;
+
+  let out = trimmed;
+  while (out.endsWith('/')) out = out.slice(0, -1);
+  if (!out.startsWith('http://') && !out.startsWith('https://')) return null;
+  return out;
+}
+
+async function refreshHomepageSnapshotViaSelfFetch(env: Env): Promise<void> {
+  const origin = normalizeSelfOrigin(env.UPTIMER_SELF_ORIGIN);
+  if (!origin || !env.ADMIN_TOKEN) {
+    throw new Error('UPTIMER_SELF_ORIGIN or ADMIN_TOKEN missing');
+  }
+
+  const res = await fetch(`${origin}/api/v1/internal/refresh/homepage`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+    cache: 'no-store',
+    body: env.ADMIN_TOKEN,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`self refresh failed: HTTP ${res.status} ${text}`.trim());
+  }
+}
+
+async function refreshHomepageSnapshotInline(env: Env, now: number): Promise<void> {
+  const [{ computePublicHomepagePayload }, { refreshPublicHomepageSnapshot }] = await Promise.all([
+    import('../public/homepage'),
+    import('../snapshots'),
+  ]);
+
+  await refreshPublicHomepageSnapshot({
+    db: env.DB,
+    now,
+    compute: () => computePublicHomepagePayload(env.DB, now),
+  });
+}
 
 type CachedMonitorHttpJson = {
   http_headers_json: string | null;
@@ -669,16 +710,15 @@ function queueMonitorNotification(
 export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
+  const shouldSelfRefresh = normalizeSelfOrigin(env.UPTIMER_SELF_ORIGIN) !== null && !!env.ADMIN_TOKEN;
   const queueHomepageRefresh = () =>
-    refreshPublicHomepageSnapshot({
-      db: env.DB,
-      now,
-      compute: async () => {
-        return computePublicHomepagePayload(env.DB, now);
-      },
-    }).catch((err) => {
-      console.warn('homepage snapshot: refresh failed', err);
-    });
+    shouldSelfRefresh
+      ? refreshHomepageSnapshotViaSelfFetch(env).catch((err) => {
+          console.warn('homepage snapshot: self refresh failed', err);
+        })
+      : refreshHomepageSnapshotInline(env, now).catch((err) => {
+          console.warn('homepage snapshot: refresh failed', err);
+        });
 
   const acquired = await acquireLease(env.DB, LOCK_NAME, now, LOCK_LEASE_SECONDS);
   if (!acquired) {

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -310,7 +310,18 @@ function computeStateLastError(
   return outcome.status === 'up' ? null : outcome.error;
 }
 
-function buildPersistStatements(completed: CompletedDueMonitor, db: D1Database): D1PreparedStatement[] {
+type PersistStatementTemplates = {
+  insertCheckResult: D1PreparedStatement;
+  upsertMonitorState: D1PreparedStatement;
+  openOutageIfMissing: D1PreparedStatement;
+  closeOutage: D1PreparedStatement;
+  updateOutageLastError: D1PreparedStatement;
+};
+
+function buildPersistStatements(
+  completed: CompletedDueMonitor,
+  templates: PersistStatementTemplates,
+): D1PreparedStatement[] {
   const {
     row,
     checkedAt,
@@ -324,20 +335,7 @@ function buildPersistStatements(completed: CompletedDueMonitor, db: D1Database):
   const statements: D1PreparedStatement[] = [];
 
   statements.push(
-    db.prepare(
-      `
-      INSERT INTO check_results (
-        monitor_id,
-        checked_at,
-        status,
-        latency_ms,
-        http_status,
-        error,
-        location,
-        attempt
-      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-    `,
-    ).bind(
+    templates.insertCheckResult.bind(
       row.id,
       checkedAt,
       outcome.status,
@@ -350,28 +348,7 @@ function buildPersistStatements(completed: CompletedDueMonitor, db: D1Database):
   );
 
   statements.push(
-    db.prepare(
-      `
-      INSERT INTO monitor_state (
-        monitor_id,
-        status,
-        last_checked_at,
-        last_changed_at,
-        last_latency_ms,
-        last_error,
-        consecutive_failures,
-        consecutive_successes
-      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-      ON CONFLICT(monitor_id) DO UPDATE SET
-        status = excluded.status,
-        last_checked_at = excluded.last_checked_at,
-        last_changed_at = excluded.last_changed_at,
-        last_latency_ms = excluded.last_latency_ms,
-        last_error = excluded.last_error,
-        consecutive_failures = excluded.consecutive_failures,
-        consecutive_successes = excluded.consecutive_successes
-    `,
-    ).bind(
+    templates.upsertMonitorState.bind(
       row.id,
       next.status,
       checkedAt,
@@ -385,35 +362,21 @@ function buildPersistStatements(completed: CompletedDueMonitor, db: D1Database):
 
   if (outageAction === 'open') {
     statements.push(
-      db.prepare(
-        `
-        INSERT INTO outages (monitor_id, started_at, ended_at, initial_error, last_error)
-        SELECT ?1, ?2, NULL, ?3, ?4
-        WHERE NOT EXISTS (
-          SELECT 1 FROM outages WHERE monitor_id = ?5 AND ended_at IS NULL
-        )
-      `,
-      ).bind(row.id, checkedAt, checkError ?? 'down', checkError ?? 'down', row.id),
+      templates.openOutageIfMissing.bind(
+        row.id,
+        checkedAt,
+        checkError ?? 'down',
+        checkError ?? 'down',
+        row.id,
+      ),
     );
   } else if (outageAction === 'close') {
     statements.push(
-      db.prepare(
-        `
-        UPDATE outages
-        SET ended_at = ?1
-        WHERE monitor_id = ?2 AND ended_at IS NULL
-      `,
-      ).bind(checkedAt, row.id),
+      templates.closeOutage.bind(checkedAt, row.id),
     );
   } else if (outageAction === 'update' && checkError) {
     statements.push(
-      db.prepare(
-        `
-        UPDATE outages
-        SET last_error = ?1
-        WHERE monitor_id = ?2 AND ended_at IS NULL
-      `,
-      ).bind(checkError, row.id),
+      templates.updateOutageLastError.bind(checkError, row.id),
     );
   }
 
@@ -515,12 +478,74 @@ async function persistCompletedMonitors(
   db: D1Database,
   completed: CompletedDueMonitor[],
 ): Promise<void> {
+  const templates: PersistStatementTemplates = {
+    insertCheckResult: db.prepare(
+      `
+      INSERT INTO check_results (
+        monitor_id,
+        checked_at,
+        status,
+        latency_ms,
+        http_status,
+        error,
+        location,
+        attempt
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+    `,
+    ),
+    upsertMonitorState: db.prepare(
+      `
+      INSERT INTO monitor_state (
+        monitor_id,
+        status,
+        last_checked_at,
+        last_changed_at,
+        last_latency_ms,
+        last_error,
+        consecutive_failures,
+        consecutive_successes
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+      ON CONFLICT(monitor_id) DO UPDATE SET
+        status = excluded.status,
+        last_checked_at = excluded.last_checked_at,
+        last_changed_at = excluded.last_changed_at,
+        last_latency_ms = excluded.last_latency_ms,
+        last_error = excluded.last_error,
+        consecutive_failures = excluded.consecutive_failures,
+        consecutive_successes = excluded.consecutive_successes
+    `,
+    ),
+    openOutageIfMissing: db.prepare(
+      `
+      INSERT INTO outages (monitor_id, started_at, ended_at, initial_error, last_error)
+      SELECT ?1, ?2, NULL, ?3, ?4
+      WHERE NOT EXISTS (
+        SELECT 1 FROM outages WHERE monitor_id = ?5 AND ended_at IS NULL
+      )
+    `,
+    ),
+    closeOutage: db.prepare(
+      `
+      UPDATE outages
+      SET ended_at = ?1
+      WHERE monitor_id = ?2 AND ended_at IS NULL
+    `,
+    ),
+    updateOutageLastError: db.prepare(
+      `
+      UPDATE outages
+      SET last_error = ?1
+      WHERE monitor_id = ?2 AND ended_at IS NULL
+    `,
+    ),
+  };
+
   for (let i = 0; i < completed.length; i += PERSIST_BATCH_SIZE) {
     const chunk = completed.slice(i, i + PERSIST_BATCH_SIZE);
     const statements: D1PreparedStatement[] = [];
 
     for (const monitor of chunk) {
-      statements.push(...buildPersistStatements(monitor, db));
+      statements.push(...buildPersistStatements(monitor, templates));
     }
 
     if (statements.length > 0) {

--- a/apps/worker/src/settings.ts
+++ b/apps/worker/src/settings.ts
@@ -45,6 +45,22 @@ const DEFAULTS: SettingsResponse['settings'] = {
 
 type SettingsRow = { key: string; value: string };
 
+const READ_SETTINGS_SQL = 'SELECT key, value FROM settings';
+const UPSERT_SETTING_SQL = `
+  INSERT INTO settings (key, value)
+  VALUES (?1, ?2)
+  ON CONFLICT(key) DO UPDATE SET value = excluded.value
+`;
+
+const readSettingsStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
+const patchSettingsStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
+
+const SETTINGS_CACHE_TTL_MS = 60_000;
+const settingsCacheByDb = new WeakMap<
+  D1Database,
+  { fetchedAtMs: number; settings: SettingsResponse['settings'] }
+>();
+
 function parseIntSetting(
   raw: string | undefined,
   opts: { min: number; max: number },
@@ -87,7 +103,18 @@ export function parseSettingsPatch(rawBody: unknown): SettingsPatchInput {
 }
 
 export async function readSettings(db: D1Database): Promise<SettingsResponse['settings']> {
-  const { results } = await db.prepare('SELECT key, value FROM settings').all<SettingsRow>();
+  const cachedResult = settingsCacheByDb.get(db);
+  if (cachedResult && Date.now() - cachedResult.fetchedAtMs < SETTINGS_CACHE_TTL_MS) {
+    return cachedResult.settings;
+  }
+
+  const cached = readSettingsStatementByDb.get(db);
+  const statement = cached ?? db.prepare(READ_SETTINGS_SQL);
+  if (!cached) {
+    readSettingsStatementByDb.set(db, statement);
+  }
+
+  const { results } = await statement.all<SettingsRow>();
 
   const map = new Map<string, string>();
   for (const r of results ?? []) {
@@ -138,7 +165,7 @@ export async function readSettings(db: D1Database): Promise<SettingsResponse['se
     max: 5,
   }) ?? DEFAULTS.uptime_rating_level) as 1 | 2 | 3 | 4 | 5;
 
-  return {
+  const settings: SettingsResponse['settings'] = {
     site_title,
     site_description,
     site_locale,
@@ -154,29 +181,29 @@ export async function readSettings(db: D1Database): Promise<SettingsResponse['se
 
     uptime_rating_level,
   };
+
+  settingsCacheByDb.set(db, { fetchedAtMs: Date.now(), settings });
+  return settings;
 }
 
 export async function patchSettings(db: D1Database, patch: SettingsPatchInput): Promise<void> {
   const statements: D1PreparedStatement[] = [];
+
+  const cached = patchSettingsStatementByDb.get(db);
+  const statement = cached ?? db.prepare(UPSERT_SETTING_SQL);
+  if (!cached) {
+    patchSettingsStatementByDb.set(db, statement);
+  }
 
   for (const [key, value] of Object.entries(patch)) {
     if (value === undefined) continue;
 
     const strValue = typeof value === 'string' ? value : String(value);
 
-    statements.push(
-      db
-        .prepare(
-          `
-          INSERT INTO settings (key, value)
-          VALUES (?1, ?2)
-          ON CONFLICT(key) DO UPDATE SET value = excluded.value
-        `,
-        )
-        .bind(key, strValue),
-    );
+    statements.push(statement.bind(key, strValue));
   }
 
   if (statements.length === 0) return;
   await db.batch(statements);
+  settingsCacheByDb.delete(db);
 }

--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -16,6 +16,14 @@ const READ_SNAPSHOT_SQL = `
   FROM public_snapshots
   WHERE key = ?1
 `;
+const UPSERT_SNAPSHOT_SQL = `
+  INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
+  VALUES (?1, ?2, ?3, ?4)
+  ON CONFLICT(key) DO UPDATE SET
+    generated_at = excluded.generated_at,
+    body_json = excluded.body_json,
+    updated_at = excluded.updated_at
+`;
 
 const SPLIT_SNAPSHOT_VERSION = 3;
 const LEGACY_COMBINED_SNAPSHOT_VERSION = 2;
@@ -29,6 +37,7 @@ export type PublicHomepageRenderArtifact = {
 };
 
 const readSnapshotStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
+const upsertSnapshotStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -722,18 +731,13 @@ function homepageSnapshotUpsertStatement(
   bodyJson: string,
   now: number,
 ): D1PreparedStatement {
-  return db
-    .prepare(
-      `
-      INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
-      VALUES (?1, ?2, ?3, ?4)
-      ON CONFLICT(key) DO UPDATE SET
-        generated_at = excluded.generated_at,
-        body_json = excluded.body_json,
-        updated_at = excluded.updated_at
-    `,
-    )
-    .bind(key, generatedAt, bodyJson, now);
+  const cached = upsertSnapshotStatementByDb.get(db);
+  const statement = cached ?? db.prepare(UPSERT_SNAPSHOT_SQL);
+  if (!cached) {
+    upsertSnapshotStatementByDb.set(db, statement);
+  }
+
+  return statement.bind(key, generatedAt, bodyJson, now);
 }
 
 export async function writeHomepageSnapshot(

--- a/apps/worker/src/snapshots/public-status.ts
+++ b/apps/worker/src/snapshots/public-status.ts
@@ -8,8 +8,17 @@ const READ_STATUS_SQL = `
   FROM public_snapshots
   WHERE key = ?1
 `;
+const UPSERT_STATUS_SQL = `
+  INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
+  VALUES (?1, ?2, ?3, ?4)
+  ON CONFLICT(key) DO UPDATE SET
+    generated_at = excluded.generated_at,
+    body_json = excluded.body_json,
+    updated_at = excluded.updated_at
+`;
 
 const readStatusStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
+const upsertStatusStatementByDb = new WeakMap<D1Database, D1PreparedStatement>();
 
 export function getSnapshotKey() {
   return SNAPSHOT_KEY;
@@ -134,19 +143,13 @@ export async function writeStatusSnapshot(
   payload: PublicStatusResponse,
 ): Promise<void> {
   const bodyJson = JSON.stringify(payload);
-  await db
-    .prepare(
-      `
-      INSERT INTO public_snapshots (key, generated_at, body_json, updated_at)
-      VALUES (?1, ?2, ?3, ?4)
-      ON CONFLICT(key) DO UPDATE SET
-        generated_at = excluded.generated_at,
-        body_json = excluded.body_json,
-        updated_at = excluded.updated_at
-    `,
-    )
-    .bind(SNAPSHOT_KEY, payload.generated_at, bodyJson, now)
-    .run();
+  const cached = upsertStatusStatementByDb.get(db);
+  const statement = cached ?? db.prepare(UPSERT_STATUS_SQL);
+  if (!cached) {
+    upsertStatusStatementByDb.set(db, statement);
+  }
+
+  await statement.bind(SNAPSHOT_KEY, payload.generated_at, bodyJson, now).run();
 }
 
 export function applyStatusCacheHeaders(res: Response, ageSeconds: number): void {

--- a/apps/worker/test/helpers/fake-d1.ts
+++ b/apps/worker/test/helpers/fake-d1.ts
@@ -46,13 +46,15 @@ class FakePreparedStatement {
   constructor(
     private readonly sql: string,
     private readonly handlers: FakeD1QueryHandler[],
+    normalizedSql?: string,
   ) {
-    this.normalizedSql = normalizeSql(sql);
+    this.normalizedSql = normalizedSql ?? normalizeSql(sql);
   }
 
-  bind(...args: unknown[]): this {
-    this.args = args;
-    return this;
+  bind(...args: unknown[]): FakePreparedStatement {
+    const bound = new FakePreparedStatement(this.sql, this.handlers, this.normalizedSql);
+    bound.args = args;
+    return bound;
   }
 
   async all<T = unknown>(): Promise<{ results: T[] }> {

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -688,7 +688,7 @@ describe('scheduler/scheduled regression', () => {
       await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
 
       expect(errorSpy).toHaveBeenCalledWith(
-        'scheduled: 1/1 monitors failed',
+        expect.stringContaining('scheduled: 1/1 monitors failed'),
         expect.objectContaining({
           status: 'rejected',
           reason: expect.any(Error),

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -216,32 +216,25 @@ describe('scheduler/scheduled regression', () => {
     expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
   });
 
-  it('self-invokes homepage refresh when UPTIMER_SELF_ORIGIN is configured', async () => {
+  it('self-invokes homepage refresh via service binding when SELF is configured', async () => {
     const env = createEnv({ dueRows: [] }) as unknown as Env;
-    env.UPTIMER_SELF_ORIGIN = 'https://self.example.com';
     env.ADMIN_TOKEN = 'test-admin-token';
+    const selfFetch = vi.fn().mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    env.SELF = { fetch: selfFetch } as unknown as Fetcher;
     const waitUntil = vi.fn();
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
 
-    try {
-      await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
+    await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
 
-      expect(waitUntil).toHaveBeenCalledTimes(1);
-      await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        'https://self.example.com/api/v1/internal/refresh/homepage',
-        expect.objectContaining({
-          method: 'POST',
-          body: 'test-admin-token',
-        }),
-      );
-      expect(refreshPublicHomepageSnapshot).not.toHaveBeenCalled();
-    } finally {
-      fetchSpy.mockRestore();
-    }
+    expect(selfFetch).toHaveBeenCalledTimes(1);
+    const req = selfFetch.mock.calls[0]?.[0] as Request;
+    expect(req).toBeInstanceOf(Request);
+    expect(req.method).toBe('POST');
+    expect(new URL(req.url).pathname).toBe('/api/v1/internal/refresh/homepage');
+    expect(await req.text()).toBe('test-admin-token');
+    expect(refreshPublicHomepageSnapshot).not.toHaveBeenCalled();
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -16,20 +16,26 @@ vi.mock('../src/notify/webhook', () => ({
   dispatchWebhookToChannels: vi.fn(),
 }));
 vi.mock('../src/public/homepage', () => ({
-  computePublicHomepageArtifactPayload: vi.fn(),
+  homepageFromStatusPayload: vi.fn(),
+  readHomepageHistoryPreviews: vi.fn(),
+}));
+vi.mock('../src/public/status', () => ({
+  computePublicStatusPayload: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
-  refreshPublicHomepageArtifactSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
+  writeStatusSnapshot: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { runHttpCheck } from '../src/monitor/http';
 import { runTcpCheck } from '../src/monitor/tcp';
 import { dispatchWebhookToChannels } from '../src/notify/webhook';
-import { computePublicHomepageArtifactPayload } from '../src/public/homepage';
+import { homepageFromStatusPayload, readHomepageHistoryPreviews } from '../src/public/homepage';
+import { computePublicStatusPayload } from '../src/public/status';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageArtifactSnapshotIfNeeded } from '../src/snapshots';
+import { refreshPublicHomepageSnapshotIfNeeded, writeStatusSnapshot } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -137,10 +143,34 @@ describe('scheduler/scheduled regression', () => {
       uptime_rating_level: 3,
     });
     vi.mocked(dispatchWebhookToChannels).mockResolvedValue(undefined);
-    vi.mocked(computePublicHomepageArtifactPayload).mockResolvedValue({
+    vi.mocked(computePublicStatusPayload).mockResolvedValue({
+      generated_at: Math.floor(Date.now() / 1000),
+      site_title: 'Uptimer',
+      site_description: '',
+      site_locale: 'auto',
+      site_timezone: 'UTC',
+      uptime_rating_level: 3,
+      overall_status: 'up',
+      banner: {
+        source: 'monitors',
+        status: 'operational',
+        title: 'All Systems Operational',
+        down_ratio: null,
+      },
+      summary: { up: 0, down: 0, maintenance: 0, paused: 0, unknown: 0 },
+      monitors: [],
+      active_incidents: [],
+      maintenance_windows: { active: [], upcoming: [] },
+    } as never);
+    vi.mocked(writeStatusSnapshot).mockResolvedValue(undefined);
+    vi.mocked(readHomepageHistoryPreviews).mockResolvedValue({
+      resolvedIncidentPreview: null,
+      maintenanceHistoryPreview: null,
+    });
+    vi.mocked(homepageFromStatusPayload).mockReturnValue({
       generated_at: Math.floor(Date.now() / 1000),
     } as never);
-    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -183,20 +213,27 @@ describe('scheduler/scheduled regression', () => {
 
     expect(acquireLease).toHaveBeenCalledWith(env.DB, 'scheduler:tick', expectedNow, 55);
     expect(readSettings).toHaveBeenCalledTimes(1);
-    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledWith({
+    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
       compute: expect.any(Function),
     });
-    const refreshArgs = vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mock.calls[0]?.[0];
+    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
-    expect(computePublicHomepageArtifactPayload).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(computePublicStatusPayload).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(writeStatusSnapshot).toHaveBeenCalledWith(
+      env.DB,
+      expectedNow,
+      expect.objectContaining({ generated_at: expectedNow }),
+    );
+    expect(readHomepageHistoryPreviews).toHaveBeenCalledWith(env.DB, expectedNow);
+    expect(homepageFromStatusPayload).toHaveBeenCalled();
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {
-    vi.mocked(refreshPublicHomepageArtifactSnapshotIfNeeded).mockRejectedValueOnce(
+    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockRejectedValueOnce(
       new Error('snapshot refresh failed'),
     );
 
@@ -289,7 +326,7 @@ describe('scheduler/scheduled regression', () => {
     expect(runArgs[stateUpsertIndex]?.[1]).toBe('up');
     expect(runArgs[stateUpsertIndex]?.[2]).toBe(expectedCheckedAt);
 
-    expect(refreshPublicHomepageArtifactSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -16,26 +16,20 @@ vi.mock('../src/notify/webhook', () => ({
   dispatchWebhookToChannels: vi.fn(),
 }));
 vi.mock('../src/public/homepage', () => ({
-  homepageFromStatusPayload: vi.fn(),
-  readHomepageHistoryPreviews: vi.fn(),
-}));
-vi.mock('../src/public/status', () => ({
-  computePublicStatusPayload: vi.fn(),
+  computePublicHomepagePayload: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
   refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
-  writeStatusSnapshot: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
 import { runHttpCheck } from '../src/monitor/http';
 import { runTcpCheck } from '../src/monitor/tcp';
 import { dispatchWebhookToChannels } from '../src/notify/webhook';
-import { homepageFromStatusPayload, readHomepageHistoryPreviews } from '../src/public/homepage';
-import { computePublicStatusPayload } from '../src/public/status';
+import { computePublicHomepagePayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageSnapshotIfNeeded, writeStatusSnapshot } from '../src/snapshots';
+import { refreshPublicHomepageSnapshotIfNeeded } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -143,8 +137,10 @@ describe('scheduler/scheduled regression', () => {
       uptime_rating_level: 3,
     });
     vi.mocked(dispatchWebhookToChannels).mockResolvedValue(undefined);
-    vi.mocked(computePublicStatusPayload).mockResolvedValue({
+    vi.mocked(computePublicHomepagePayload).mockResolvedValue({
       generated_at: Math.floor(Date.now() / 1000),
+      bootstrap_mode: 'full',
+      monitor_count_total: 0,
       site_title: 'Uptimer',
       site_description: '',
       site_locale: 'auto',
@@ -161,14 +157,8 @@ describe('scheduler/scheduled regression', () => {
       monitors: [],
       active_incidents: [],
       maintenance_windows: { active: [], upcoming: [] },
-    } as never);
-    vi.mocked(writeStatusSnapshot).mockResolvedValue(undefined);
-    vi.mocked(readHomepageHistoryPreviews).mockResolvedValue({
-      resolvedIncidentPreview: null,
-      maintenanceHistoryPreview: null,
-    });
-    vi.mocked(homepageFromStatusPayload).mockReturnValue({
-      generated_at: Math.floor(Date.now() / 1000),
+      resolved_incident_preview: null,
+      maintenance_history_preview: null,
     } as never);
     vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
     vi.mocked(runHttpCheck).mockResolvedValue({
@@ -221,14 +211,7 @@ describe('scheduler/scheduled regression', () => {
     const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
-    expect(computePublicStatusPayload).toHaveBeenCalledWith(env.DB, expectedNow);
-    expect(writeStatusSnapshot).toHaveBeenCalledWith(
-      env.DB,
-      expectedNow,
-      expect.objectContaining({ generated_at: expectedNow }),
-    );
-    expect(readHomepageHistoryPreviews).toHaveBeenCalledWith(env.DB, expectedNow);
-    expect(homepageFromStatusPayload).toHaveBeenCalled();
+    expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -19,7 +19,7 @@ vi.mock('../src/public/homepage', () => ({
   computePublicHomepagePayload: vi.fn(),
 }));
 vi.mock('../src/snapshots', () => ({
-  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
+  refreshPublicHomepageSnapshot: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
@@ -29,7 +29,7 @@ import { dispatchWebhookToChannels } from '../src/notify/webhook';
 import { computePublicHomepagePayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../src/snapshots';
+import { refreshPublicHomepageSnapshot } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -160,7 +160,7 @@ describe('scheduler/scheduled regression', () => {
       resolved_incident_preview: null,
       maintenance_history_preview: null,
     } as never);
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageSnapshot).mockResolvedValue(undefined);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -203,12 +203,12 @@ describe('scheduler/scheduled regression', () => {
 
     expect(acquireLease).toHaveBeenCalledWith(env.DB, 'scheduler:tick', expectedNow, 55);
     expect(readSettings).toHaveBeenCalledTimes(1);
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
+    expect(refreshPublicHomepageSnapshot).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
       compute: expect.any(Function),
     });
-    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
+    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshot).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
     expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
@@ -216,7 +216,7 @@ describe('scheduler/scheduled regression', () => {
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockRejectedValueOnce(
+    vi.mocked(refreshPublicHomepageSnapshot).mockRejectedValueOnce(
       new Error('snapshot refresh failed'),
     );
 
@@ -309,7 +309,7 @@ describe('scheduler/scheduled regression', () => {
     expect(runArgs[stateUpsertIndex]?.[1]).toBe('up');
     expect(runArgs[stateUpsertIndex]?.[2]).toBe(expectedCheckedAt);
 
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageSnapshot).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -203,6 +203,8 @@ describe('scheduler/scheduled regression', () => {
 
     expect(acquireLease).toHaveBeenCalledWith(env.DB, 'scheduler:tick', expectedNow, 55);
     expect(readSettings).toHaveBeenCalledTimes(1);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
     expect(refreshPublicHomepageSnapshot).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
@@ -212,7 +214,34 @@ describe('scheduler/scheduled regression', () => {
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
     expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
-    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it('self-invokes homepage refresh when UPTIMER_SELF_ORIGIN is configured', async () => {
+    const env = createEnv({ dueRows: [] }) as unknown as Env;
+    env.UPTIMER_SELF_ORIGIN = 'https://self.example.com';
+    env.ADMIN_TOKEN = 'test-admin-token';
+    const waitUntil = vi.fn();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    try {
+      await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
+
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://self.example.com/api/v1/internal/refresh/homepage',
+        expect.objectContaining({
+          method: 'POST',
+          body: 'test-admin-token',
+        }),
+      );
+      expect(refreshPublicHomepageSnapshot).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {
@@ -309,8 +338,9 @@ describe('scheduler/scheduled regression', () => {
     expect(runArgs[stateUpsertIndex]?.[1]).toBe('up');
     expect(runArgs[stateUpsertIndex]?.[2]).toBe(expectedCheckedAt);
 
-    expect(refreshPublicHomepageSnapshot).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+    expect(refreshPublicHomepageSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it('passes explicit response assertion modes through scheduled HTTP checks', async () => {


### PR DESCRIPTION
**What**
- Split scheduled work so the homepage snapshot refresh runs in a separate invocation (avoids CPU stacking in a single cron tick).
- Use a Worker Service Binding (`env.SELF.fetch`) for internal refresh (no public self-fetch).
- Scheduler D1/JSON reuse micro-opts preserved from Dev.

**Why**
- The platform CPU limit is per-invocation; separating homepage refresh is required to keep all percentiles under budget.

**Where**
- apps/worker/src/scheduler/scheduled.ts
- apps/worker/src/scheduler/lock.ts
- apps/worker/src/monitor/http.ts
- apps/worker/src/settings.ts
- .github/workflows/deploy.yml
- apps/worker/src/env.ts

**How to verify**
- pnpm lint
- pnpm typecheck
- pnpm test

Stacking
- This PR is intentionally stacked on top of PR #63.
