### PR TITLE
Consolidate Cloudflare Cron triggers

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -287,7 +287,9 @@ function parseInternalRefreshRuntimeUpdates(
   return runtimeUpdates ? { runtime_updates: runtimeUpdates } : null;
 }
 
-function parseInternalScheduledCheckBatchBody(value: unknown): InternalScheduledCheckBatchBody | null {
+function parseInternalScheduledCheckBatchBody(
+  value: unknown,
+): InternalScheduledCheckBatchBody | null {
   if (!isRecord(value)) {
     return null;
   }
@@ -315,10 +317,7 @@ function parseInternalScheduledCheckBatchBody(value: unknown): InternalScheduled
   ) {
     return null;
   }
-  if (
-    value.allow_notifications !== undefined &&
-    typeof value.allow_notifications !== 'boolean'
-  ) {
+  if (value.allow_notifications !== undefined && typeof value.allow_notifications !== 'boolean') {
     return null;
   }
 
@@ -430,13 +429,17 @@ async function handleInternalHomepageRefresh(request: Request, env: Env): Promis
 
   if (trace?.enabled && traceResidualDetails) {
     trace.setLabel('request_content_length', request.headers.get('Content-Length') ?? 'unknown');
-    trace.setLabel('internal_format', wantsCompactInternalFormat(request) ? 'compact-v1' : 'default');
+    trace.setLabel(
+      'internal_format',
+      wantsCompactInternalFormat(request) ? 'compact-v1' : 'default',
+    );
   }
 
   if (contentType.includes('application/json')) {
     const rawBody = detailTrace
-      ? await detailTrace.timeAsync('homepage_refresh_body_json_read', async () =>
-          await request.json().catch(() => null),
+      ? await detailTrace.timeAsync(
+          'homepage_refresh_body_json_read',
+          async () => await request.json().catch(() => null),
         )
       : await request.json().catch(() => null);
     const parseBody = () =>
@@ -507,9 +510,7 @@ async function handleInternalShardedPublicSnapshotAssemble(
     return new Response('Bad Request', { status: 400 });
   }
 
-  const { assembleShardedPublicSnapshot } = await import(
-    './internal/sharded-public-snapshot-core'
-  );
+  const { assembleShardedPublicSnapshot } = await import('./internal/sharded-public-snapshot-core');
   const canPublish =
     parsed.data.publish &&
     normalizeTruthyHeader(env.UPTIMER_PUBLIC_SHARDED_SNAPSHOT_PUBLISH ?? null);
@@ -572,9 +573,8 @@ async function handleInternalShardedPublicSnapshotSeed(
     return new Response('Bad Request', { status: 400 });
   }
 
-  const { seedShardedPublicSnapshotFragments } = await import(
-    './internal/sharded-public-snapshot-core'
-  );
+  const { seedShardedPublicSnapshotFragments } =
+    await import('./internal/sharded-public-snapshot-core');
   const result = await seedShardedPublicSnapshotFragments({
     env,
     kind: parsed.data.kind,
@@ -627,40 +627,40 @@ async function handleInternalShardedPublicSnapshotContinuation(
     return new Response('Bad Request', { status: 400 });
   }
 
-  const { runShardedPublicSnapshotContinuation } = await import(
-    './internal/sharded-public-snapshot-continuation'
-  );
+  const { runShardedPublicSnapshotContinuation } =
+    await import('./internal/sharded-public-snapshot-continuation');
   const result = await runShardedPublicSnapshotContinuation({
     env,
     ctx,
     now: Math.floor(Date.now() / 1000),
-    step: parsed.data.step === 'runtime'
-      ? {
-          step: 'runtime',
-          ...(parsed.data.update_offset !== undefined
-            ? { updateOffset: parsed.data.update_offset }
-            : {}),
-          ...(parsed.data.update_limit !== undefined
-            ? { updateLimit: parsed.data.update_limit }
-            : {}),
-        }
-      : parsed.data.step === 'assemble'
-        ? { step: 'assemble', kind: parsed.data.kind }
-        : parsed.data.step === 'artifact'
-          ? {
-              step: 'artifact',
-              kind: 'homepage',
-              ...(parsed.data.generated_at !== undefined
-                ? { generatedAt: parsed.data.generated_at }
-                : {}),
-            }
-          : {
-              step: 'seed',
-              kind: parsed.data.kind,
-              part: parsed.data.part,
-              monitorOffset: parsed.data.monitor_offset,
-              monitorLimit: parsed.data.monitor_limit,
-            },
+    step:
+      parsed.data.step === 'runtime'
+        ? {
+            step: 'runtime',
+            ...(parsed.data.update_offset !== undefined
+              ? { updateOffset: parsed.data.update_offset }
+              : {}),
+            ...(parsed.data.update_limit !== undefined
+              ? { updateLimit: parsed.data.update_limit }
+              : {}),
+          }
+        : parsed.data.step === 'assemble'
+          ? { step: 'assemble', kind: parsed.data.kind }
+          : parsed.data.step === 'artifact'
+            ? {
+                step: 'artifact',
+                kind: 'homepage',
+                ...(parsed.data.generated_at !== undefined
+                  ? { generatedAt: parsed.data.generated_at }
+                  : {}),
+              }
+            : {
+                step: 'seed',
+                kind: parsed.data.kind,
+                part: parsed.data.part,
+                monitorOffset: parsed.data.monitor_offset,
+                monitorLimit: parsed.data.monitor_limit,
+              },
   });
   const toResponseStep = (step: NonNullable<typeof result.nextStep>) =>
     step.step === 'runtime'
@@ -795,9 +795,8 @@ async function handleInternalRuntimeFragmentsRefresh(
     return new Response('Payload Too Large', { status: 413 });
   }
 
-  const { refreshMonitorRuntimeSnapshotFromUpdateFragments } = await import(
-    './internal/runtime-fragments-refresh-core'
-  );
+  const { refreshMonitorRuntimeSnapshotFromUpdateFragments } =
+    await import('./internal/runtime-fragments-refresh-core');
   const result = await refreshMonitorRuntimeSnapshotFromUpdateFragments({
     env,
     now: Math.floor(Date.now() / 1000),
@@ -884,29 +883,30 @@ async function handleInternalScheduledCheckBatch(
   const trustSchedulerLease = normalizeTruthyHeader(
     env.UPTIMER_INTERNAL_CHECK_BATCH_TRUST_SCHEDULER_LEASE ?? null,
   );
-  const [{ runExclusivePersistedMonitorBatch }, notificationsModule] = await timeInternalCheckBatchDiagnostic(
-    diagnosticsEnabled,
-    diagnosticsTimings,
-    'imports',
-    async () =>
-      await (trace
-        ? trace.timeAsync(
-            'check_batch_import_modules',
-            async () =>
-              await Promise.all([
-                import('./scheduler/scheduled'),
-                parsedBody.allow_notifications === true
-                  ? import('./scheduler/notifications')
-                  : Promise.resolve(null),
-              ]),
-          )
-        : Promise.all([
-            import('./scheduler/scheduled'),
-            parsedBody.allow_notifications === true
-              ? import('./scheduler/notifications')
-              : Promise.resolve(null),
-          ])),
-  );
+  const [{ runExclusivePersistedMonitorBatch }, notificationsModule] =
+    await timeInternalCheckBatchDiagnostic(
+      diagnosticsEnabled,
+      diagnosticsTimings,
+      'imports',
+      async () =>
+        await (trace
+          ? trace.timeAsync(
+              'check_batch_import_modules',
+              async () =>
+                await Promise.all([
+                  import('./scheduler/scheduled'),
+                  parsedBody.allow_notifications === true
+                    ? import('./scheduler/notifications')
+                    : Promise.resolve(null),
+                ]),
+            )
+          : Promise.all([
+              import('./scheduler/scheduled'),
+              parsedBody.allow_notifications === true
+                ? import('./scheduler/notifications')
+                : Promise.resolve(null),
+            ])),
+    );
 
   const notify = notificationsModule
     ? await timeInternalCheckBatchDiagnostic(
@@ -953,22 +953,32 @@ async function handleInternalScheduledCheckBatch(
   } catch (err) {
     if (err instanceof LeaseLostError) {
       console.warn(err.message);
-      return finalizeInternalCheckBatchResponse(new Response('Service Unavailable', {
-        status: 503,
+      return finalizeInternalCheckBatchResponse(
+        new Response('Service Unavailable', {
+          status: 503,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Cache-Control': 'no-store',
+          },
+        }),
+        trace,
+        traceMod,
+        { ok: false },
+      );
+    }
+    console.error('internal scheduled check batch failed', err);
+    return finalizeInternalCheckBatchResponse(
+      new Response('Internal Server Error', {
+        status: 500,
         headers: {
           'Content-Type': 'text/plain; charset=utf-8',
           'Cache-Control': 'no-store',
         },
-      }), trace, traceMod, { ok: false });
-    }
-    console.error('internal scheduled check batch failed', err);
-    return finalizeInternalCheckBatchResponse(new Response('Internal Server Error', {
-      status: 500,
-      headers: {
-        'Content-Type': 'text/plain; charset=utf-8',
-        'Cache-Control': 'no-store',
-      },
-    }), trace, traceMod, { ok: false, error: true });
+      }),
+      trace,
+      traceMod,
+      { ok: false, error: true },
+    );
   }
 
   const monitorUpdateFragmentWritesEnabled = normalizeTruthyHeader(
@@ -1061,16 +1071,18 @@ async function handleInternalScheduledCheckBatch(
     checksDurMs: result.checksDurMs,
     persistDurMs: result.persistDurMs,
   });
-  return finalizeInternalCheckBatchResponse(new Response(
-    bodyText,
-    {
+  return finalizeInternalCheckBatchResponse(
+    new Response(bodyText, {
       status: 200,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
         'Cache-Control': 'no-store',
       },
-    },
-  ), trace, traceMod, { ok: true });
+    }),
+    trace,
+    traceMod,
+    { ok: true },
+  );
 }
 
 export default {
@@ -1102,14 +1114,46 @@ export default {
     return mod.handleFetch(request, env, ctx);
   },
   scheduled: async (controller: ScheduledController, env: Env, ctx: ExecutionContext) => {
-    if (controller.cron === '0 0 * * *') {
-      const { runDailyRollup } = await import('./scheduler/daily-rollup');
-      await runDailyRollup(env, controller, ctx);
-      return;
+    const scheduledAt = controller.scheduledTime ?? Date.now();
+    const scheduledDate = new Date(scheduledAt);
+    const isConsolidatedMinuteCron = controller.cron === '* * * * *';
+    const isLegacyDailyRollupCron = controller.cron === '0 0 * * *';
+    const isLegacyRetentionCron = controller.cron === '30 0 * * *';
+    const shouldRunDailyRollup =
+      isLegacyDailyRollupCron ||
+      (isConsolidatedMinuteCron &&
+        scheduledDate.getUTCHours() === 0 &&
+        scheduledDate.getUTCMinutes() === 0);
+    const shouldRunRetention =
+      isLegacyRetentionCron ||
+      (isConsolidatedMinuteCron &&
+        scheduledDate.getUTCHours() === 0 &&
+        scheduledDate.getUTCMinutes() === 30);
+
+    // Keep legacy cron branches during Cloudflare's trigger propagation window,
+    // but only the consolidated minute cron runs the monitor tick.
+    if (shouldRunDailyRollup) {
+      ctx.waitUntil(
+        (async () => {
+          const { runDailyRollup } = await import('./scheduler/daily-rollup');
+          await runDailyRollup(env, controller, ctx);
+        })().catch((err) => {
+          console.error('scheduled: daily rollup failed', err);
+        }),
+      );
     }
-    if (controller.cron === '30 0 * * *') {
-      const { runRetention } = await import('./scheduler/retention');
-      await runRetention(env, controller);
+    if (shouldRunRetention) {
+      ctx.waitUntil(
+        (async () => {
+          const { runRetention } = await import('./scheduler/retention');
+          await runRetention(env, controller);
+        })().catch((err) => {
+          console.error('scheduled: retention failed', err);
+        }),
+      );
+    }
+
+    if (isLegacyDailyRollupCron || isLegacyRetentionCron) {
       return;
     }
 

--- a/apps/worker/test/index-scheduled.test.ts
+++ b/apps/worker/test/index-scheduled.test.ts
@@ -19,53 +19,108 @@ vi.mock('../src/scheduler/scheduled', () => ({
 import worker from '../src/index';
 import type { Env } from '../src/env';
 
+function createExecutionContext(): {
+  ctx: ExecutionContext;
+  waitUntil: ReturnType<typeof vi.fn>;
+  waitUntilPromises: Promise<unknown>[];
+} {
+  const waitUntilPromises: Promise<unknown>[] = [];
+  const waitUntil = vi.fn((promise: Promise<unknown>) => {
+    waitUntilPromises.push(promise);
+  });
+  return {
+    ctx: { waitUntil } as unknown as ExecutionContext,
+    waitUntil,
+    waitUntilPromises,
+  };
+}
+
 describe('worker scheduled dispatch', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('runs daily rollup on the midnight cron only', async () => {
-    const controller = {
-      cron: '0 0 * * *',
-      scheduledTime: Date.UTC(2026, 1, 18, 0, 0, 0),
-    } as ScheduledController;
-    const env = {} as Env;
-    const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
-
-    await worker.scheduled(controller, env, ctx);
-
-    expect(runDailyRollup).toHaveBeenCalledWith(env, controller, ctx);
-    expect(runRetention).not.toHaveBeenCalled();
-    expect(runScheduledTick).not.toHaveBeenCalled();
-  });
-
-  it('runs retention on the separate post-midnight cron only', async () => {
-    const controller = {
-      cron: '30 0 * * *',
-      scheduledTime: Date.UTC(2026, 1, 18, 0, 30, 0),
-    } as ScheduledController;
-    const env = {} as Env;
-    const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
-
-    await worker.scheduled(controller, env, ctx);
-
-    expect(runRetention).toHaveBeenCalledWith(env, controller);
-    expect(runDailyRollup).not.toHaveBeenCalled();
-    expect(runScheduledTick).not.toHaveBeenCalled();
-  });
-
-  it('runs the minute scheduler for non-daily crons', async () => {
+  it('runs only the minute scheduler for ordinary consolidated cron ticks', async () => {
     const controller = {
       cron: '* * * * *',
       scheduledTime: Date.UTC(2026, 1, 18, 0, 1, 0),
     } as ScheduledController;
     const env = {} as Env;
-    const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
+    const { ctx, waitUntil } = createExecutionContext();
 
     await worker.scheduled(controller, env, ctx);
 
     expect(runScheduledTick).toHaveBeenCalledWith(env, ctx);
     expect(runDailyRollup).not.toHaveBeenCalled();
     expect(runRetention).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it('queues daily rollup at UTC midnight on the consolidated minute cron', async () => {
+    const controller = {
+      cron: '* * * * *',
+      scheduledTime: Date.UTC(2026, 1, 18, 0, 0, 0),
+    } as ScheduledController;
+    const env = {} as Env;
+    const { ctx, waitUntil, waitUntilPromises } = createExecutionContext();
+
+    await worker.scheduled(controller, env, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(runScheduledTick).toHaveBeenCalledWith(env, ctx);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(runDailyRollup).toHaveBeenCalledWith(env, controller, ctx);
+    expect(runRetention).not.toHaveBeenCalled();
+  });
+
+  it('queues retention at UTC 00:30 on the consolidated minute cron', async () => {
+    const controller = {
+      cron: '* * * * *',
+      scheduledTime: Date.UTC(2026, 1, 18, 0, 30, 0),
+    } as ScheduledController;
+    const env = {} as Env;
+    const { ctx, waitUntil, waitUntilPromises } = createExecutionContext();
+
+    await worker.scheduled(controller, env, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(runScheduledTick).toHaveBeenCalledWith(env, ctx);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(runRetention).toHaveBeenCalledWith(env, controller);
+    expect(runDailyRollup).not.toHaveBeenCalled();
+  });
+
+  it('keeps the legacy daily rollup cron compatible during trigger propagation', async () => {
+    const controller = {
+      cron: '0 0 * * *',
+      scheduledTime: Date.UTC(2026, 1, 18, 0, 0, 0),
+    } as ScheduledController;
+    const env = {} as Env;
+    const { ctx, waitUntil, waitUntilPromises } = createExecutionContext();
+
+    await worker.scheduled(controller, env, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(runDailyRollup).toHaveBeenCalledWith(env, controller, ctx);
+    expect(runRetention).not.toHaveBeenCalled();
+    expect(runScheduledTick).not.toHaveBeenCalled();
+  });
+
+  it('keeps the legacy retention cron compatible during trigger propagation', async () => {
+    const controller = {
+      cron: '30 0 * * *',
+      scheduledTime: Date.UTC(2026, 1, 18, 0, 30, 0),
+    } as ScheduledController;
+    const env = {} as Env;
+    const { ctx, waitUntil, waitUntilPromises } = createExecutionContext();
+
+    await worker.scheduled(controller, env, ctx);
+    await Promise.all(waitUntilPromises);
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(runRetention).toHaveBeenCalledWith(env, controller);
+    expect(runDailyRollup).not.toHaveBeenCalled();
+    expect(runScheduledTick).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -11,7 +11,7 @@ enabled = true
   head_sampling_rate = 1
 
 [triggers]
-crons = ["* * * * *", "0 0 * * *", "30 0 * * *"]
+crons = ["* * * * *"]
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary
- Consolidate Cloudflare Cron Triggers to a single `* * * * *` trigger.
- Dispatch daily rollup at UTC 00:00 and retention cleanup at UTC 00:30 inside the scheduled handler.
- Keep legacy daily/retention cron branches compatible during Cloudflare trigger propagation.

## Verification
- `pnpm --filter @uptimer/worker exec vitest run --config vitest.config.ts test/index-scheduled.test.ts`
- `pnpm --filter @uptimer/worker typecheck`
- `pnpm --filter @uptimer/worker lint`
- `pnpm --filter @uptimer/worker test:cron`
- `pnpm --filter @uptimer/worker test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #80
