### PR TITLE
Fix 30-day availability bar width

### DIFF
--- a/apps/web/src/components/MonitorCard.tsx
+++ b/apps/web/src/components/MonitorCard.tsx
@@ -21,7 +21,7 @@ import {
 } from '../utils/uptime';
 
 const HEARTBEAT_BARS = 60;
-const AVAILABILITY_BARS = 60;
+const AVAILABILITY_BARS = 30;
 
 type PublicMonitorLike = Pick<
   PublicMonitor,


### PR DESCRIPTION
## Summary

- Render the status page availability strip with 30 slots, matching the 30-day uptime data and label.
- Leave the 60-point heartbeat strip unchanged.

## Root Cause

MonitorCard requested 60 availability bars while the payload and UI copy are 30-day data, so the component padded the left half with empty slots.

## Validation

- pnpm lint
- pnpm typecheck
- pnpm --filter @uptimer/web build
- pnpm test (full suite hit two Worker route timeouts; scoped rerun of those files passed 42/42 tests, then failed only the global coverage threshold because the run was scoped)

Fixes #86