### PR TITLE
perf(homepage): avoid double stringify in artifact snapshot

### DIFF
--- a/apps/worker/src/snapshots/public-homepage.ts
+++ b/apps/worker/src/snapshots/public-homepage.ts
@@ -315,17 +315,14 @@ export function buildHomepageRenderArtifact(
   const allMonitorNames = needsMonitorNames
     ? new Map(snapshot.monitors.map((monitor) => [monitor.id, monitor.name]))
     : undefined;
-  const bootstrapSnapshot =
+  const bootstrapSnapshot: PublicHomepageResponse =
     snapshot.bootstrap_mode === 'partial' || snapshot.monitors.length > MAX_BOOTSTRAP_MONITORS
       ? {
           ...snapshot,
           bootstrap_mode: 'partial' as const,
           monitors: snapshot.monitors.slice(0, MAX_BOOTSTRAP_MONITORS),
         }
-      : {
-          ...snapshot,
-          bootstrap_mode: 'full' as const,
-        };
+      : snapshot;
   const metaTitle = normalizeSnapshotText(snapshot.site_title, 'Uptimer');
   const fallbackDescription = normalizeSnapshotText(
     snapshot.banner.title,
@@ -342,6 +339,19 @@ export function buildHomepageRenderArtifact(
     meta_title: metaTitle,
     meta_description: metaDescription,
   };
+}
+
+function buildHomepageRenderArtifactBodyJson(opts: {
+  fullSnapshot: PublicHomepageResponse;
+  render: PublicHomepageRenderArtifact;
+  snapshotBodyJson: string | null;
+}): string {
+  const snapshotJson =
+    opts.snapshotBodyJson && opts.render.snapshot === opts.fullSnapshot
+      ? opts.snapshotBodyJson
+      : JSON.stringify(opts.render.snapshot);
+
+  return `{"generated_at":${opts.render.generated_at},"preload_html":${JSON.stringify(opts.render.preload_html)},"snapshot":${snapshotJson},"meta_title":${JSON.stringify(opts.render.meta_title)},"meta_description":${JSON.stringify(opts.render.meta_description)}}`;
 }
 
 function looksLikeHomepagePayload(value: unknown): value is PublicHomepageResponse {
@@ -747,7 +757,11 @@ export async function writeHomepageSnapshot(
 ): Promise<void> {
   const render = buildHomepageRenderArtifact(payload);
   const dataBodyJson = JSON.stringify(payload);
-  const renderBodyJson = JSON.stringify(render);
+  const renderBodyJson = buildHomepageRenderArtifactBodyJson({
+    fullSnapshot: payload,
+    render,
+    snapshotBodyJson: dataBodyJson,
+  });
 
   await db.batch([
     homepageSnapshotUpsertStatement(db, SNAPSHOT_KEY, payload.generated_at, dataBodyJson, now),
@@ -767,7 +781,11 @@ export async function writeHomepageArtifactSnapshot(
   payload: PublicHomepageResponse,
 ): Promise<void> {
   const render = buildHomepageRenderArtifact(payload);
-  const renderBodyJson = JSON.stringify(render);
+  const renderBodyJson = buildHomepageRenderArtifactBodyJson({
+    fullSnapshot: payload,
+    render,
+    snapshotBodyJson: null,
+  });
 
   await homepageSnapshotUpsertStatement(
     db,


### PR DESCRIPTION
## What
- Build the `homepage:artifact` JSON with a lightweight string builder that reuses the already-serialized homepage snapshot JSON, avoiding a second deep `JSON.stringify()` of the snapshot object.
- Avoid cloning the snapshot object when no bootstrap truncation is needed.

## Why
- The internal `/api/v1/internal/refresh/homepage` path is CPU-dominant at P90+. The refresh writes both `homepage` and `homepage:artifact`; serializing the snapshot twice is pure CPU overhead.
- This keeps UX/data identical while reducing refresh CPU.

## Where
- apps/worker/src/snapshots/public-homepage.ts

## How to verify
- Local: `pnpm lint && pnpm typecheck && pnpm test`
- Prod: watch Workers Metrics CPU P90 and `wrangler tail` samples for `POST /api/v1/internal/refresh/homepage`.