### PR TITLE
dev(trace): homepage end-to-end Server-Timing

### DIFF
--- a/apps/web/public/_worker.js
+++ b/apps/web/public/_worker.js
@@ -2,10 +2,180 @@ const SNAPSHOT_MAX_AGE_SECONDS = 60;
 const PREFERRED_MAX_AGE_SECONDS = 30;
 const FALLBACK_HTML_MAX_AGE_SECONDS = 600;
 const HOMEPAGE_CACHE_GENERATED_AT_HEADER = 'X-Uptimer-Generated-At';
+const TRACE_HEADER = 'X-Uptimer-Trace';
+const TRACE_ID_HEADER = 'X-Uptimer-Trace-Id';
+const TRACE_TOKEN_HEADER = 'X-Uptimer-Trace-Token';
+const TRACE_MODE_HEADER = 'X-Uptimer-Trace-Mode';
 
 function acceptsHtml(request) {
   const accept = request.headers.get('Accept') || '';
   return accept.includes('text/html');
+}
+
+function normalizeTruthyHeader(value) {
+  if (!value) return false;
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return false;
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function resolveTraceContext(request, env) {
+  const enabled = normalizeTruthyHeader(request.headers.get(TRACE_HEADER));
+  if (!enabled) return null;
+
+  const tokenEnv = typeof env?.UPTIMER_TRACE_TOKEN === 'string' ? env.UPTIMER_TRACE_TOKEN.trim() : '';
+  const fallbackEnvToken = typeof env?.TRACE_TOKEN === 'string' ? env.TRACE_TOKEN.trim() : '';
+  const expectedToken = tokenEnv || fallbackEnvToken;
+  const providedToken = request.headers.get(TRACE_TOKEN_HEADER) || '';
+  if (expectedToken && providedToken !== expectedToken) return null;
+
+  const id = request.headers.get(TRACE_ID_HEADER) || crypto.randomUUID();
+  const modeRaw = request.headers.get(TRACE_MODE_HEADER) || '';
+  const mode = modeRaw.trim().length > 0 ? modeRaw.trim() : null;
+
+  const spans = [];
+  const labels = new Map();
+  const t0 = performance.now();
+  let finished = false;
+
+  function setLabel(key, value) {
+    if (!key) return;
+    if (value === null || value === undefined) return;
+    const str = typeof value === 'string' ? value : String(value);
+    if (!str) return;
+    labels.set(String(key), str.replace(/[;\r\n]/g, '_'));
+  }
+
+  function addSpan(name, durMs) {
+    if (!name) return;
+    spans.push({ name: String(name), durMs: Number.isFinite(durMs) ? Math.max(0, durMs) : 0 });
+  }
+
+  function time(name, fn) {
+    const tStart = performance.now();
+    const out = fn();
+    const tEnd = performance.now();
+    addSpan(name, tEnd - tStart);
+    return out;
+  }
+
+  async function timeAsync(name, fn) {
+    const tStart = performance.now();
+    try {
+      return await fn();
+    } finally {
+      const tEnd = performance.now();
+      addSpan(name, tEnd - tStart);
+    }
+  }
+
+  function finish(name = 'total') {
+    if (finished) return;
+    finished = true;
+    addSpan(name, performance.now() - t0);
+  }
+
+  function toServerTiming(prefix = 'p') {
+    const p = prefix && String(prefix).trim().length > 0 ? `${String(prefix).trim()}_` : '';
+    return spans
+      .map((span) => `${(p + span.name).replace(/[^a-zA-Z0-9_.-]/g, '_')};dur=${span.durMs.toFixed(2)}`)
+      .join(', ');
+  }
+
+  function toInfoHeader(prefix = 'p') {
+    const p = prefix && String(prefix).trim().length > 0 ? `${String(prefix).trim()}_` : '';
+    const parts = [];
+    for (const [key, value] of labels.entries()) {
+      parts.push(`${(p + key).replace(/[^a-zA-Z0-9_.-]/g, '_')}=${value}`);
+    }
+    if (mode) {
+      parts.push(`${p}mode=${mode.replace(/[;\r\n]/g, '_')}`);
+    }
+    return parts.join(';');
+  }
+
+  return {
+    id,
+    mode,
+    token: providedToken,
+    spans,
+    labels,
+    apiServerTiming: null,
+    apiInfo: null,
+    setLabel,
+    addSpan,
+    time,
+    timeAsync,
+    finish,
+    toServerTiming,
+    toInfoHeader,
+  };
+}
+
+function appendServerTiming(headers, value) {
+  if (!value) return;
+  const existing = headers.get('Server-Timing');
+  if (existing) {
+    headers.set('Server-Timing', `${existing}, ${value}`);
+  } else {
+    headers.set('Server-Timing', value);
+  }
+}
+
+function prefixServerTiming(value, prefix) {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw) return '';
+  const p = prefix && String(prefix).trim().length > 0 ? `${String(prefix).trim()}_` : '';
+  return raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const idx = part.indexOf(';');
+      if (idx <= 0) return `${p}${part}`;
+      const name = part.slice(0, idx).trim();
+      return `${p}${name}${part.slice(idx)}`;
+    })
+    .join(', ');
+}
+
+function mergeTraceInfo(targetLabels, rawInfo, prefix) {
+  const raw = typeof rawInfo === 'string' ? rawInfo.trim() : '';
+  if (!raw) return;
+  const p = prefix && String(prefix).trim().length > 0 ? `${String(prefix).trim()}_` : '';
+  for (const part of raw.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (!key || !value) continue;
+    targetLabels.set(`${p}${key}`.replace(/[^a-zA-Z0-9_.-]/g, '_'), value.replace(/[;\r\n]/g, '_'));
+  }
+}
+
+function finalizeTraceResponse(res, trace) {
+  if (!trace) return res;
+
+  // Fold API trace info into page labels before rendering headers.
+  mergeTraceInfo(trace.labels, trace.apiInfo, 'api');
+
+  trace.finish('total');
+
+  const out = new Response(res.body, res);
+  out.headers.set(TRACE_ID_HEADER, trace.id);
+
+  const info = trace.toInfoHeader('p');
+  if (info) {
+    const existing = out.headers.get(TRACE_HEADER);
+    out.headers.set(TRACE_HEADER, existing ? `${existing};${info}` : info);
+  }
+
+  appendServerTiming(out.headers, trace.toServerTiming('p'));
+  appendServerTiming(out.headers, prefixServerTiming(trace.apiServerTiming, 'api'));
+
+  return out;
 }
 
 function escapeHtml(value) {
@@ -200,7 +370,7 @@ async function fetchIndexHtml(env, url) {
   return env.ASSETS.fetch(req);
 }
 
-async function fetchPublicHomepageArtifact(env) {
+async function fetchPublicHomepageArtifact(env, trace) {
   const apiOrigin = env.UPTIMER_API_ORIGIN;
   if (typeof apiOrigin !== 'string' || apiOrigin.length === 0) return null;
 
@@ -211,14 +381,33 @@ async function fetchPublicHomepageArtifact(env) {
   const t = setTimeout(() => controller.abort(), 800);
 
   try {
-    const resp = await fetch(statusUrl.toString(), {
-      headers: { Accept: 'application/json' },
-      signal: controller.signal,
-    });
+    const headers = { Accept: 'application/json' };
+    if (trace) {
+      headers[TRACE_HEADER] = '1';
+      headers[TRACE_ID_HEADER] = trace.id;
+      if (trace.token) headers[TRACE_TOKEN_HEADER] = trace.token;
+      if (trace.mode) headers[TRACE_MODE_HEADER] = trace.mode;
+    }
+
+    const resp = trace
+      ? await trace.timeAsync('api_fetch', () =>
+          fetch(statusUrl.toString(), { headers, signal: controller.signal }),
+        )
+      : await fetch(statusUrl.toString(), { headers, signal: controller.signal });
+
+    if (trace) {
+      trace.setLabel('api_status', resp.status);
+      const serverTiming = resp.headers.get('Server-Timing');
+      if (serverTiming) trace.apiServerTiming = serverTiming;
+      const apiInfo = resp.headers.get(TRACE_HEADER);
+      if (apiInfo) trace.apiInfo = apiInfo;
+    }
 
     if (!resp.ok) return null;
 
-    const data = await resp.json();
+    const data = trace
+      ? await trace.timeAsync('api_json', () => resp.json())
+      : await resp.json();
     if (!data || typeof data !== 'object') return null;
 
     if (typeof data.preload_html !== 'string') return null;
@@ -242,6 +431,7 @@ export default {
       }
 
       const url = new URL(request.url);
+      const trace = resolveTraceContext(request, env);
 
       // HTML requests: serve SPA entry for client-side routes.
       const wantsHtml = request.method === 'GET' && acceptsHtml(request);
@@ -249,61 +439,121 @@ export default {
       // Special-case the status page for HTML injection.
       const isStatusPage = url.pathname === '/' || url.pathname === '/index.html';
       if (wantsHtml && isStatusPage) {
+        if (trace) {
+          trace.setLabel('route', 'pages/homepage');
+        }
+
         const cacheKey = new Request(url.origin + '/', { method: 'GET' });
         let cached = null;
-        try {
-          cached = await caches.default.match(cacheKey);
-        } catch {
+        if (trace && trace.mode === 'bypass-cache') {
+          trace.setLabel('cache', 'bypass');
           cached = null;
+        } else {
+          try {
+            cached = trace
+              ? await trace.timeAsync('cache_match', () => caches.default.match(cacheKey))
+              : await caches.default.match(cacheKey);
+          } catch {
+            cached = null;
+          }
         }
 
         const now = Math.floor(Date.now() / 1000);
         if (cached) {
           const cachedGeneratedAt = readGeneratedAtHeader(cached);
           if (cachedGeneratedAt === null) {
-            return cached;
+            if (trace) {
+              trace.setLabel('path', 'cache_hit_raw');
+            }
+            return finalizeTraceResponse(cached, trace);
           }
 
-        const cachedAge = Math.max(0, now - cachedGeneratedAt);
-        if (cachedAge <= SNAPSHOT_MAX_AGE_SECONDS) {
-          return buildHomepageCacheHit(cached, cachedAge);
-        }
-      }
-
-      const base = await fetchIndexHtml(env, url);
-      const html = await base.text();
-
-      const artifact = await fetchPublicHomepageArtifact(env);
-      if (!artifact) {
-        if (cached) {
-          const cachedGeneratedAt = readGeneratedAtHeader(cached);
-          if (cachedGeneratedAt === null) return cached;
-          return buildHomepageCacheHit(cached, Math.max(0, now - cachedGeneratedAt));
+          const cachedAge = Math.max(0, now - cachedGeneratedAt);
+          if (cachedAge <= SNAPSHOT_MAX_AGE_SECONDS) {
+            const hit = trace
+              ? trace.time('cache_hit_build', () => buildHomepageCacheHit(cached, cachedAge))
+              : buildHomepageCacheHit(cached, cachedAge);
+            if (trace) {
+              trace.setLabel('path', 'cache_hit');
+              trace.setLabel('age', cachedAge);
+            }
+            return finalizeTraceResponse(hit, trace);
+          }
         }
 
-        const headers = new Headers(base.headers);
-        headers.set('Content-Type', 'text/html; charset=utf-8');
-        headers.append('Vary', 'Accept');
-        headers.delete('Location');
+        const base = trace
+          ? await trace.timeAsync('index_fetch', () => fetchIndexHtml(env, url))
+          : await fetchIndexHtml(env, url);
+        const html = trace
+          ? await trace.timeAsync('index_text', () => base.text())
+          : await base.text();
 
-          return new Response(html, { status: 200, headers });
+        const artifact = await fetchPublicHomepageArtifact(env, trace);
+        if (!artifact) {
+          if (cached) {
+            const cachedGeneratedAt = readGeneratedAtHeader(cached);
+            if (cachedGeneratedAt === null) {
+              if (trace) trace.setLabel('path', 'api_fail_cache_raw');
+              return finalizeTraceResponse(cached, trace);
+            }
+            const cachedAge = Math.max(0, now - cachedGeneratedAt);
+            const hit = trace
+              ? trace.time('cache_hit_build', () => buildHomepageCacheHit(cached, cachedAge))
+              : buildHomepageCacheHit(cached, cachedAge);
+            if (trace) {
+              trace.setLabel('path', 'api_fail_cache_hit');
+              trace.setLabel('age', cachedAge);
+            }
+            return finalizeTraceResponse(hit, trace);
+          }
+
+          const headers = new Headers(base.headers);
+          headers.set('Content-Type', 'text/html; charset=utf-8');
+          headers.append('Vary', 'Accept');
+          headers.delete('Location');
+
+          if (trace) {
+            trace.setLabel('path', 'api_fail_index');
+            trace.setLabel('html_chars', html.length);
+          }
+          return finalizeTraceResponse(new Response(html, { status: 200, headers }), trace);
         }
 
         const generatedAt =
           typeof artifact.generated_at === 'number' ? artifact.generated_at : now;
         const age = Math.max(0, now - generatedAt);
 
-        let injected = html.replace(
-          '<div id="root"></div>',
-          `${artifact.preload_html}<div id="root"></div>`,
-        );
+        const snapshotInlineJson = trace
+          ? trace.time('snapshot_inline_json', () => safeJsonForInlineScript(artifact.snapshot))
+          : safeJsonForInlineScript(artifact.snapshot);
 
-        injected = injectStatusMetaTags(injected, artifact, url);
+        let injected = trace
+          ? trace.time('inject_root', () =>
+              html.replace(
+                '<div id="root"></div>',
+                `${artifact.preload_html}<div id="root"></div>`,
+              ),
+            )
+          : html.replace(
+              '<div id="root"></div>',
+              `${artifact.preload_html}<div id="root"></div>`,
+            );
 
-        injected = injected.replace(
-          '</head>',
-          `  ${HOMEPAGE_PRELOAD_STYLE_TAG}\n  <script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${safeJsonForInlineScript(artifact.snapshot)};</script>\n</head>`,
-        );
+        injected = trace
+          ? trace.time('inject_meta', () => injectStatusMetaTags(injected, artifact, url))
+          : injectStatusMetaTags(injected, artifact, url);
+
+        injected = trace
+          ? trace.time('inject_bootstrap', () =>
+              injected.replace(
+                '</head>',
+                `  ${HOMEPAGE_PRELOAD_STYLE_TAG}\n  <script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${snapshotInlineJson};</script>\n</head>`,
+              ),
+            )
+          : injected.replace(
+              '</head>',
+              `  ${HOMEPAGE_PRELOAD_STYLE_TAG}\n  <script>globalThis.__UPTIMER_INITIAL_HOMEPAGE__=${snapshotInlineJson};</script>\n</head>`,
+            );
 
         const headers = new Headers(base.headers);
         headers.set('Content-Type', 'text/html; charset=utf-8');
@@ -311,21 +561,37 @@ export default {
         headers.append('Vary', 'Accept');
         headers.delete('Location');
 
-        const resp = new Response(injected, { status: 200, headers });
+        const resp = trace
+          ? trace.time('resp_build', () => new Response(injected, { status: 200, headers }))
+          : new Response(injected, { status: 200, headers });
 
         const cacheHeaders = new Headers(headers);
         cacheHeaders.set('Cache-Control', `public, max-age=${FALLBACK_HTML_MAX_AGE_SECONDS}`);
         cacheHeaders.set(HOMEPAGE_CACHE_GENERATED_AT_HEADER, `${generatedAt}`);
         cacheHeaders.delete('Set-Cookie');
-        const cacheResp = new Response(injected, { status: 200, headers: cacheHeaders });
+        const cacheResp = trace
+          ? trace.time('cache_resp_build', () =>
+              new Response(injected, { status: 200, headers: cacheHeaders }),
+            )
+          : new Response(injected, { status: 200, headers: cacheHeaders });
 
         try {
-          ctx.waitUntil(caches.default.put(cacheKey, cacheResp).catch(() => undefined));
+          if (!trace || trace.mode !== 'bypass-cache') {
+            ctx.waitUntil(caches.default.put(cacheKey, cacheResp).catch(() => undefined));
+          } else if (trace) {
+            trace.setLabel('cache_put', 'skip');
+          }
         } catch {
           // Ignore cache write failures. The injected HTML response is still usable and
           // the worker should never throw a 1101 just because the cache rejected a put.
         }
-        return resp;
+        if (trace) {
+          trace.setLabel('path', 'inject');
+          trace.setLabel('age', age);
+          trace.setLabel('html_chars', injected.length);
+          trace.setLabel('payload_chars', snapshotInlineJson.length);
+        }
+        return finalizeTraceResponse(resp, trace);
       }
 
       // Default: serve static assets.

--- a/apps/worker/src/middleware/cache-public.ts
+++ b/apps/worker/src/middleware/cache-public.ts
@@ -1,7 +1,28 @@
 import type { MiddlewareHandler } from 'hono';
 
+import {
+  Trace,
+  TRACE_HEADER,
+  TRACE_ID_HEADER,
+  applyTraceToResponse,
+  resolveTraceOptions,
+} from '../observability/trace';
+
 function hasAuthorizationHeader(req: { header?(name: string): string | undefined }): boolean {
   return Boolean(req.header?.('Authorization'));
+}
+
+function appendVaryHeader(res: Response, value: string): void {
+  const next = value.trim();
+  if (!next) return;
+  const existing = res.headers.get('Vary');
+  if (!existing) {
+    res.headers.set('Vary', next);
+    return;
+  }
+  const parts = existing.split(',').map((part) => part.trim().toLowerCase());
+  if (parts.includes(next.toLowerCase())) return;
+  res.headers.set('Vary', `${existing}, ${next}`);
 }
 
 function buildCacheKey(url: string, origin: string | undefined): Request {
@@ -25,6 +46,15 @@ export function cachePublic(opts: {
   skipPathnames?: readonly string[];
 }): MiddlewareHandler {
   return async (c, next) => {
+    const traceOptions =
+      c.req.header(TRACE_HEADER) !== undefined
+        ? resolveTraceOptions({
+            header: (name) => c.req.header(name),
+            env: c.env as unknown as Record<string, unknown>,
+          })
+        : { enabled: false, id: '', mode: null };
+    const trace = traceOptions.enabled ? new Trace(traceOptions) : null;
+
     if (c.req.method !== 'GET' || hasAuthorizationHeader(c.req)) {
       await next();
       return;
@@ -42,8 +72,33 @@ export function cachePublic(opts: {
     const cache = await caches.open(opts.cacheName);
     const cacheKey = buildCacheKey(c.req.url, c.req.header('Origin'));
 
-    const cached = await cache.match(cacheKey);
-    if (cached) return cached;
+    const bypassCache = trace?.mode === 'bypass-cache';
+    if (!bypassCache) {
+      const matchT0 = trace ? performance.now() : 0;
+      const cached = await cache.match(cacheKey);
+      if (trace) {
+        trace.addSpan('cache_match', performance.now() - matchT0);
+      }
+      if (cached) {
+        if (trace) {
+          trace.setLabel('edge_cache', 'hit');
+          trace.finish('total');
+          const res = new Response(cached.body, cached);
+          applyTraceToResponse({ res, trace, prefix: 'edge' });
+          // Avoid caching traced responses in browser/edge layers.
+          res.headers.set('Cache-Control', 'private, no-store');
+          appendVaryHeader(res, TRACE_HEADER);
+          res.headers.set(TRACE_ID_HEADER, trace.id);
+          return res;
+        }
+        return cached;
+      }
+      if (trace) {
+        trace.setLabel('edge_cache', 'miss');
+      }
+    } else if (trace) {
+      trace.setLabel('edge_cache', 'bypass');
+    }
 
     await next();
 
@@ -61,6 +116,14 @@ export function cachePublic(opts: {
     // If the handler already set Cache-Control, keep it.
     if (!cacheControl) {
       c.res.headers.set('Cache-Control', `public, max-age=${opts.maxAgeSeconds}`);
+    }
+
+    if (trace) {
+      trace.finish('total');
+      applyTraceToResponse({ res: c.res, trace, prefix: 'edge' });
+      c.res.headers.set('Cache-Control', 'private, no-store');
+      appendVaryHeader(c.res, TRACE_HEADER);
+      return;
     }
 
     // Put into Cloudflare's cache without blocking the response.

--- a/apps/worker/src/observability/trace.ts
+++ b/apps/worker/src/observability/trace.ts
@@ -131,11 +131,11 @@ export class Trace {
     const pairs: string[] = [];
     for (const [key, value] of this.#labels.entries()) {
       const safeKey = key.replace(/[^a-zA-Z0-9_.-]/g, '_');
-      const safeValue = value.replace(/[;\\r\\n]/g, '_');
+      const safeValue = value.replace(/[;\r\n]/g, '_');
       pairs.push(`${safeKey}=${safeValue}`);
     }
     if (this.mode) {
-      pairs.push(`mode=${this.mode.replace(/[;\\r\\n]/g, '_')}`);
+      pairs.push(`mode=${this.mode.replace(/[;\r\n]/g, '_')}`);
     }
     return pairs.join(';');
   }

--- a/apps/worker/src/routes/public.ts
+++ b/apps/worker/src/routes/public.ts
@@ -36,6 +36,7 @@ import {
 
 import { AppError } from '../middleware/errors';
 import { cachePublic } from '../middleware/cache-public';
+import { Trace, applyTraceToResponse, resolveTraceOptions } from '../observability/trace';
 
 type PublicStatusSnapshotRow = {
   generated_at: number;
@@ -548,23 +549,44 @@ async function listMaintenanceWindowMonitorIdsByWindowId(
 publicRoutes.get('/status', async (c) => {
   const now = Math.floor(Date.now() / 1000);
   const includeHiddenMonitors = isAuthorizedStatusAdminRequest(c);
+  const trace = new Trace(
+    resolveTraceOptions({
+      header: (name) => c.req.header(name),
+      env: c.env as unknown as Record<string, unknown>,
+    }),
+  );
+  trace.setLabel('route', 'public/status');
+  trace.setLabel('hidden', includeHiddenMonitors);
 
   if (includeHiddenMonitors) {
-    const payload = await computePublicStatusPayload(c.env.DB, now, {
+    const payload = await trace.timeAsync('status_compute', () =>
+      computePublicStatusPayload(c.env.DB, now, {
       includeHiddenMonitors: true,
-    });
-    return applyPrivateNoStore(c.json(payload));
+      }),
+    );
+    const res = applyPrivateNoStore(c.json(payload));
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
+    return res;
   }
 
-  const snapshot = await readStatusSnapshotJson(c.env.DB, now);
+  const snapshot = await trace.timeAsync('status_snapshot_read', () =>
+    readStatusSnapshotJson(c.env.DB, now),
+  );
   if (snapshot) {
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
     applyStatusCacheHeaders(res, snapshot.age);
+    trace.setLabel('path', 'snapshot');
+    trace.setLabel('age', snapshot.age);
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
     return res;
   }
   try {
-    const payload = await computePublicStatusPayload(c.env.DB, now);
+    const payload = await trace.timeAsync('status_compute', () =>
+      computePublicStatusPayload(c.env.DB, now),
+    );
     const res = c.json(payload);
     applyStatusCacheHeaders(res, 0);
 
@@ -574,6 +596,9 @@ publicRoutes.get('/status', async (c) => {
       }),
     );
 
+    trace.setLabel('path', 'compute');
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
     return res;
   } catch (err) {
     console.warn('public status: compute failed', err);
@@ -584,6 +609,10 @@ publicRoutes.get('/status', async (c) => {
     if (stale) {
       const res = c.json(toSnapshotPayload(stale.data));
       applyStatusCacheHeaders(res, Math.min(60, stale.age));
+      trace.setLabel('path', 'stale');
+      trace.setLabel('age', stale.age);
+      trace.finish('total');
+      applyTraceToResponse({ res, trace, prefix: 'w' });
       return res;
     }
 
@@ -593,11 +622,24 @@ publicRoutes.get('/status', async (c) => {
 
 publicRoutes.get('/homepage', async (c) => {
   const now = Math.floor(Date.now() / 1000);
-  const snapshot = await readHomepageSnapshotJson(c.env.DB, now);
+  const trace = new Trace(
+    resolveTraceOptions({
+      header: (name) => c.req.header(name),
+      env: c.env as unknown as Record<string, unknown>,
+    }),
+  );
+  trace.setLabel('route', 'public/homepage');
+  const snapshot = await trace.timeAsync('homepage_snapshot_read', () =>
+    readHomepageSnapshotJson(c.env.DB, now),
+  );
   if (snapshot) {
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
+    trace.setLabel('path', 'snapshot');
+    trace.setLabel('age', snapshot.age);
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
     return res;
   }
 
@@ -608,32 +650,51 @@ publicRoutes.get('/homepage', async (c) => {
       maintenanceHistoryPreview: null,
     };
   });
-  const statusSnapshot = await readStatusSnapshot(c.env.DB, now);
+  const statusSnapshot = await trace.timeAsync('status_snapshot_read', () =>
+    readStatusSnapshot(c.env.DB, now),
+  );
   if (statusSnapshot) {
-    const payload = homepageFromStatusPayload(
-      statusSnapshot.data,
-      await historyPreviewsPromise,
+    const previews = await trace.timeAsync('homepage_previews', () => historyPreviewsPromise);
+    const payload = trace.time('homepage_compose', () =>
+      homepageFromStatusPayload(statusSnapshot.data, previews),
     );
     const res = c.json(payload);
     applyHomepageCacheHeaders(res, statusSnapshot.age);
+    trace.setLabel('path', 'status_snapshot');
+    trace.setLabel('age', statusSnapshot.age);
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
     return res;
   }
 
-  const artifactSnapshotPromise = readStaleHomepageSnapshotArtifact(c.env.DB, now);
+  const artifactSnapshotPromise = trace.timeAsync('homepage_artifact_stale_read', () =>
+    readStaleHomepageSnapshotArtifact(c.env.DB, now),
+  );
 
   try {
-    const statusPayload = await computePublicStatusPayload(c.env.DB, now);
-    const artifactSnapshot = await artifactSnapshotPromise;
+    const statusPayload = await trace.timeAsync('status_compute', () =>
+      computePublicStatusPayload(c.env.DB, now),
+    );
+    const artifactSnapshot = await trace.timeAsync('homepage_artifact_stale_wait', () =>
+      artifactSnapshotPromise,
+    );
     if (
       artifactSnapshot &&
       shouldPreferRecentHomepageArtifact({ artifact: artifactSnapshot, computed: statusPayload })
     ) {
       const res = c.json(artifactSnapshot.data.snapshot);
       applyHomepageCacheHeaders(res, Math.min(60, artifactSnapshot.age));
+      trace.setLabel('path', 'artifact_prefer');
+      trace.setLabel('age', artifactSnapshot.age);
+      trace.finish('total');
+      applyTraceToResponse({ res, trace, prefix: 'w' });
       return res;
     }
 
-    const payload = homepageFromStatusPayload(statusPayload, await historyPreviewsPromise);
+    const previews = await trace.timeAsync('homepage_previews', () => historyPreviewsPromise);
+    const payload = trace.time('homepage_compose', () =>
+      homepageFromStatusPayload(statusPayload, previews),
+    );
     const res = c.json(payload);
     applyHomepageCacheHeaders(res, 0);
 
@@ -643,18 +704,29 @@ publicRoutes.get('/homepage', async (c) => {
       }),
     );
 
+    trace.setLabel('path', 'compute');
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
     return res;
   } catch (err) {
     console.warn('public homepage: secondary status compute failed', err);
 
-    const staleHomepage = await readStaleHomepageSnapshot(c.env.DB, now);
+    const staleHomepage = await trace.timeAsync('homepage_snapshot_stale_read', () =>
+      readStaleHomepageSnapshot(c.env.DB, now),
+    );
     if (staleHomepage) {
       const res = c.json(staleHomepage.data);
       applyHomepageCacheHeaders(res, Math.min(60, staleHomepage.age));
+      trace.setLabel('path', 'stale_homepage');
+      trace.setLabel('age', staleHomepage.age);
+      trace.finish('total');
+      applyTraceToResponse({ res, trace, prefix: 'w' });
       return res;
     }
 
-    const staleStatus = await readStaleStatusSnapshot(c.env.DB, now, 10 * 60);
+    const staleStatus = await trace.timeAsync('status_snapshot_stale_read', () =>
+      readStaleStatusSnapshot(c.env.DB, now, 10 * 60),
+    );
     if (staleStatus) {
       const payload = homepageFromStatusPayload(
         toSnapshotPayload(staleStatus.data),
@@ -665,13 +737,23 @@ publicRoutes.get('/homepage', async (c) => {
       );
       const res = c.json(payload);
       applyHomepageCacheHeaders(res, Math.min(60, staleStatus.age));
+      trace.setLabel('path', 'stale_status');
+      trace.setLabel('age', staleStatus.age);
+      trace.finish('total');
+      applyTraceToResponse({ res, trace, prefix: 'w' });
       return res;
     }
 
-    const staleArtifact = await artifactSnapshotPromise;
+    const staleArtifact = await trace.timeAsync('homepage_artifact_stale_wait', () =>
+      artifactSnapshotPromise,
+    );
     if (staleArtifact) {
       const res = c.json(staleArtifact.data.snapshot);
       applyHomepageCacheHeaders(res, Math.min(60, staleArtifact.age));
+      trace.setLabel('path', 'stale_artifact');
+      trace.setLabel('age', staleArtifact.age);
+      trace.finish('total');
+      applyTraceToResponse({ res, trace, prefix: 'w' });
       return res;
     }
 
@@ -681,19 +763,40 @@ publicRoutes.get('/homepage', async (c) => {
 
 publicRoutes.get('/homepage-artifact', async (c) => {
   const now = Math.floor(Date.now() / 1000);
-  const snapshot = await readHomepageSnapshotArtifactJson(c.env.DB, now);
+  const trace = new Trace(
+    resolveTraceOptions({
+      header: (name) => c.req.header(name),
+      env: c.env as unknown as Record<string, unknown>,
+    }),
+  );
+  trace.setLabel('route', 'public/homepage-artifact');
+  const snapshot = await trace.timeAsync('homepage_artifact_read', () =>
+    readHomepageSnapshotArtifactJson(c.env.DB, now),
+  );
   if (snapshot) {
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
     applyHomepageCacheHeaders(res, snapshot.age);
+    trace.setLabel('path', 'snapshot');
+    trace.setLabel('age', snapshot.age);
+    trace.setLabel('bytes', snapshot.bodyJson.length);
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
     return res;
   }
 
-  const stale = await readStaleHomepageSnapshotArtifactJson(c.env.DB, now);
+  const stale = await trace.timeAsync('homepage_artifact_stale_read', () =>
+    readStaleHomepageSnapshotArtifactJson(c.env.DB, now),
+  );
   if (stale) {
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(stale.bodyJson);
     applyHomepageCacheHeaders(res, Math.min(60, stale.age));
+    trace.setLabel('path', 'stale');
+    trace.setLabel('age', stale.age);
+    trace.setLabel('bytes', stale.bodyJson.length);
+    trace.finish('total');
+    applyTraceToResponse({ res, trace, prefix: 'w' });
     return res;
   }
 

--- a/tools/trace-homepage.mjs
+++ b/tools/trace-homepage.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+import { performance } from 'node:perf_hooks';
+
+function parseArgs(argv) {
+  const out = { url: '', n: 60, mode: '', token: '', concurrency: 1 };
+  const rest = argv.slice(2);
+  if (rest[0] && !rest[0].startsWith('-')) {
+    out.url = rest[0];
+    rest.shift();
+  }
+  for (let i = 0; i < rest.length; i += 1) {
+    const cur = rest[i];
+    const next = rest[i + 1];
+    if (!cur) continue;
+    if (cur === '--n' && next) {
+      out.n = Number.parseInt(next, 10) || out.n;
+      i += 1;
+      continue;
+    }
+    if (cur === '--mode' && next) {
+      out.mode = next;
+      i += 1;
+      continue;
+    }
+    if (cur === '--token' && next) {
+      out.token = next;
+      i += 1;
+      continue;
+    }
+    if (cur === '--concurrency' && next) {
+      out.concurrency = Number.parseInt(next, 10) || out.concurrency;
+      i += 1;
+      continue;
+    }
+  }
+  if (!out.url) out.url = process.env.UPTIMER_TRACE_URL || '';
+  if (!out.token) out.token = process.env.UPTIMER_TRACE_TOKEN || '';
+  return out;
+}
+
+function parseServerTiming(value) {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw) return {};
+  const out = {};
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const [namePart, ...rest] = trimmed.split(';');
+    const name = (namePart || '').trim();
+    if (!name) continue;
+    let dur = null;
+    for (const it of rest) {
+      const kv = it.trim();
+      if (kv.startsWith('dur=')) {
+        const n = Number.parseFloat(kv.slice('dur='.length));
+        if (Number.isFinite(n)) dur = n;
+      }
+    }
+    if (dur !== null) out[name] = dur;
+  }
+  return out;
+}
+
+function parseKvHeader(value) {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw) return {};
+  const out = {};
+  for (const part of raw.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const v = trimmed.slice(eq + 1).trim();
+    if (!key) continue;
+    out[key] = v;
+  }
+  return out;
+}
+
+function percentile(sorted, p) {
+  if (sorted.length === 0) return null;
+  const idx = Math.max(0, Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length)));
+  return sorted[idx];
+}
+
+function formatMs(value) {
+  if (value === null || value === undefined) return '-';
+  return `${value.toFixed(2)}ms`;
+}
+
+async function run() {
+  const args = parseArgs(process.argv);
+  if (!args.url) {
+    console.error('Usage: node tools/trace-homepage.mjs <url> [--n 120] [--mode bypass-cache] [--token ...]');
+    process.exit(2);
+  }
+
+  const headers = {
+    Accept: 'text/html',
+    'X-Uptimer-Trace': '1',
+    'Cache-Control': 'no-cache',
+    Pragma: 'no-cache',
+  };
+  if (args.mode) headers['X-Uptimer-Trace-Mode'] = args.mode;
+  if (args.token) headers['X-Uptimer-Trace-Token'] = args.token;
+
+  const runs = new Array(args.n);
+
+  async function one(index) {
+    const t0 = performance.now();
+    const res = await fetch(args.url, { headers, redirect: 'follow' });
+    const t1 = performance.now();
+    const serverTiming = parseServerTiming(res.headers.get('server-timing') || '');
+    const info = parseKvHeader(res.headers.get('x-uptimer-trace') || '');
+    const traceId = res.headers.get('x-uptimer-trace-id') || '';
+    const body = await res.text();
+    return {
+      index,
+      ok: res.ok,
+      status: res.status,
+      wall_ms: t1 - t0,
+      server_timing: serverTiming,
+      info,
+      trace_id: traceId,
+      html_chars: body.length,
+    };
+  }
+
+  const concurrency = Math.max(1, Math.min(32, args.concurrency || 1));
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, args.n) }, async () => {
+      while (true) {
+        const index = cursor;
+        cursor += 1;
+        if (index >= args.n) return;
+        runs[index] = await one(index);
+      }
+    }),
+  );
+
+  const okRuns = runs.filter((r) => r.ok);
+  const groups = new Map();
+  for (const r of okRuns) {
+    const g = r.info.p_path || 'unknown';
+    const list = groups.get(g) || [];
+    list.push(r);
+    groups.set(g, list);
+  }
+
+  const allMetrics = new Set();
+  for (const r of okRuns) {
+    for (const k of Object.keys(r.server_timing)) allMetrics.add(k);
+  }
+
+  console.log(`url=${args.url}`);
+  console.log(`n=${runs.length} ok=${okRuns.length} mode=${args.mode || '-'} concurrency=${concurrency}`);
+  console.log('');
+
+  for (const [group, list] of [...groups.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    const walls = list.map((r) => r.wall_ms).sort((a, b) => a - b);
+    console.log(`[${group}] count=${list.length} wall_p50=${formatMs(percentile(walls, 50))} wall_p90=${formatMs(percentile(walls, 90))}`);
+
+    for (const metric of [...allMetrics].sort()) {
+      const values = list
+        .map((r) => r.server_timing[metric])
+        .filter((v) => typeof v === 'number')
+        .sort((a, b) => a - b);
+      if (values.length === 0) continue;
+      const p50 = percentile(values, 50);
+      const p90 = percentile(values, 90);
+      console.log(`  ${metric}: p50=${formatMs(p50)} p90=${formatMs(p90)} n=${values.length}`);
+    }
+    console.log('');
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
**What**
- Add end-to-end trace plumbing (Server-Timing + trace headers) for homepage/status.
- Add a small local tool script to generate trace requests.

**Why**
- Cloudflare only exposes coarse Metrics; this enables targeted profiling/debugging without changing user-visible UX.

**Where**
- apps/web/public/_worker.js
- apps/worker/src/middleware/cache-public.ts
- apps/worker/src/observability/trace.ts
- apps/worker/src/routes/public.ts
- tools/trace-homepage.mjs

**How to verify**
- pnpm lint
- pnpm typecheck
- pnpm test

Notes
- This PR is intentionally not part of the performance PR chain; performance changes already landed via #65.
