### PR TITLE
perf(worker): enable wrangler minify

### DIFF
--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -1,6 +1,7 @@
 name = "uptimer"
 main = "src/index.ts"
 compatibility_date = "2026-01-28"
+minify = true
 
 [triggers]
 crons = ["* * * * *", "0 0 * * *"]


### PR DESCRIPTION
## What
- Enable Wrangler bundling minification for the Worker (`minify = true`).

## Why
- P90 CPU is still above budget; a likely contributor is cold-start/parse+compile cost.
- Minification materially reduces bundle size, which should reduce cold-start CPU.
- Local `wrangler deploy --dry-run` size comparison:
  - without minify: ~834.23 KiB (gzip 145.75 KiB)
  - with minify: ~369.45 KiB (gzip 95.82 KiB)

## Where
- `apps/worker/wrangler.toml`

## Trade-offs
- Stack traces are less readable.

## How to verify
- CI: `pnpm test`
- Prod: watch Workers CPU P90 after deploy.
