### PR TITLE
perf(worker): serve bounded stale homepage snapshot

### DIFF
--- a/apps/worker/src/fetch-handler.ts
+++ b/apps/worker/src/fetch-handler.ts
@@ -4,7 +4,7 @@ import type { Trace } from './observability/trace';
 import {
   applyHomepageCacheHeaders,
   readHomepageSnapshotArtifactJson,
-  readHomepageSnapshotJson,
+  readHomepageSnapshotJsonAnyAge,
   readStaleHomepageSnapshotArtifactJson,
 } from './snapshots/public-homepage-read';
 import {
@@ -15,6 +15,7 @@ import {
 
 const CORS_ALLOW_METHODS = 'GET,POST,PUT,PATCH,DELETE,OPTIONS';
 const CORS_ALLOW_HEADERS = 'Authorization,Content-Type';
+const HOMEPAGE_STALE_GRACE_SECONDS = 2 * 60;
 
 function appendVaryHeader(headers: Headers, value: string): void {
   const next = value.trim();
@@ -191,17 +192,17 @@ async function handlePublicHomepage(req: Request, env: Env, ctx: ExecutionContex
   const snapshot = trace
     ? await trace.timeAsync(
         'homepage_snapshot_read',
-        () => readHomepageSnapshotJson(env.DB, now),
+        () => readHomepageSnapshotJsonAnyAge(env.DB, now, HOMEPAGE_STALE_GRACE_SECONDS),
       )
-    : await readHomepageSnapshotJson(env.DB, now);
+    : await readHomepageSnapshotJsonAnyAge(env.DB, now, HOMEPAGE_STALE_GRACE_SECONDS);
   if (snapshot) {
     const res = new Response(snapshot.bodyJson, {
       status: 200,
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
     });
-    applyHomepageCacheHeaders(res, snapshot.age);
+    applyHomepageCacheHeaders(res, Math.min(60, snapshot.age));
     if (trace) {
-      trace.setLabel('path', 'snapshot');
+      trace.setLabel('path', snapshot.age <= 60 ? 'snapshot' : 'stale');
       trace.setLabel('age', snapshot.age);
       trace.finish('total');
       await applyTrace(res, trace, 'w');
@@ -373,4 +374,3 @@ export async function handleFetch(request: Request, env: Env, ctx: ExecutionCont
   const { fetch } = await import('./hono-app');
   return fetch(request, env, ctx);
 }
-

--- a/apps/worker/src/routes/public-hot.ts
+++ b/apps/worker/src/routes/public-hot.ts
@@ -10,7 +10,7 @@ import {
 } from '../observability/trace';
 import {
   applyHomepageCacheHeaders,
-  readHomepageSnapshotJson,
+  readHomepageSnapshotJsonAnyAge,
   readHomepageSnapshotArtifactJson,
   readStaleHomepageSnapshotArtifactJson,
 } from '../snapshots/public-homepage-read';
@@ -19,6 +19,8 @@ import {
   readStatusSnapshotJson,
   readStaleStatusSnapshotJson,
 } from '../snapshots/public-status-read';
+
+const HOMEPAGE_STALE_GRACE_SECONDS = 2 * 60;
 
 function appendVaryHeader(res: Response, value: string): void {
   const next = value.trim();
@@ -79,13 +81,13 @@ publicHotRoutes.get('/homepage', async (c) => {
   trace.setLabel('route', 'public/homepage');
 
   const snapshot = await trace.timeAsync('homepage_snapshot_read', () =>
-    readHomepageSnapshotJson(c.env.DB, now),
+    readHomepageSnapshotJsonAnyAge(c.env.DB, now, HOMEPAGE_STALE_GRACE_SECONDS),
   );
   if (snapshot) {
     c.header('Content-Type', 'application/json; charset=utf-8');
     const res = c.body(snapshot.bodyJson);
-    applyHomepageCacheHeaders(res, snapshot.age);
-    trace.setLabel('path', 'snapshot');
+    applyHomepageCacheHeaders(res, Math.min(60, snapshot.age));
+    trace.setLabel('path', snapshot.age <= 60 ? 'snapshot' : 'stale');
     trace.setLabel('age', snapshot.age);
     trace.finish('total');
     applyTraceToResponse({ res, trace, prefix: 'w' });

--- a/apps/worker/src/snapshots/public-homepage-read.ts
+++ b/apps/worker/src/snapshots/public-homepage-read.ts
@@ -105,15 +105,16 @@ export function applyHomepageCacheHeaders(res: Response, ageSeconds: number): vo
   );
 }
 
-export async function readHomepageSnapshotJson(
+export async function readHomepageSnapshotJsonAnyAge(
   db: D1Database,
   now: number,
+  maxStaleSeconds = MAX_STALE_SECONDS,
 ): Promise<{ bodyJson: string; age: number } | null> {
   const row = await readSnapshotRow(db, SNAPSHOT_KEY);
   if (!row) return null;
 
   const age = Math.max(0, now - row.generated_at);
-  if (age > MAX_AGE_SECONDS) return null;
+  if (age > maxStaleSeconds) return null;
 
   if (looksLikeSerializedHomepagePayload(row.body_json)) {
     return { bodyJson: row.body_json, age };
@@ -138,6 +139,13 @@ export async function readHomepageSnapshotJson(
 
   console.warn('homepage snapshot: invalid payload');
   return null;
+}
+
+export async function readHomepageSnapshotJson(
+  db: D1Database,
+  now: number,
+): Promise<{ bodyJson: string; age: number } | null> {
+  return await readHomepageSnapshotJsonAnyAge(db, now, MAX_AGE_SECONDS);
 }
 
 export async function readHomepageSnapshotArtifactJson(

--- a/apps/worker/test/public-homepage-routes.test.ts
+++ b/apps/worker/test/public-homepage-routes.test.ts
@@ -320,6 +320,32 @@ describe('public homepage route', () => {
     expect(dbReads).toEqual(['homepage', 'homepage', 'homepage']);
   });
 
+  it('serves a slightly stale homepage snapshot via the worker hot path', async () => {
+    const payload = samplePayload(139);
+    const dbReads: string[] = [];
+    vi.spyOn(Date, 'now').mockReturnValue(200 * 1000);
+
+    const res = await requestHomepageViaApp('/api/v1/public/homepage', [
+      {
+        match: 'from public_snapshots',
+        first: (args) => {
+          dbReads.push(String(args[0]));
+          return args[0] === 'homepage'
+            ? {
+                generated_at: payload.generated_at,
+                body_json: JSON.stringify(payload),
+              }
+            : null;
+        },
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(payload);
+    expect(dbReads).toEqual(['homepage']);
+    expect(res.headers.get('Cache-Control')).toContain('max-age=0');
+  });
+
   it('falls back to the fresh public status snapshot when the full homepage snapshot is missing', async () => {
     const now = 200;
     vi.spyOn(Date, 'now').mockReturnValue(now * 1000);


### PR DESCRIPTION
## What
- Serve `/api/v1/public/homepage` from a bounded stale snapshot (<= 120s) instead of falling back to live compute when snapshot age briefly exceeds 60s.
- Keep `Cache-Control` conservative on stale responses (`max-age=0`) so clients revalidate quickly.

## Why
- Prod trace sampling shows occasional `path=compute` on `/public/homepage` when `age` crosses 60s due to refresh drift, which is a likely source of CPU P90 outliers.
- Serving a slightly stale snapshot preserves UX/data payload shape while avoiding the expensive compute + routing fallback on the hottest path.

## Where
- `apps/worker/src/snapshots/public-homepage-read.ts`
- `apps/worker/src/fetch-handler.ts`
- `apps/worker/src/routes/public-hot.ts`
- `apps/worker/test/public-homepage-routes.test.ts`

## How to verify
- `pnpm test`
- Trace: `curl -D - -o /dev/null -H "X-Uptimer-Trace: 1" "https://uptimer.vrcao.workers.dev/api/v1/public/homepage"` and confirm `path=stale` (not `compute`) when `age` is > 60.
