### PR TITLE
revert: inline homepage refresh

### DIFF
--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -33,14 +33,37 @@ const PERSIST_BATCH_SIZE = 25;
 // Look back a bit so maintenance start/end notifications are not missed if a tick is delayed.
 const MAINTENANCE_EVENT_LOOKBACK_SECONDS = 10 * 60;
 
+async function refreshHomepageSnapshotViaService(env: Env): Promise<void> {
+  if (!env.SELF) {
+    throw new Error('SELF service binding missing');
+  }
+  if (!env.ADMIN_TOKEN) {
+    throw new Error('ADMIN_TOKEN missing');
+  }
+
+  const res = await env.SELF.fetch(
+    new Request('http://internal/api/v1/internal/refresh/homepage', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+      body: env.ADMIN_TOKEN,
+    }),
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`service refresh failed: HTTP ${res.status} ${text}`.trim());
+  }
+}
+
 async function refreshHomepageSnapshotInline(env: Env, now: number): Promise<void> {
-  const [{ computePublicHomepagePayload }, { refreshPublicHomepageSnapshotIfNeeded }] =
-    await Promise.all([
+  const [{ computePublicHomepagePayload }, { refreshPublicHomepageSnapshot }] = await Promise.all([
     import('../public/homepage'),
-    import('../snapshots/public-homepage'),
+    import('../snapshots'),
   ]);
 
-  await refreshPublicHomepageSnapshotIfNeeded({
+  await refreshPublicHomepageSnapshot({
     db: env.DB,
     now,
     compute: () => computePublicHomepagePayload(env.DB, now),
@@ -682,9 +705,16 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
   const now = Math.floor(Date.now() / 1000);
   const checkedAt = Math.floor(now / 60) * 60;
   const queueHomepageRefresh = () =>
-    refreshHomepageSnapshotInline(env, now).catch((err) => {
-      console.warn('homepage snapshot: refresh failed', err);
-    });
+    env.SELF
+      ? refreshHomepageSnapshotViaService(env).catch(async (err) => {
+          console.warn('homepage snapshot: service refresh failed', err);
+          await refreshHomepageSnapshotInline(env, now).catch((fallbackErr) => {
+            console.warn('homepage snapshot: refresh failed', fallbackErr);
+          });
+        })
+      : refreshHomepageSnapshotInline(env, now).catch((err) => {
+          console.warn('homepage snapshot: refresh failed', err);
+        });
 
   const acquired = await acquireLease(env.DB, LOCK_NAME, now, LOCK_LEASE_SECONDS);
   if (!acquired) {

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -18,8 +18,8 @@ vi.mock('../src/notify/webhook', () => ({
 vi.mock('../src/public/homepage', () => ({
   computePublicHomepagePayload: vi.fn(),
 }));
-vi.mock('../src/snapshots/public-homepage', () => ({
-  refreshPublicHomepageSnapshotIfNeeded: vi.fn(),
+vi.mock('../src/snapshots', () => ({
+  refreshPublicHomepageSnapshot: vi.fn(),
 }));
 
 import type { Env } from '../src/env';
@@ -29,7 +29,7 @@ import { dispatchWebhookToChannels } from '../src/notify/webhook';
 import { computePublicHomepagePayload } from '../src/public/homepage';
 import { runScheduledTick } from '../src/scheduler/scheduled';
 import { acquireLease } from '../src/scheduler/lock';
-import { refreshPublicHomepageSnapshotIfNeeded } from '../src/snapshots/public-homepage';
+import { refreshPublicHomepageSnapshot } from '../src/snapshots';
 import { readSettings } from '../src/settings';
 import { createFakeD1Database, type FakeD1QueryHandler } from './helpers/fake-d1';
 
@@ -160,7 +160,7 @@ describe('scheduler/scheduled regression', () => {
       resolved_incident_preview: null,
       maintenance_history_preview: null,
     } as never);
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockResolvedValue(false);
+    vi.mocked(refreshPublicHomepageSnapshot).mockResolvedValue(undefined);
     vi.mocked(runHttpCheck).mockResolvedValue({
       status: 'up',
       latencyMs: 21,
@@ -205,19 +205,40 @@ describe('scheduler/scheduled regression', () => {
     expect(readSettings).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
     await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledWith({
+    expect(refreshPublicHomepageSnapshot).toHaveBeenCalledWith({
       db: env.DB,
       now: expectedNow,
       compute: expect.any(Function),
     });
-    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mock.calls[0]?.[0];
+    const refreshArgs = vi.mocked(refreshPublicHomepageSnapshot).mock.calls[0]?.[0];
     expect(refreshArgs).toBeDefined();
     await refreshArgs?.compute();
     expect(computePublicHomepagePayload).toHaveBeenCalledWith(env.DB, expectedNow);
   });
 
+  it('self-invokes homepage refresh via service binding when SELF is configured', async () => {
+    const env = createEnv({ dueRows: [] }) as unknown as Env;
+    env.ADMIN_TOKEN = 'test-admin-token';
+    const selfFetch = vi.fn().mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    env.SELF = { fetch: selfFetch } as unknown as Fetcher;
+    const waitUntil = vi.fn();
+
+    await runScheduledTick(env, { waitUntil } as unknown as ExecutionContext);
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+
+    expect(selfFetch).toHaveBeenCalledTimes(1);
+    const req = selfFetch.mock.calls[0]?.[0] as Request;
+    expect(req).toBeInstanceOf(Request);
+    expect(req.method).toBe('POST');
+    expect(new URL(req.url).pathname).toBe('/api/v1/internal/refresh/homepage');
+    expect(await req.text()).toBe('test-admin-token');
+    expect(refreshPublicHomepageSnapshot).not.toHaveBeenCalled();
+  });
+
   it('logs homepage snapshot refresh failures without breaking the tick', async () => {
-    vi.mocked(refreshPublicHomepageSnapshotIfNeeded).mockRejectedValueOnce(
+    vi.mocked(refreshPublicHomepageSnapshot).mockRejectedValueOnce(
       new Error('snapshot refresh failed'),
     );
 
@@ -312,7 +333,7 @@ describe('scheduler/scheduled regression', () => {
 
     expect(waitUntil).toHaveBeenCalledTimes(1);
     await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
-    expect(refreshPublicHomepageSnapshotIfNeeded).toHaveBeenCalledTimes(1);
+    expect(refreshPublicHomepageSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it('passes explicit response assertion modes through scheduled HTTP checks', async () => {


### PR DESCRIPTION
## Why

After merging #70, `scheduled * * * * *` CPU jumped to ~18–21ms (Tail `cpuTime`), which is a clear regression relative to the prior split model (scheduled ~8ms + internal refresh ~13–16ms).

Inline refresh is not viable under the 10ms CPU target.

## What

- Revert #70 (restore service-binding based homepage refresh + inline fallback).

## How to verify

- `pnpm --filter @uptimer/worker test`
- After deploy: Tail should again show `fetch /api/v1/internal/refresh/homepage` and scheduled tick CPU should drop back near the previous baseline.
