### PR TITLE
feat(monitor): 添加HTTP监控状态码黑白名单与区间支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Develop/Local-Development-Experience.md
 /tmp/
 .ralph/
 /apps/worker/coverage-cron/
+CLAUDE.md
 
 # Misc
 coverage

--- a/Develop/Application.md
+++ b/Develop/Application.md
@@ -145,8 +145,10 @@ graph TD
 - Headers：可配；默认附加 `User-Agent: Uptimer/<version>`。
 - Body：可选（主要用于 POST 探测）。
 - Status code assertion：
-  - 默认：2xx 视为成功（可选包含 3xx）。
-  - 可配置允许码列表（如 `[200,204,301]`）。
+  - 默认：2xx 视为成功。
+  - 可配置允许码/区间（`expected_status_json`，如 `[200,204,{"from":301,"to":399}]`）。
+  - 可配置禁止码/区间（`forbidden_status_json`）；**黑名单优先**于白名单。
+  - 仅配置黑名单时仍默认 2xx，再排除禁止码。
 - Response assertion：
   - `responseKeyword`：必须包含（可选）。
   - `responseForbiddenKeyword`：必须不包含（可选）。
@@ -279,7 +281,8 @@ CREATE TABLE IF NOT EXISTS monitors (
   http_method TEXT,
   http_headers_json TEXT,
   http_body TEXT,
-  expected_status_json TEXT, -- e.g. [200,204,301]
+  expected_status_json TEXT, -- e.g. [200,204,{"from":301,"to":399}]
+  forbidden_status_json TEXT, -- e.g. [204,{"from":500,"to":599}]; blacklist first
   response_keyword TEXT,
   response_forbidden_keyword TEXT,
 

--- a/Develop/Plan.md
+++ b/Develop/Plan.md
@@ -105,7 +105,7 @@ Phased delivery plan from MVP to production. Each phase includes acceptance crit
 - HTTP check：
   - 超时（AbortController）
   - 禁用缓存（`cache: 'no-store'` + `cf.cacheTtlByStatus: { '100-599': -1 }`）
-  - 状态码断言、关键字断言（必要时读取 body）
+  - 状态码断言（精确码/区间白名单、黑名单优先）、关键字断言（必要时读取 body）
 - TCP check：
   - `cloudflare:sockets` connect + 超时 + close
 - 状态机：

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ English | **[中文](README.zh-CN.md)**
 
 **Monitoring**
 
-- HTTP(S) probes with custom headers, body, status code & keyword assertions
+- HTTP(S) probes with custom headers, body, status code allow/deny lists (exact codes & ranges) & keyword assertions
 - TCP port connectivity checks
 - Configurable timeouts, retry thresholds, and flapping control
 - Automatic state machine: UP / DOWN / MAINTENANCE / PAUSED / UNKNOWN

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@
 
 **监控**
 
-- HTTP(S) 探测，支持自定义 Headers、Body、状态码与关键词断言
+- HTTP(S) 探测，支持自定义 Headers、Body、状态码白名单/黑名单（精确码与区间）与关键词断言
 - TCP 端口连通性检测
 - 可配置的超时、重试阈值与抖动控制
 - 自动状态机：UP / DOWN / MAINTENANCE / PAUSED / UNKNOWN

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -4,6 +4,8 @@ export type MonitorStatus = 'up' | 'down' | 'maintenance' | 'paused' | 'unknown'
 export type CheckStatus = 'up' | 'down' | 'maintenance' | 'unknown';
 export type MonitorType = 'http' | 'tcp';
 export type HttpResponseMatchMode = 'contains' | 'regex';
+/** Exact code or inclusive range (100-599). Matches worker/DB status rule JSON. */
+export type StatusCodeRule = number | { from: number; to: number };
 export type SupportedLocale = 'en' | 'zh-CN' | 'zh-TW' | 'ja' | 'es';
 export type LocaleSetting = 'auto' | SupportedLocale;
 export type HomepageBootstrapMode = 'full' | 'partial';
@@ -356,7 +358,8 @@ export interface AdminMonitor {
   http_headers_json: Record<string, string> | null;
   http_body: string | null;
   follow_redirects: boolean;
-  expected_status_json: number[] | null;
+  expected_status_json: StatusCodeRule[] | null;
+  forbidden_status_json: StatusCodeRule[] | null;
   response_keyword: string | null;
   response_keyword_mode: HttpResponseMatchMode | null;
   response_forbidden_keyword: string | null;
@@ -387,7 +390,8 @@ export interface CreateMonitorInput {
   http_headers_json?: Record<string, string>;
   http_body?: string;
   follow_redirects?: boolean;
-  expected_status_json?: number[];
+  expected_status_json?: StatusCodeRule[];
+  forbidden_status_json?: StatusCodeRule[];
   response_keyword?: string;
   response_keyword_mode?: HttpResponseMatchMode;
   response_forbidden_keyword?: string;
@@ -409,7 +413,8 @@ export interface PatchMonitorInput {
   http_headers_json?: Record<string, string> | null;
   http_body?: string | null;
   follow_redirects?: boolean;
-  expected_status_json?: number[] | null;
+  expected_status_json?: StatusCodeRule[] | null;
+  forbidden_status_json?: StatusCodeRule[] | null;
   response_keyword?: string | null;
   response_keyword_mode?: HttpResponseMatchMode | null;
   response_forbidden_keyword?: string | null;

--- a/apps/web/src/components/MonitorForm.tsx
+++ b/apps/web/src/components/MonitorForm.tsx
@@ -6,6 +6,7 @@ import type {
   HttpResponseMatchMode,
   MonitorType,
   PatchMonitorInput,
+  StatusCodeRule,
 } from '../api/types';
 import { useI18n } from '../app/I18nContext';
 import {
@@ -76,13 +77,116 @@ function hasAdvancedHttpConfig(monitor: AdminMonitor | undefined): boolean {
   const hasHeaders =
     !!monitor.http_headers_json && Object.keys(monitor.http_headers_json).length > 0;
   const hasExpected = !!monitor.expected_status_json && monitor.expected_status_json.length > 0;
+  const hasForbiddenStatus =
+    !!monitor.forbidden_status_json && monitor.forbidden_status_json.length > 0;
   const hasBody = !!monitor.http_body && monitor.http_body.trim().length > 0;
   const hasRedirectOverride = monitor.follow_redirects === false;
   const hasKw = !!monitor.response_keyword && monitor.response_keyword.trim().length > 0;
   const hasForbiddenKw =
     !!monitor.response_forbidden_keyword && monitor.response_forbidden_keyword.trim().length > 0;
 
-  return hasHeaders || hasExpected || hasBody || hasRedirectOverride || hasKw || hasForbiddenKw;
+  return (
+    hasHeaders ||
+    hasExpected ||
+    hasForbiddenStatus ||
+    hasBody ||
+    hasRedirectOverride ||
+    hasKw ||
+    hasForbiddenKw
+  );
+}
+
+function formatStatusRules(rules: StatusCodeRule[] | null | undefined): string {
+  if (!rules || rules.length === 0) return '';
+  return rules
+    .map((rule) => (typeof rule === 'number' ? String(rule) : `${rule.from}-${rule.to}`))
+    .join(', ');
+}
+
+function parseStatusCodeRuleToken(
+  token: string,
+  t: TranslateFn,
+): { ok: true; value: StatusCodeRule } | { ok: false; error: string } {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return { ok: false as const, error: t('monitor_form.error_status_rule_empty') };
+  }
+
+  const rangeMatch = /^(\d{3})-(\d{3})$/.exec(trimmed);
+  if (rangeMatch) {
+    const from = Number.parseInt(rangeMatch[1]!, 10);
+    const to = Number.parseInt(rangeMatch[2]!, 10);
+    if (from < 100 || from > 599 || to < 100 || to > 599) {
+      return {
+        ok: false as const,
+        error: t('monitor_form.error_status_rule_invalid', { value: trimmed }),
+      };
+    }
+    if (from > to) {
+      return {
+        ok: false as const,
+        error: t('monitor_form.error_status_rule_range_order', { value: trimmed }),
+      };
+    }
+    return { ok: true as const, value: { from, to } };
+  }
+
+  if (!/^\d{3}$/.test(trimmed)) {
+    return {
+      ok: false as const,
+      error: t('monitor_form.error_status_rule_invalid', { value: trimmed }),
+    };
+  }
+
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n < 100 || n > 599) {
+    return {
+      ok: false as const,
+      error: t('monitor_form.error_status_rule_invalid', { value: trimmed }),
+    };
+  }
+
+  return { ok: true as const, value: n };
+}
+
+function parseStatusRuleFromJsonItem(
+  item: unknown,
+  t: TranslateFn,
+): { ok: true; value: StatusCodeRule } | { ok: false; error: string } {
+  if (typeof item === 'number' && Number.isInteger(item) && item >= 100 && item <= 599) {
+    return { ok: true as const, value: item };
+  }
+
+  if (item && typeof item === 'object' && !Array.isArray(item)) {
+    const rec = item as Record<string, unknown>;
+    const from = rec.from;
+    const to = rec.to;
+    if (
+      typeof from === 'number' &&
+      typeof to === 'number' &&
+      Number.isInteger(from) &&
+      Number.isInteger(to) &&
+      from >= 100 &&
+      from <= 599 &&
+      to >= 100 &&
+      to <= 599
+    ) {
+      if (from > to) {
+        return {
+          ok: false as const,
+          error: t('monitor_form.error_status_rule_range_order', {
+            value: `${from}-${to}`,
+          }),
+        };
+      }
+      return { ok: true as const, value: { from, to } };
+    }
+  }
+
+  return {
+    ok: false as const,
+    error: t('monitor_form.error_status_rule_invalid', { value: String(item) }),
+  };
 }
 
 function parseHeadersJson(
@@ -115,34 +219,24 @@ function parseHeadersJson(
   return { ok: true as const, value: parsed as Record<string, string> };
 }
 
-function parseExpectedStatusInput(
+function parseStatusRulesInput(
   text: string,
   t: TranslateFn,
-): { ok: true; value: number[] | null } | { ok: false; error: string } {
+): { ok: true; value: StatusCodeRule[] | null } | { ok: false; error: string } {
   const trimmed = text.trim();
   if (!trimmed) return { ok: true as const, value: null };
 
-  const parseList = (parts: string[]) => {
-    if (parts.length === 0) {
-      return { ok: false as const, error: t('monitor_form.error_expected_status_empty') };
+  const finalize = (rules: StatusCodeRule[]) => {
+    if (rules.length === 0) {
+      return { ok: false as const, error: t('monitor_form.error_status_rules_empty') };
     }
-
-    const out: number[] = [];
-    for (const p of parts) {
-      const n = Number.parseInt(p, 10);
-      if (!Number.isFinite(n) || n < 100 || n > 599) {
-        return {
-          ok: false as const,
-          error: t('monitor_form.error_expected_status_invalid', { value: p }),
-        };
-      }
-      out.push(n);
+    if (rules.length > 50) {
+      return { ok: false as const, error: t('monitor_form.error_status_rules_too_many') };
     }
-
-    return { ok: true as const, value: out };
+    return { ok: true as const, value: rules };
   };
 
-  // Also accept JSON array input like: [200, 204]
+  // Also accept JSON array input like: [200, 204, {"from":301,"to":399}]
   if (trimmed.startsWith('[')) {
     let parsed: unknown;
     try {
@@ -150,16 +244,21 @@ function parseExpectedStatusInput(
     } catch {
       return {
         ok: false as const,
-        error: t('monitor_form.error_expected_status_json_or_list'),
+        error: t('monitor_form.error_status_rules_json_or_list'),
       };
     }
 
     if (!Array.isArray(parsed)) {
-      return { ok: false as const, error: t('monitor_form.error_expected_status_must_array') };
+      return { ok: false as const, error: t('monitor_form.error_status_rules_must_array') };
     }
 
-    const parts = parsed.map((x) => String(x));
-    return parseList(parts);
+    const out: StatusCodeRule[] = [];
+    for (const item of parsed) {
+      const r = parseStatusRuleFromJsonItem(item, t);
+      if (!r.ok) return r;
+      out.push(r.value);
+    }
+    return finalize(out);
   }
 
   const parts = trimmed
@@ -167,7 +266,14 @@ function parseExpectedStatusInput(
     .map((p) => p.trim())
     .filter(Boolean);
 
-  return parseList(parts);
+  const out: StatusCodeRule[] = [];
+  for (const p of parts) {
+    const r = parseStatusCodeRuleToken(p, t);
+    if (!r.ok) return r;
+    out.push(r.value);
+  }
+
+  return finalize(out);
 }
 
 function parseOptionalSortOrderInput(
@@ -267,8 +373,12 @@ export function MonitorForm(props: CreateProps | EditProps) {
 
   const [expectedStatusInput, setExpectedStatusInput] = useState(() => {
     if (!monitor || monitor.type !== 'http') return '';
-    if (!monitor.expected_status_json || monitor.expected_status_json.length === 0) return '';
-    return monitor.expected_status_json.join(', ');
+    return formatStatusRules(monitor.expected_status_json);
+  });
+
+  const [forbiddenStatusInput, setForbiddenStatusInput] = useState(() => {
+    if (!monitor || monitor.type !== 'http') return '';
+    return formatStatusRules(monitor.forbidden_status_json);
   });
 
   const [httpBody, setHttpBody] = useState(() =>
@@ -281,7 +391,9 @@ export function MonitorForm(props: CreateProps | EditProps) {
     monitor?.type === 'http' ? (monitor.response_keyword ?? '') : '',
   );
   const [responseKeywordMode, setResponseKeywordMode] = useState<HttpResponseMatchMode>(() =>
-    monitor?.type === 'http' ? normalizeHttpResponseMatchMode(monitor.response_keyword_mode) : 'contains',
+    monitor?.type === 'http'
+      ? normalizeHttpResponseMatchMode(monitor.response_keyword_mode)
+      : 'contains',
   );
   const [responseForbiddenKeyword, setResponseForbiddenKeyword] = useState(() =>
     monitor?.type === 'http' ? (monitor.response_forbidden_keyword ?? '') : '',
@@ -299,8 +411,12 @@ export function MonitorForm(props: CreateProps | EditProps) {
     [displayUrl, t],
   );
   const expectedStatusParse = useMemo(
-    () => parseExpectedStatusInput(expectedStatusInput, t),
+    () => parseStatusRulesInput(expectedStatusInput, t),
     [expectedStatusInput, t],
+  );
+  const forbiddenStatusParse = useMemo(
+    () => parseStatusRulesInput(forbiddenStatusInput, t),
+    [forbiddenStatusInput, t],
   );
   const responseKeywordRegexParse = useMemo(
     () => parseRegexPatternInput(responseKeyword, responseKeywordMode, t),
@@ -324,6 +440,7 @@ export function MonitorForm(props: CreateProps | EditProps) {
       !showAdvancedHttp ||
       (headersParse.ok &&
         expectedStatusParse.ok &&
+        forbiddenStatusParse.ok &&
         responseKeywordRegexParse.ok &&
         responseForbiddenKeywordRegexParse.ok));
 
@@ -347,7 +464,11 @@ export function MonitorForm(props: CreateProps | EditProps) {
         ...base,
         group_name: normalizedGroupName.length > 0 ? normalizedGroupName : null,
       };
-      if (groupSortOrderTouched && groupSortOrderParse.ok && groupSortOrderParse.value !== undefined) {
+      if (
+        groupSortOrderTouched &&
+        groupSortOrderParse.ok &&
+        groupSortOrderParse.value !== undefined
+      ) {
         data.group_sort_order = groupSortOrderParse.value;
       }
 
@@ -366,6 +487,10 @@ export function MonitorForm(props: CreateProps | EditProps) {
             data.expected_status_json = expectedStatusParse.value;
           }
 
+          if (forbiddenStatusParse.ok) {
+            data.forbidden_status_json = forbiddenStatusParse.value;
+          }
+
           data.http_body = httpBody.trim().length > 0 ? httpBody : null;
           data.response_keyword = responseKeyword.trim().length > 0 ? responseKeyword.trim() : null;
           data.response_keyword_mode =
@@ -378,6 +503,7 @@ export function MonitorForm(props: CreateProps | EditProps) {
           // In edit mode, hiding advanced options means reset all persisted advanced HTTP settings.
           data.http_headers_json = null;
           data.expected_status_json = null;
+          data.forbidden_status_json = null;
           data.http_body = null;
           data.follow_redirects = true;
           data.response_keyword = null;
@@ -409,6 +535,10 @@ export function MonitorForm(props: CreateProps | EditProps) {
 
         if (expectedStatusParse.ok && expectedStatusParse.value !== null) {
           data.expected_status_json = expectedStatusParse.value;
+        }
+
+        if (forbiddenStatusParse.ok && forbiddenStatusParse.value !== null) {
+          data.forbidden_status_json = forbiddenStatusParse.value;
         }
 
         if (httpBody.trim().length > 0) {
@@ -566,9 +696,7 @@ export function MonitorForm(props: CreateProps | EditProps) {
           className={inputClass}
         />
         {!displayUrlParse.ok && (
-          <div className="mt-1 text-xs text-red-600 dark:text-red-400">
-            {displayUrlParse.error}
-          </div>
+          <div className="mt-1 text-xs text-red-600 dark:text-red-400">{displayUrlParse.error}</div>
         )}
         <div className={FIELD_HELP_CLASS}>{t('monitor_form.display_url_help')}</div>
       </div>
@@ -679,6 +807,23 @@ export function MonitorForm(props: CreateProps | EditProps) {
               </div>
 
               <div>
+                <label className={labelClass}>{t('monitor_form.forbidden_status_optional')}</label>
+                <input
+                  type="text"
+                  value={forbiddenStatusInput}
+                  onChange={(e) => setForbiddenStatusInput(e.target.value)}
+                  className={inputClass}
+                  placeholder={t('monitor_form.forbidden_status_placeholder')}
+                />
+                {!forbiddenStatusParse.ok && (
+                  <div className="mt-1 text-xs text-red-600 dark:text-red-400">
+                    {forbiddenStatusParse.error}
+                  </div>
+                )}
+                <div className={FIELD_HELP_CLASS}>{t('monitor_form.forbidden_status_help')}</div>
+              </div>
+
+              <div>
                 <label className={labelClass}>{t('monitor_form.body_optional')}</label>
                 <textarea
                   value={httpBody}
@@ -718,7 +863,9 @@ export function MonitorForm(props: CreateProps | EditProps) {
                   <label className={labelClass}>{t('monitor_form.match_mode')}</label>
                   <select
                     value={responseKeywordMode}
-                    onChange={(e) => setResponseKeywordMode(e.target.value as HttpResponseMatchMode)}
+                    onChange={(e) =>
+                      setResponseKeywordMode(e.target.value as HttpResponseMatchMode)
+                    }
                     className={selectClass}
                   >
                     <option value="contains">{t('monitor_form.match_mode_contains')}</option>

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -335,8 +335,13 @@ const en = {
   'monitor_form.headers_placeholder': '{"Authorization":"Bearer ..."}',
   'monitor_form.headers_help': 'Tip: set Content-Type here if you use a request body.',
   'monitor_form.expected_status_optional': 'Expected Status Codes (optional)',
-  'monitor_form.expected_status_placeholder': '200, 204, 301',
-  'monitor_form.expected_status_help': 'Leave empty to accept 2xx.',
+  'monitor_form.expected_status_placeholder': '200, 204, 301-399',
+  'monitor_form.expected_status_help':
+    'Leave empty to accept 2xx. Supports exact codes and ranges (e.g. 200-299).',
+  'monitor_form.forbidden_status_optional': 'Forbidden Status Codes (optional)',
+  'monitor_form.forbidden_status_placeholder': '204, 500-599',
+  'monitor_form.forbidden_status_help':
+    'Blacklist is checked first. With no expected codes, default is still 2xx then exclude these.',
   'monitor_form.body_optional': 'Body (optional)',
   'monitor_form.body_placeholder_get_head': '(usually empty for GET/HEAD)',
   'monitor_form.body_placeholder_default': '...',
@@ -354,12 +359,16 @@ const en = {
     'Headers must be valid JSON (e.g. {"Authorization":"Bearer ..."})',
   'monitor_form.error_headers_must_object': 'Headers must be a JSON object of string values',
   'monitor_form.error_header_value_string': 'Header "{key}" must be a string',
-  'monitor_form.error_expected_status_empty': 'Expected status codes cannot be empty',
-  'monitor_form.error_expected_status_invalid':
-    'Invalid status code: "{value}" (must be an integer 100-599)',
-  'monitor_form.error_expected_status_json_or_list':
-    'Expected status codes must be a JSON array like [200,204] or a list like "200, 204"',
-  'monitor_form.error_expected_status_must_array': 'Expected status codes must be an array',
+  'monitor_form.error_status_rules_empty': 'Status codes cannot be empty',
+  'monitor_form.error_status_rule_empty': 'Status code entry cannot be empty',
+  'monitor_form.error_status_rule_invalid':
+    'Invalid status code or range: "{value}" (use 100-599 or 200-299)',
+  'monitor_form.error_status_rule_range_order':
+    'Invalid range "{value}": start must be less than or equal to end',
+  'monitor_form.error_status_rules_json_or_list':
+    'Status codes must be a JSON array like [200,{"from":301,"to":399}] or a list like "200, 301-399"',
+  'monitor_form.error_status_rules_must_array': 'Status codes must be an array',
+  'monitor_form.error_status_rules_too_many': 'At most 50 status code rules are allowed',
   'monitor_form.error_display_url_invalid': 'Display URL must be a valid URL',
   'monitor_form.error_display_url_protocol': 'Display URL protocol must be http or https',
   'monitor_form.error_regex_invalid': 'Invalid regex: {message}',
@@ -772,8 +781,7 @@ const zhCn: LocaleMessages = {
   'monitor_form.target_host_port_placeholder': 'example.com:443',
   'monitor_form.display_url_optional': '展现网址（可选）',
   'monitor_form.display_url_placeholder': 'https://example.com',
-  'monitor_form.display_url_help':
-    '设置后用于后台展示和默认通知。留空时不展示任何网址。',
+  'monitor_form.display_url_help': '设置后用于后台展示和默认通知。留空时不展示任何网址。',
   'monitor_form.method': '请求方法',
   'monitor_form.interval_sec': '探测间隔（秒）',
   'monitor_form.timeout_ms': '超时（毫秒）',
@@ -785,8 +793,12 @@ const zhCn: LocaleMessages = {
   'monitor_form.headers_placeholder': '{"Authorization":"Bearer ..."}',
   'monitor_form.headers_help': '提示：如果要发送请求体，请在此设置 Content-Type。',
   'monitor_form.expected_status_optional': '期望状态码（可选）',
-  'monitor_form.expected_status_placeholder': '200, 204, 301',
-  'monitor_form.expected_status_help': '留空时默认接受 2xx。',
+  'monitor_form.expected_status_placeholder': '200, 204, 301-399',
+  'monitor_form.expected_status_help': '留空时默认接受 2xx。支持精确码与区间（如 200-299）。',
+  'monitor_form.forbidden_status_optional': '禁止状态码（可选）',
+  'monitor_form.forbidden_status_placeholder': '204, 500-599',
+  'monitor_form.forbidden_status_help':
+    '黑名单优先判定。未配置期望状态码时仍默认 2xx，再排除这些码。',
   'monitor_form.body_optional': '请求体（可选）',
   'monitor_form.body_placeholder_get_head': '（GET/HEAD 通常留空）',
   'monitor_form.body_placeholder_default': '...',
@@ -803,11 +815,15 @@ const zhCn: LocaleMessages = {
     '请求头必须是合法 JSON（例如 {"Authorization":"Bearer ..."}）',
   'monitor_form.error_headers_must_object': '请求头必须是字符串值的 JSON 对象',
   'monitor_form.error_header_value_string': '请求头 "{key}" 的值必须是字符串',
-  'monitor_form.error_expected_status_empty': '期望状态码不能为空',
-  'monitor_form.error_expected_status_invalid': '无效状态码："{value}"（必须是 100-599 的整数）',
-  'monitor_form.error_expected_status_json_or_list':
-    '期望状态码必须是 JSON 数组（如 [200,204]）或列表（如 "200, 204"）',
-  'monitor_form.error_expected_status_must_array': '期望状态码必须是数组',
+  'monitor_form.error_status_rules_empty': '状态码不能为空',
+  'monitor_form.error_status_rule_empty': '状态码条目不能为空',
+  'monitor_form.error_status_rule_invalid':
+    '无效状态码或区间："{value}"（请使用 100-599 或 200-299）',
+  'monitor_form.error_status_rule_range_order': '无效区间 "{value}"：起始必须小于或等于结束',
+  'monitor_form.error_status_rules_json_or_list':
+    '状态码必须是 JSON 数组（如 [200,{"from":301,"to":399}]）或列表（如 "200, 301-399"）',
+  'monitor_form.error_status_rules_must_array': '状态码必须是数组',
+  'monitor_form.error_status_rules_too_many': '最多允许 50 条状态码规则',
   'monitor_form.error_display_url_invalid': '展现网址必须是合法 URL',
   'monitor_form.error_display_url_protocol': '展现网址协议必须是 http 或 https',
   'monitor_form.error_regex_invalid': '正则表达式无效：{message}',
@@ -1136,7 +1152,8 @@ const zhTw: LocaleMessages = {
   'admin_dashboard.group_all': '所有群組',
   'admin_dashboard.group_move_up': '群組上移',
   'admin_dashboard.group_move_down': '群組下移',
-  'admin_dashboard.group_tip': '提示：點選群組可篩選出對應的監測器，並自動帶入「批次指派」的「目標群組」欄位中。',
+  'admin_dashboard.group_tip':
+    '提示：點選群組可篩選出對應的監測器，並自動帶入「批次指派」的「目標群組」欄位中。',
   'admin_dashboard.bulk_assign_title': '批次指派',
   'admin_dashboard.bulk_assign_selected': '已選取監測器：{count}',
   'admin_dashboard.bulk_assign_target_group': '目標群組',
@@ -1216,8 +1233,7 @@ const zhTw: LocaleMessages = {
   'monitor_form.target_host_port_placeholder': 'example.com:443',
   'monitor_form.display_url_optional': '顯示網址（選填）',
   'monitor_form.display_url_placeholder': 'https://example.com',
-  'monitor_form.display_url_help':
-    '設定後將在管理後台及預設通知中顯示。留空則不顯示任何網址。',
+  'monitor_form.display_url_help': '設定後將在管理後台及預設通知中顯示。留空則不顯示任何網址。',
   'monitor_form.method': '請求方法',
   'monitor_form.interval_sec': '檢查間隔（秒）',
   'monitor_form.timeout_ms': '逾時（毫秒）',
@@ -1229,8 +1245,12 @@ const zhTw: LocaleMessages = {
   'monitor_form.headers_placeholder': '{"Authorization":"Bearer ..."}',
   'monitor_form.headers_help': '提示：若要發送請求 Body，請在此設定 Content-Type。',
   'monitor_form.expected_status_optional': '預期狀態碼（選填）',
-  'monitor_form.expected_status_placeholder': '200, 204, 301',
-  'monitor_form.expected_status_help': '留空時預設接受 2xx。',
+  'monitor_form.expected_status_placeholder': '200, 204, 301-399',
+  'monitor_form.expected_status_help': '留空時預設接受 2xx。支援精確碼與區間（如 200-299）。',
+  'monitor_form.forbidden_status_optional': '禁止狀態碼（選填）',
+  'monitor_form.forbidden_status_placeholder': '204, 500-599',
+  'monitor_form.forbidden_status_help':
+    '黑名單優先判定。未設定預期狀態碼時仍預設 2xx，再排除這些碼。',
   'monitor_form.body_optional': '請求 Body（選填）',
   'monitor_form.body_placeholder_get_head': '（GET/HEAD 通常留空）',
   'monitor_form.body_placeholder_default': '...',
@@ -1241,17 +1261,22 @@ const zhTw: LocaleMessages = {
   'monitor_form.response_must_contain_placeholder': '例如：ok',
   'monitor_form.response_must_not_contain_optional': '回應不能包含（選填）',
   'monitor_form.response_must_not_contain_placeholder': '例如：error',
-  'monitor_form.response_regex_help': '使用 JavaScript 正規表達式語法。只需輸入規則本身，請勿加上前後的 / 斜線。',
+  'monitor_form.response_regex_help':
+    '使用 JavaScript 正規表達式語法。只需輸入規則本身，請勿加上前後的 / 斜線。',
   'monitor_form.clear_help': '清空欄位將還原為預設行為。',
   'monitor_form.error_headers_invalid_json':
     '請求標頭必須是合法的 JSON（例如 {"Authorization":"Bearer ..."}）',
   'monitor_form.error_headers_must_object': '請求標頭必須為字串鍵值的 JSON 物件',
   'monitor_form.error_header_value_string': '請求標頭 "{key}" 的值必須為字串',
-  'monitor_form.error_expected_status_empty': '預期狀態碼不能為空',
-  'monitor_form.error_expected_status_invalid': '無效的狀態碼："{value}"（必須是 100-599 的整數）',
-  'monitor_form.error_expected_status_json_or_list':
-    '預期狀態碼必須是 JSON 陣列（如 [200,204]）或逗號分隔字串（如 "200, 204"）',
-  'monitor_form.error_expected_status_must_array': '預期狀態碼必須為陣列',
+  'monitor_form.error_status_rules_empty': '狀態碼不能為空',
+  'monitor_form.error_status_rule_empty': '狀態碼項目不能為空',
+  'monitor_form.error_status_rule_invalid':
+    '無效的狀態碼或區間："{value}"（請使用 100-599 或 200-299）',
+  'monitor_form.error_status_rule_range_order': '無效區間 "{value}"：起始必須小於或等於結束',
+  'monitor_form.error_status_rules_json_or_list':
+    '狀態碼必須是 JSON 陣列（如 [200,{"from":301,"to":399}]）或列表（如 "200, 301-399"）',
+  'monitor_form.error_status_rules_must_array': '狀態碼必須為陣列',
+  'monitor_form.error_status_rules_too_many': '最多允許 50 條狀態碼規則',
   'monitor_form.error_display_url_invalid': '顯示網址必須是合法的 URL',
   'monitor_form.error_display_url_protocol': '顯示網址協議必須為 http 或 https',
   'monitor_form.error_regex_invalid': '無效的正規表達式：{message}',

--- a/apps/worker/migrations/0014_monitor_forbidden_status.sql
+++ b/apps/worker/migrations/0014_monitor_forbidden_status.sql
@@ -1,0 +1,5 @@
+-- Status code blacklist for HTTP monitors (ranges shared with expected_status_json).
+-- NOTE: Keep this file append-only.
+
+ALTER TABLE monitors
+  ADD COLUMN forbidden_status_json TEXT;

--- a/apps/worker/src/monitor/http.ts
+++ b/apps/worker/src/monitor/http.ts
@@ -1,3 +1,5 @@
+import { evaluateHttpStatusCode, type StatusCodeRule } from '@uptimer/db';
+
 import {
   evaluateHttpResponseAssertions,
   prepareHttpResponseAssertions,
@@ -14,7 +16,8 @@ export type HttpCheckConfig = {
   headers: Record<string, string> | null;
   body: string | null;
   followRedirects: boolean;
-  expectedStatus: number[] | null;
+  expectedStatus: StatusCodeRule[] | null;
+  forbiddenStatus: StatusCodeRule[] | null;
   responseKeyword: string | null;
   responseKeywordMode: HttpResponseMatchMode | null;
   responseForbiddenKeyword: string | null;
@@ -116,13 +119,6 @@ async function readTextUpTo(
   return { text, truncated };
 }
 
-function statusOk(httpStatus: number, expectedStatus: number[] | null): boolean {
-  if (expectedStatus && expectedStatus.length > 0) {
-    return expectedStatus.includes(httpStatus);
-  }
-  return httpStatus >= 200 && httpStatus < 300;
-}
-
 async function attemptHttpCheck(
   config: HttpCheckConfig,
   assertions: PreparedHttpResponseAssertion[],
@@ -154,13 +150,20 @@ async function attemptHttpCheck(
     const latencyMs = Math.round(performance.now() - started);
     const httpStatus = res.status;
 
-    if (!statusOk(httpStatus, config.expectedStatus)) {
+    const statusEval = evaluateHttpStatusCode(httpStatus, {
+      expected: config.expectedStatus,
+      forbidden: config.forbiddenStatus,
+    });
+    if (!statusEval.ok) {
       res.body?.cancel();
       return {
         status: 'down',
         latencyMs,
         httpStatus,
-        error: `Unexpected HTTP status: ${httpStatus}`,
+        error:
+          statusEval.reason === 'forbidden'
+            ? `Forbidden HTTP status: ${httpStatus}`
+            : `Unexpected HTTP status: ${httpStatus}`,
       };
     }
 

--- a/apps/worker/src/routes/admin.ts
+++ b/apps/worker/src/routes/admin.ts
@@ -6,6 +6,7 @@ import {
   eq,
   type CustomWebhookChannelConfig,
   expectedStatusJsonSchema,
+  forbiddenStatusJsonSchema,
   getDb,
   httpHeadersJsonSchema,
   monitors,
@@ -279,6 +280,9 @@ function monitorRowToApi(
     expected_status_json: parseDbJsonNullable(expectedStatusJsonSchema, row.expectedStatusJson, {
       field: 'expected_status_json',
     }),
+    forbidden_status_json: parseDbJsonNullable(forbiddenStatusJsonSchema, row.forbiddenStatusJson, {
+      field: 'forbidden_status_json',
+    }),
     response_keyword: row.responseKeyword,
     response_keyword_mode: row.responseKeywordMode,
     response_forbidden_keyword: row.responseForbiddenKeyword,
@@ -458,6 +462,16 @@ adminRoutes.post('/monitors', async (c) => {
               field: 'expected_status_json',
             })
           : null,
+      forbiddenStatusJson:
+        input.type === 'http'
+          ? serializeDbJsonNullable(
+              forbiddenStatusJsonSchema,
+              input.forbidden_status_json ?? null,
+              {
+                field: 'forbidden_status_json',
+              },
+            )
+          : null,
       responseKeyword: input.type === 'http' ? (input.response_keyword ?? null) : null,
       responseKeywordMode:
         input.type === 'http'
@@ -529,6 +543,7 @@ adminRoutes.patch('/monitors/:id', async (c) => {
       'http_body',
       'follow_redirects',
       'expected_status_json',
+      'forbidden_status_json',
       'response_keyword',
       'response_keyword_mode',
       'response_forbidden_keyword',
@@ -604,6 +619,12 @@ adminRoutes.patch('/monitors/:id', async (c) => {
               field: 'expected_status_json',
             })
           : existing.expectedStatusJson,
+      forbiddenStatusJson:
+        input.forbidden_status_json !== undefined
+          ? serializeDbJsonNullable(forbiddenStatusJsonSchema, input.forbidden_status_json, {
+              field: 'forbidden_status_json',
+            })
+          : existing.forbiddenStatusJson,
       responseKeyword: nextResponseKeyword,
       responseKeywordMode: nextResponseKeywordMode,
       responseForbiddenKeyword: nextResponseForbiddenKeyword,
@@ -685,6 +706,9 @@ adminRoutes.post('/monitors/:id/test', async (c) => {
       followRedirects: monitor.followRedirects,
       expectedStatus: parseDbJsonNullable(expectedStatusJsonSchema, monitor.expectedStatusJson, {
         field: 'expected_status_json',
+      }),
+      forbiddenStatus: parseDbJsonNullable(forbiddenStatusJsonSchema, monitor.forbiddenStatusJson, {
+        field: 'forbidden_status_json',
       }),
       responseKeyword: monitor.responseKeyword,
       responseKeywordMode: monitor.responseKeywordMode,

--- a/apps/worker/src/scheduler/scheduled.ts
+++ b/apps/worker/src/scheduler/scheduled.ts
@@ -2,8 +2,10 @@ import pLimit from 'p-limit';
 
 import {
   expectedStatusJsonSchema,
+  forbiddenStatusJsonSchema,
   httpHeadersJsonSchema,
   parseDbJsonNullable,
+  type StatusCodeRule,
 } from '@uptimer/db/json';
 import type { HttpResponseMatchMode, MonitorStatus } from '@uptimer/db/schema';
 
@@ -138,12 +140,7 @@ function isTruthyEnvFlag(value: unknown): boolean {
     return false;
   }
   const normalized = value.trim().toLowerCase();
-  return (
-    normalized === '1' ||
-    normalized === 'true' ||
-    normalized === 'yes' ||
-    normalized === 'on'
-  );
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 }
 
 function shouldTraceScheduledRefresh(env: Env): boolean {
@@ -381,7 +378,7 @@ function parseJsonObject(text: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(text) as unknown;
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
+      ? (parsed as Record<string, unknown>)
       : null;
   } catch {
     return null;
@@ -455,7 +452,9 @@ async function assembleShardedPublicSnapshotViaService(
   );
   const bodyText = await res.text().catch(() => '');
   if (!res.ok) {
-    throw new Error(`sharded public snapshot assemble failed: HTTP ${res.status} ${bodyText}`.trim());
+    throw new Error(
+      `sharded public snapshot assemble failed: HTTP ${res.status} ${bodyText}`.trim(),
+    );
   }
 
   const parsed = parseJsonObject(bodyText);
@@ -569,7 +568,9 @@ async function startShardedPublicSnapshotContinuationViaService(
   );
   const bodyText = await res.text().catch(() => '');
   if (!res.ok) {
-    throw new Error(`sharded public snapshot continuation failed: HTTP ${res.status} ${bodyText}`.trim());
+    throw new Error(
+      `sharded public snapshot continuation failed: HTTP ${res.status} ${bodyText}`.trim(),
+    );
   }
   if (shouldLogScheduledRefresh(env)) {
     const parsed = parseJsonObject(bodyText);
@@ -797,8 +798,10 @@ async function runScheduledCheckBatchViaService(
 type CachedMonitorHttpJson = {
   http_headers_json: string | null;
   expected_status_json: string | null;
+  forbidden_status_json: string | null;
   httpHeaders: Record<string, string> | null;
-  expectedStatus: number[] | null;
+  expectedStatus: StatusCodeRule[] | null;
+  forbiddenStatus: StatusCodeRule[] | null;
 };
 
 const cachedMonitorHttpJsonById = new Map<number, CachedMonitorHttpJson>();
@@ -819,6 +822,7 @@ export type DueMonitorRow = {
   http_body: string | null;
   follow_redirects: number | boolean | null;
   expected_status_json: string | null;
+  forbidden_status_json: string | null;
   response_keyword: string | null;
   response_keyword_mode: HttpResponseMatchMode | null;
   response_forbidden_keyword: string | null;
@@ -894,6 +898,7 @@ const LIST_DUE_MONITORS_SQL = `
     m.http_body,
     m.follow_redirects,
     m.expected_status_json,
+    m.forbidden_status_json,
     m.response_keyword,
     m.response_keyword_mode,
     m.response_forbidden_keyword,
@@ -1062,6 +1067,7 @@ export async function listMonitorRowsByIds(
         m.http_body,
         m.follow_redirects,
         m.expected_status_json,
+        m.forbidden_status_json,
         m.response_keyword,
         m.response_keyword_mode,
         m.response_forbidden_keyword,
@@ -1558,7 +1564,8 @@ async function runDueMonitor(
         const cachedMatches =
           cached &&
           cached.http_headers_json === row.http_headers_json &&
-          cached.expected_status_json === row.expected_status_json;
+          cached.expected_status_json === row.expected_status_json &&
+          cached.forbidden_status_json === row.forbidden_status_json;
 
         const httpHeaders = cachedMatches
           ? cached.httpHeaders
@@ -1570,13 +1577,20 @@ async function runDueMonitor(
           : parseDbJsonNullable(expectedStatusJsonSchema, row.expected_status_json, {
               field: 'expected_status_json',
             });
+        const forbiddenStatus = cachedMatches
+          ? cached.forbiddenStatus
+          : parseDbJsonNullable(forbiddenStatusJsonSchema, row.forbidden_status_json, {
+              field: 'forbidden_status_json',
+            });
 
         if (!cachedMatches) {
           cachedMonitorHttpJsonById.set(row.id, {
             http_headers_json: row.http_headers_json,
             expected_status_json: row.expected_status_json,
+            forbidden_status_json: row.forbidden_status_json,
             httpHeaders,
             expectedStatus,
+            forbiddenStatus,
           });
         }
 
@@ -1589,6 +1603,7 @@ async function runDueMonitor(
           body: row.http_body,
           followRedirects: toBooleanDefaultTrue(row.follow_redirects),
           expectedStatus,
+          forbiddenStatus,
           responseKeyword: row.response_keyword,
           responseKeywordMode: row.response_keyword_mode,
           responseForbiddenKeyword: row.response_forbidden_keyword,
@@ -1721,7 +1736,10 @@ export async function runPersistedMonitorBatch(opts: {
   if (completed.length > 0) {
     if (opts.beforePersist) {
       if (opts.trace) {
-        await opts.trace.timeAsync('batch_before_persist', async () => await opts.beforePersist?.());
+        await opts.trace.timeAsync(
+          'batch_before_persist',
+          async () => await opts.beforePersist?.(),
+        );
       } else {
         await opts.beforePersist();
       }
@@ -1809,11 +1827,12 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
         );
       }
       return shouldUseScheduledShardedContinuation(env)
-        ? startShardedPublicSnapshotContinuationViaService(env, { refreshRuntimeFragments: false })
-            .catch((err) => {
-              console.warn('scheduled sharded public snapshot continuation failed', err);
-              return queueShardedPublicSnapshotWork();
-            })
+        ? startShardedPublicSnapshotContinuationViaService(env, {
+            refreshRuntimeFragments: false,
+          }).catch((err) => {
+            console.warn('scheduled sharded public snapshot continuation failed', err);
+            return queueShardedPublicSnapshotWork();
+          })
         : queueShardedPublicSnapshotWork();
     }
 
@@ -1840,10 +1859,7 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
         });
     } else {
       refreshPromise = env.SELF
-        ? refreshHomepageSnapshotViaService(
-            env,
-            runtimeUpdates ? { runtimeUpdates } : undefined,
-          )
+        ? refreshHomepageSnapshotViaService(env, runtimeUpdates ? { runtimeUpdates } : undefined)
             .then(async (result) => {
               if (!runtimeUpdates?.length || result.refreshed !== false) {
                 return;
@@ -2002,15 +2018,19 @@ export async function runScheduledTick(env: Env, ctx: ExecutionContext): Promise
             const ids = rows.map((row) => row.id);
             const suppressedIds = ids.filter((id) => suppressedMonitorIds.has(id));
             try {
-              return await runScheduledCheckBatchViaService(env, {
-                ids,
-                checkedAt,
-                suppressedMonitorIds: suppressedIds,
-                stateMachineConfig,
-                allowNotifications: Boolean(notify),
-                ...(activeRuntimeFragmentPipeline ? { runtimeFragmentsOnly: true } : {}),
-                ...(splitRuntimeFragmentWrites ? { splitRuntimeFragmentWrites: true } : {}),
-              }, schedulerLease.signal);
+              return await runScheduledCheckBatchViaService(
+                env,
+                {
+                  ids,
+                  checkedAt,
+                  suppressedMonitorIds: suppressedIds,
+                  stateMachineConfig,
+                  allowNotifications: Boolean(notify),
+                  ...(activeRuntimeFragmentPipeline ? { runtimeFragmentsOnly: true } : {}),
+                  ...(splitRuntimeFragmentWrites ? { splitRuntimeFragmentWrites: true } : {}),
+                },
+                schedulerLease.signal,
+              );
             } catch (err) {
               schedulerLease.assertHeld('dispatching inline fallback for service batch');
               const firstId = ids[0] ?? null;

--- a/apps/worker/src/schemas/monitors.ts
+++ b/apps/worker/src/schemas/monitors.ts
@@ -1,4 +1,8 @@
-import { expectedStatusJsonSchema, httpHeadersJsonSchema } from '@uptimer/db';
+import {
+  expectedStatusJsonSchema,
+  forbiddenStatusJsonSchema,
+  httpHeadersJsonSchema,
+} from '@uptimer/db';
 import { z } from 'zod';
 
 import {
@@ -47,6 +51,7 @@ export const createMonitorInputSchema = z
     http_body: z.string().optional(),
     follow_redirects: z.boolean().optional(),
     expected_status_json: expectedStatusJsonSchema.optional(),
+    forbidden_status_json: forbiddenStatusJsonSchema.optional(),
     response_keyword: z.string().min(1).optional(),
     response_keyword_mode: httpResponseMatchModeSchema.optional(),
     response_forbidden_keyword: z.string().min(1).optional(),
@@ -72,6 +77,7 @@ export const createMonitorInputSchema = z
         val.http_body !== undefined ||
         val.follow_redirects !== undefined ||
         val.expected_status_json !== undefined ||
+        val.forbidden_status_json !== undefined ||
         val.response_keyword !== undefined ||
         val.response_keyword_mode !== undefined ||
         val.response_forbidden_keyword !== undefined ||
@@ -113,6 +119,7 @@ export const patchMonitorInputSchema = z
     http_body: z.string().nullable().optional(),
     follow_redirects: z.boolean().optional(),
     expected_status_json: expectedStatusJsonSchema.nullable().optional(),
+    forbidden_status_json: forbiddenStatusJsonSchema.nullable().optional(),
     response_keyword: z.string().min(1).nullable().optional(),
     response_keyword_mode: httpResponseMatchModeSchema.nullable().optional(),
     response_forbidden_keyword: z.string().min(1).nullable().optional(),

--- a/apps/worker/test/admin-monitor-response-assertions.test.ts
+++ b/apps/worker/test/admin-monitor-response-assertions.test.ts
@@ -26,6 +26,7 @@ type StoredMonitorRow = {
   http_body: string | null;
   follow_redirects: number;
   expected_status_json: string | null;
+  forbidden_status_json: string | null;
   response_keyword: string | null;
   response_keyword_mode: 'contains' | 'regex' | null;
   response_forbidden_keyword: string | null;
@@ -53,6 +54,7 @@ function monitorRowToRaw(row: StoredMonitorRow): unknown[] {
     row.http_body,
     row.follow_redirects,
     row.expected_status_json,
+    row.forbidden_status_json,
     row.response_keyword,
     row.response_keyword_mode,
     row.response_forbidden_keyword,
@@ -99,18 +101,19 @@ function createEnv(monitorsById: Map<number, StoredMonitorRow>): Env {
           http_body: (args[8] as string | null) ?? null,
           follow_redirects: args[9] === false || args[9] === 0 ? 0 : 1,
           expected_status_json: (args[10] as string | null) ?? null,
-          response_keyword: (args[11] as string | null) ?? null,
-          response_keyword_mode: (args[12] as StoredMonitorRow['response_keyword_mode']) ?? null,
-          response_forbidden_keyword: (args[13] as string | null) ?? null,
+          forbidden_status_json: (args[11] as string | null) ?? null,
+          response_keyword: (args[12] as string | null) ?? null,
+          response_keyword_mode: (args[13] as StoredMonitorRow['response_keyword_mode']) ?? null,
+          response_forbidden_keyword: (args[14] as string | null) ?? null,
           response_forbidden_keyword_mode:
-            (args[14] as StoredMonitorRow['response_forbidden_keyword_mode']) ?? null,
-          group_name: (args[15] as string | null) ?? null,
-          group_sort_order: Number(args[16]),
-          sort_order: Number(args[17]),
-          show_on_status_page: Number(args[18]),
-          is_active: Number(args[19]),
-          created_at: Number(args[20]),
-          updated_at: Number(args[21]),
+            (args[15] as StoredMonitorRow['response_forbidden_keyword_mode']) ?? null,
+          group_name: (args[16] as string | null) ?? null,
+          group_sort_order: Number(args[17]),
+          sort_order: Number(args[18]),
+          show_on_status_page: Number(args[19]),
+          is_active: Number(args[20]),
+          created_at: Number(args[21]),
+          updated_at: Number(args[22]),
         };
         monitorsById.set(row.id, row);
         nextMonitorId += 1;
@@ -218,7 +221,9 @@ describe('admin monitor response assertion routes', () => {
       .mockResolvedValueOnce(new Response('ready:42\nFAIL_TOKEN', { status: 200 }))
       .mockResolvedValueOnce(new Response('starting up', { status: 200 }))
       .mockResolvedValueOnce(new Response('starting up', { status: 200 }))
-      .mockResolvedValueOnce(new Response('starting up', { status: 200 })) as unknown as typeof fetch;
+      .mockResolvedValueOnce(
+        new Response('starting up', { status: 200 }),
+      ) as unknown as typeof fetch;
 
     const upRes = await requestAdmin(app, env, `/api/v1/admin/monitors/${createdId}/test`, {
       method: 'POST',
@@ -297,9 +302,14 @@ describe('admin monitor response assertion routes', () => {
     });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const testRes = await requestAdmin(app, env, `/api/v1/admin/monitors/${created.monitor.id}/test`, {
-      method: 'POST',
-    });
+    const testRes = await requestAdmin(
+      app,
+      env,
+      `/api/v1/admin/monitors/${created.monitor.id}/test`,
+      {
+        method: 'POST',
+      },
+    );
 
     expect(testRes.status).toBe(200);
     await expect(testRes.json()).resolves.toMatchObject({
@@ -351,6 +361,7 @@ describe('admin monitor response assertion routes', () => {
       http_body: null,
       follow_redirects: 1,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,

--- a/apps/worker/test/monitor-http.test.ts
+++ b/apps/worker/test/monitor-http.test.ts
@@ -10,6 +10,7 @@ const BASE_CONFIG = {
   body: null,
   followRedirects: true,
   expectedStatus: null,
+  forbiddenStatus: null,
   responseKeyword: null,
   responseKeywordMode: null,
   responseForbiddenKeyword: null,
@@ -83,7 +84,9 @@ describe('monitor/http', () => {
 
   it('marks mismatched status codes as down', async () => {
     vi.useFakeTimers();
-    globalThis.fetch = vi.fn(async () => new Response('teapot', { status: 418 })) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response('teapot', { status: 418 }),
+    ) as unknown as typeof fetch;
 
     const outcomePromise = runHttpCheck({ ...BASE_CONFIG, expectedStatus: [200] });
     await vi.advanceTimersByTimeAsync(1_200);
@@ -127,10 +130,104 @@ describe('monitor/http', () => {
     expect(explicitOutcome.attempts).toBe(1);
   });
 
+  it('accepts status codes inside expected ranges', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 204 }),
+    ) as unknown as typeof fetch;
+
+    const outcome = await runHttpCheck({
+      ...BASE_CONFIG,
+      expectedStatus: [{ from: 200, to: 299 }],
+    });
+
+    expect(outcome.status).toBe('up');
+    expect(outcome.httpStatus).toBe(204);
+    expect(outcome.error).toBeNull();
+    expect(outcome.attempts).toBe(1);
+  });
+
+  it('rejects status codes outside expected ranges', async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(
+      async () => new Response('moved', { status: 301 }),
+    ) as unknown as typeof fetch;
+
+    const outcomePromise = runHttpCheck({
+      ...BASE_CONFIG,
+      expectedStatus: [{ from: 200, to: 299 }],
+    });
+    await vi.advanceTimersByTimeAsync(1_200);
+    const outcome = await outcomePromise;
+
+    expect(outcome.status).toBe('down');
+    expect(outcome.httpStatus).toBe(301);
+    expect(outcome.error).toBe('Unexpected HTTP status: 301');
+    expect(outcome.attempts).toBe(3);
+  });
+
+  it('treats forbidden status codes as down even when they match expected rules', async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 204 }),
+    ) as unknown as typeof fetch;
+
+    const outcomePromise = runHttpCheck({
+      ...BASE_CONFIG,
+      expectedStatus: [{ from: 200, to: 299 }],
+      forbiddenStatus: [204],
+    });
+    await vi.advanceTimersByTimeAsync(1_200);
+    const outcome = await outcomePromise;
+
+    expect(outcome.status).toBe('down');
+    expect(outcome.httpStatus).toBe(204);
+    expect(outcome.error).toBe('Forbidden HTTP status: 204');
+    expect(outcome.attempts).toBe(3);
+  });
+
+  it('applies default 2xx when only forbidden status rules are set', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('ok', { status: 200 }),
+    ) as unknown as typeof fetch;
+    const ok = await runHttpCheck({
+      ...BASE_CONFIG,
+      forbiddenStatus: [500, { from: 502, to: 504 }],
+    });
+    expect(ok.status).toBe('up');
+    expect(ok.httpStatus).toBe(200);
+
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(
+      async () => new Response('err', { status: 500 }),
+    ) as unknown as typeof fetch;
+    const forbiddenPromise = runHttpCheck({
+      ...BASE_CONFIG,
+      forbiddenStatus: [500],
+    });
+    await vi.advanceTimersByTimeAsync(1_200);
+    const forbidden = await forbiddenPromise;
+    expect(forbidden.status).toBe('down');
+    expect(forbidden.error).toBe('Forbidden HTTP status: 500');
+
+    globalThis.fetch = vi.fn(
+      async () => new Response('missing', { status: 404 }),
+    ) as unknown as typeof fetch;
+    const non2xxPromise = runHttpCheck({
+      ...BASE_CONFIG,
+      forbiddenStatus: [500],
+    });
+    await vi.advanceTimersByTimeAsync(1_200);
+    const non2xx = await non2xxPromise;
+    expect(non2xx.status).toBe('down');
+    expect(non2xx.error).toBe('Unexpected HTTP status: 404');
+  });
+
   it('applies keyword assertions for response bodies', async () => {
     vi.useFakeTimers();
 
-    globalThis.fetch = vi.fn(async () => new Response('all systems nominal', { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response('all systems nominal', { status: 200 }),
+    ) as unknown as typeof fetch;
     const missingPromise = runHttpCheck({ ...BASE_CONFIG, responseKeyword: 'incident' });
     await vi.advanceTimersByTimeAsync(1_200);
     const missing = await missingPromise;
@@ -138,7 +235,9 @@ describe('monitor/http', () => {
     expect(missing.error).toBe('Response keyword not found');
     expect(missing.attempts).toBe(3);
 
-    globalThis.fetch = vi.fn(async () => new Response('contains secret token', { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response('contains secret token', { status: 200 }),
+    ) as unknown as typeof fetch;
     const forbiddenPromise = runHttpCheck({ ...BASE_CONFIG, responseForbiddenKeyword: 'secret' });
     await vi.advanceTimersByTimeAsync(1_200);
     const forbidden = await forbiddenPromise;
@@ -150,7 +249,9 @@ describe('monitor/http', () => {
   it('supports regex assertions for required and forbidden response bodies', async () => {
     vi.useFakeTimers();
 
-    globalThis.fetch = vi.fn(async () => new Response('status=ready version=42', { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response('status=ready version=42', { status: 200 }),
+    ) as unknown as typeof fetch;
     const requiredSuccess = await runHttpCheck({
       ...BASE_CONFIG,
       responseKeyword: 'status=ready\\s+version=\\d+',
@@ -160,7 +261,9 @@ describe('monitor/http', () => {
     expect(requiredSuccess.error).toBeNull();
     expect(requiredSuccess.attempts).toBe(1);
 
-    globalThis.fetch = vi.fn(async () => new Response('status=starting', { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response('status=starting', { status: 200 }),
+    ) as unknown as typeof fetch;
     const requiredFailurePromise = runHttpCheck({
       ...BASE_CONFIG,
       responseKeyword: 'status=ready\\s+version=\\d+',
@@ -172,7 +275,9 @@ describe('monitor/http', () => {
     expect(requiredFailure.error).toBe('Required response regex not matched');
     expect(requiredFailure.attempts).toBe(3);
 
-    globalThis.fetch = vi.fn(async () => new Response('status=ready secret=token-123', { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response('status=ready secret=token-123', { status: 200 }),
+    ) as unknown as typeof fetch;
     const forbiddenFailurePromise = runHttpCheck({
       ...BASE_CONFIG,
       responseForbiddenKeyword: 'secret=token-\\d+',
@@ -186,7 +291,9 @@ describe('monitor/http', () => {
   });
 
   it('returns unknown when body assertions are requested but response has no readable body', async () => {
-    globalThis.fetch = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 200 }),
+    ) as unknown as typeof fetch;
 
     const outcome = await runHttpCheck({ ...BASE_CONFIG, responseKeyword: 'ok' });
     expect(outcome.status).toBe('unknown');

--- a/apps/worker/test/scheduled.bench.ts
+++ b/apps/worker/test/scheduled.bench.ts
@@ -63,6 +63,7 @@ function makeDueRows(count: number) {
     http_headers_json: null,
     http_body: null,
     expected_status_json: null,
+    forbidden_status_json: null,
     response_keyword: null,
     response_keyword_mode: null,
     response_forbidden_keyword: null,
@@ -235,9 +236,7 @@ async function runOne(scenario: Scenario): Promise<Sample> {
   const ctx = {
     waitUntil(promise: Promise<unknown>) {
       sampleState.waitUntilCalls += 1;
-      waitUntilPromises.push(
-        promise.catch(() => undefined),
-      );
+      waitUntilPromises.push(promise.catch(() => undefined));
     },
   } as unknown as ExecutionContext;
 
@@ -290,7 +289,8 @@ function summarize(samples: Sample[]) {
     batchCallsAvg: batchCalls.reduce((sum, value) => sum + value, 0) / batchCalls.length,
     statementCountAvg:
       statementCounts.reduce((sum, value) => sum + value, 0) / statementCounts.length,
-    waitUntilCallsAvg: waitUntilCalls.reduce((sum, value) => sum + value, 0) / waitUntilCalls.length,
+    waitUntilCallsAvg:
+      waitUntilCalls.reduce((sum, value) => sum + value, 0) / waitUntilCalls.length,
   };
 }
 
@@ -314,26 +314,22 @@ async function benchmarkScenario(scenario: Scenario) {
 }
 
 describe('scheduler benchmark', () => {
-  it(
-    'measures local scheduled tick throughput',
-    async () => {
-      const rows: Array<Record<string, unknown>> = [];
+  it('measures local scheduled tick throughput', async () => {
+    const rows: Array<Record<string, unknown>> = [];
 
-      await withMutedConsole(async () => {
-        for (const scenario of SCENARIOS) {
-          rows.push(await benchmarkScenario(scenario));
-        }
-      });
-
-      const payload = JSON.stringify(rows, null, 2);
-      if (OUTPUT_PATH) {
-        await writeFile(OUTPUT_PATH, payload, 'utf8');
-      } else {
-        console.log(payload);
+    await withMutedConsole(async () => {
+      for (const scenario of SCENARIOS) {
+        rows.push(await benchmarkScenario(scenario));
       }
+    });
 
-      expect(rows).toHaveLength(SCENARIOS.length);
-    },
-    120_000,
-  );
+    const payload = JSON.stringify(rows, null, 2);
+    if (OUTPUT_PATH) {
+      await writeFile(OUTPUT_PATH, payload, 'utf8');
+    } else {
+      console.log(payload);
+    }
+
+    expect(rows).toHaveLength(SCENARIOS.length);
+  }, 120_000);
 });

--- a/apps/worker/test/scheduled.test.ts
+++ b/apps/worker/test/scheduled.test.ts
@@ -105,8 +105,7 @@ function createEnv(options: CreateEnvOptions = {}): Env {
     },
     {
       match: (normalizedSql) =>
-        normalizedSql.includes('select 1 as present') &&
-        normalizedSql.includes('from monitors m'),
+        normalizedSql.includes('select 1 as present') && normalizedSql.includes('from monitors m'),
       first: () => (readSchedulableMonitorPresent() ? { present: 1 } : null),
     },
     {
@@ -308,6 +307,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -640,6 +640,7 @@ describe('scheduler/scheduled regression', () => {
       http_headers_json: null,
       http_body: null,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,
@@ -678,10 +679,10 @@ describe('scheduler/scheduled regression', () => {
         );
       }
       if (path === '/api/v1/internal/refresh/runtime-fragments') {
-        return new Response(
-          JSON.stringify({ ok: true, refreshed: true, update_count: 7 }),
-          { status: 200, headers: { 'Content-Type': 'application/json; charset=utf-8' } },
-        );
+        return new Response(JSON.stringify({ ok: true, refreshed: true, update_count: 7 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        });
       }
       if (path === '/api/v1/internal/refresh/homepage') {
         return new Response(JSON.stringify({ ok: true, refreshed: true }), {
@@ -705,7 +706,11 @@ describe('scheduler/scheduled regression', () => {
       (request) => new URL(request.url).pathname === '/api/v1/internal/scheduled/check-batch',
     );
     expect(checkBatchRequests).toHaveLength(2);
-    expect(checkBatchRequests.every((request) => request.headers.get('X-Uptimer-Runtime-Fragments-Only') === '1')).toBe(true);
+    expect(
+      checkBatchRequests.every(
+        (request) => request.headers.get('X-Uptimer-Runtime-Fragments-Only') === '1',
+      ),
+    ).toBe(true);
     expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
       '/api/v1/internal/scheduled/check-batch',
       '/api/v1/internal/scheduled/check-batch',
@@ -733,6 +738,7 @@ describe('scheduler/scheduled regression', () => {
       http_headers_json: null,
       http_body: null,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,
@@ -789,10 +795,10 @@ describe('scheduler/scheduled regression', () => {
         });
       }
       if (path === '/api/v1/internal/refresh/runtime-fragments') {
-        return new Response(
-          JSON.stringify({ ok: true, refreshed: true, update_count: 7 }),
-          { status: 200, headers: { 'Content-Type': 'application/json; charset=utf-8' } },
-        );
+        return new Response(JSON.stringify({ ok: true, refreshed: true, update_count: 7 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        });
       }
       if (path === '/api/v1/internal/refresh/homepage') {
         return new Response(JSON.stringify({ ok: true, refreshed: true }), {
@@ -809,10 +815,29 @@ describe('scheduler/scheduled regression', () => {
     await Promise.all(waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
 
     const requests = selfFetch.mock.calls.map((call) => call[0] as Request);
-    expect(requests.filter((request) => new URL(request.url).pathname === '/api/v1/internal/scheduled/check-batch')).toHaveLength(2);
-    expect(requests.filter((request) => new URL(request.url).pathname === '/api/v1/internal/write/runtime-update-fragments')).toHaveLength(1);
+    expect(
+      requests.filter(
+        (request) => new URL(request.url).pathname === '/api/v1/internal/scheduled/check-batch',
+      ),
+    ).toHaveLength(2);
+    expect(
+      requests.filter(
+        (request) =>
+          new URL(request.url).pathname === '/api/v1/internal/write/runtime-update-fragments',
+      ),
+    ).toHaveLength(1);
     expect(writerBodies).toEqual([
-      { runtime_updates: [[1, 60, 1_760_000_001, checkedAt, 'up', 'up', 21], [2, 60, 1_760_000_002, checkedAt, 'up', 'up', 21], [3, 60, 1_760_000_003, checkedAt, 'up', 'up', 21], [4, 60, 1_760_000_004, checkedAt, 'up', 'up', 21], [5, 60, 1_760_000_005, checkedAt, 'up', 'up', 21], [6, 60, 1_760_000_006, checkedAt, 'up', 'up', 21], [7, 60, 1_760_000_007, checkedAt, 'up', 'up', 21]] },
+      {
+        runtime_updates: [
+          [1, 60, 1_760_000_001, checkedAt, 'up', 'up', 21],
+          [2, 60, 1_760_000_002, checkedAt, 'up', 'up', 21],
+          [3, 60, 1_760_000_003, checkedAt, 'up', 'up', 21],
+          [4, 60, 1_760_000_004, checkedAt, 'up', 'up', 21],
+          [5, 60, 1_760_000_005, checkedAt, 'up', 'up', 21],
+          [6, 60, 1_760_000_006, checkedAt, 'up', 'up', 21],
+          [7, 60, 1_760_000_007, checkedAt, 'up', 'up', 21],
+        ],
+      },
     ]);
     expect(refreshPublicMonitorRuntimeSnapshot).not.toHaveBeenCalled();
   });
@@ -842,7 +867,9 @@ describe('scheduler/scheduled regression', () => {
       preferCachedBaseSnapshot: true,
     });
     expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('scheduled: homepage_refresh_direct route=internal/homepage-refresh mode=scheduled direct=1 ok=1 refreshed=1'),
+      expect.stringContaining(
+        'scheduled: homepage_refresh_direct route=internal/homepage-refresh mode=scheduled direct=1 ok=1 refreshed=1',
+      ),
     );
     logSpy.mockRestore();
   });
@@ -862,6 +889,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -931,12 +959,8 @@ describe('scheduler/scheduled regression', () => {
     expect(req.headers.get('X-Uptimer-Trace-Mode')).toBe('scheduled');
     expect(req.headers.get('X-Uptimer-Trace-Token')).toBe('trace-token');
     expect(req.headers.get('X-Uptimer-Trace-Id')).toBeTruthy();
-    expect(log).toHaveBeenCalledWith(
-      expect.stringContaining('scheduled: homepage_refresh_trace'),
-    );
-    expect(log).toHaveBeenCalledWith(
-      expect.stringContaining('response_trace_id=child-trace-id'),
-    );
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('scheduled: homepage_refresh_trace'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('response_trace_id=child-trace-id'));
   });
 
   it('does not emit scheduler trace headers without a trace token', async () => {
@@ -981,6 +1005,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1013,7 +1038,9 @@ describe('scheduler/scheduled regression', () => {
     expect(req.headers.get('Content-Type')).toContain('application/json');
     expect(req.headers.get('X-Uptimer-Internal-Format')).toBe('compact-v1');
     await expect(req.json()).resolves.toMatchObject({
-      runtime_updates: [[1, 60, 1_760_000_000, Math.floor(Date.now() / 1000 / 60) * 60, 'up', 'up', 21]],
+      runtime_updates: [
+        [1, 60, 1_760_000_000, Math.floor(Date.now() / 1000 / 60) * 60, 'up', 'up', 21],
+      ],
     });
   });
 
@@ -1031,6 +1058,7 @@ describe('scheduler/scheduled regression', () => {
       http_headers_json: null,
       http_body: null,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,
@@ -1188,6 +1216,7 @@ describe('scheduler/scheduled regression', () => {
       http_headers_json: null,
       http_body: null,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,
@@ -1255,6 +1284,7 @@ describe('scheduler/scheduled regression', () => {
       http_headers_json: null,
       http_body: null,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,
@@ -1337,6 +1367,7 @@ describe('scheduler/scheduled regression', () => {
       http_headers_json: null,
       http_body: null,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,
@@ -1455,6 +1486,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1549,6 +1581,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1655,6 +1688,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1713,6 +1747,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1782,6 +1817,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1839,6 +1875,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1890,6 +1927,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1913,6 +1951,7 @@ describe('scheduler/scheduled regression', () => {
           http_headers_json: null,
           http_body: null,
           expected_status_json: null,
+          forbidden_status_json: null,
           response_keyword: null,
           response_keyword_mode: null,
           response_forbidden_keyword: null,
@@ -1979,6 +2018,7 @@ describe('scheduler/scheduled regression', () => {
       http_headers_json: null,
       http_body: null,
       expected_status_json: null,
+      forbidden_status_json: null,
       response_keyword: null,
       response_keyword_mode: null,
       response_forbidden_keyword: null,
@@ -2085,6 +2125,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2116,6 +2157,7 @@ describe('scheduler/scheduled regression', () => {
       body: null,
       followRedirects: true,
       expectedStatus: null,
+      forbiddenStatus: null,
       responseKeyword: null,
       responseKeywordMode: null,
       responseForbiddenKeyword: null,
@@ -2160,6 +2202,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: '^ready:\\\\d+$',
         response_keyword_mode: 'regex',
         response_forbidden_keyword: 'error',
@@ -2183,6 +2226,7 @@ describe('scheduler/scheduled regression', () => {
       body: null,
       followRedirects: true,
       expectedStatus: null,
+      forbiddenStatus: null,
       responseKeyword: '^ready:\\\\d+$',
       responseKeywordMode: 'regex',
       responseForbiddenKeyword: 'error',
@@ -2204,6 +2248,7 @@ describe('scheduler/scheduled regression', () => {
         http_body: null,
         follow_redirects: 0,
         expected_status_json: JSON.stringify([302]),
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2241,6 +2286,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2262,6 +2308,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2304,6 +2351,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2379,6 +2427,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2435,6 +2484,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2497,6 +2547,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2541,6 +2592,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,
@@ -2594,6 +2646,7 @@ describe('scheduler/scheduled regression', () => {
         http_headers_json: null,
         http_body: null,
         expected_status_json: null,
+        forbidden_status_json: null,
         response_keyword: null,
         response_keyword_mode: null,
         response_forbidden_keyword: null,

--- a/apps/worker/test/status-rules.test.ts
+++ b/apps/worker/test/status-rules.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateHttpStatusCode,
+  expectedStatusJsonSchema,
+  forbiddenStatusJsonSchema,
+  isHttpStatusAccepted,
+  matchesStatusCodeRules,
+} from '@uptimer/db';
+
+describe('status code rules schema', () => {
+  it('accepts legacy exact code arrays', () => {
+    expect(expectedStatusJsonSchema.parse([200, 204])).toEqual([200, 204]);
+    expect(forbiddenStatusJsonSchema.parse([500])).toEqual([500]);
+  });
+
+  it('accepts ranges and mixed rules', () => {
+    expect(
+      expectedStatusJsonSchema.parse([200, { from: 301, to: 399 }, { from: 200, to: 200 }]),
+    ).toEqual([200, { from: 301, to: 399 }, { from: 200, to: 200 }]);
+  });
+
+  it('rejects inverted ranges and out-of-bounds codes', () => {
+    expect(expectedStatusJsonSchema.safeParse([{ from: 399, to: 301 }]).success).toBe(false);
+    expect(expectedStatusJsonSchema.safeParse([99]).success).toBe(false);
+    expect(expectedStatusJsonSchema.safeParse([600]).success).toBe(false);
+    expect(expectedStatusJsonSchema.safeParse([]).success).toBe(false);
+  });
+});
+
+describe('status code matching', () => {
+  it('matches exact codes and inclusive ranges', () => {
+    expect(matchesStatusCodeRules(204, [200, 204])).toBe(true);
+    expect(matchesStatusCodeRules(201, [{ from: 200, to: 299 }])).toBe(true);
+    expect(matchesStatusCodeRules(300, [{ from: 200, to: 299 }])).toBe(false);
+    expect(matchesStatusCodeRules(200, null)).toBe(false);
+  });
+
+  it('applies blacklist-first then allowlist then default 2xx', () => {
+    expect(
+      isHttpStatusAccepted(204, { expected: [{ from: 200, to: 299 }], forbidden: [204] }),
+    ).toBe(false);
+    expect(
+      isHttpStatusAccepted(200, { expected: [{ from: 200, to: 299 }], forbidden: [204] }),
+    ).toBe(true);
+    expect(isHttpStatusAccepted(200, { forbidden: [500] })).toBe(true);
+    expect(isHttpStatusAccepted(500, { forbidden: [500] })).toBe(false);
+    expect(isHttpStatusAccepted(404, { forbidden: [500] })).toBe(false);
+    expect(isHttpStatusAccepted(302, { expected: [302] })).toBe(true);
+    expect(isHttpStatusAccepted(200, {})).toBe(true);
+    expect(isHttpStatusAccepted(404, {})).toBe(false);
+  });
+
+  it('reports forbidden vs unexpected reasons', () => {
+    expect(
+      evaluateHttpStatusCode(204, { expected: [{ from: 200, to: 299 }], forbidden: [204] }),
+    ).toEqual({ ok: false, reason: 'forbidden' });
+    expect(evaluateHttpStatusCode(301, { expected: [{ from: 200, to: 299 }] })).toEqual({
+      ok: false,
+      reason: 'unexpected',
+    });
+    expect(evaluateHttpStatusCode(200, {})).toEqual({ ok: true });
+  });
+});

--- a/packages/db/src/json.ts
+++ b/packages/db/src/json.ts
@@ -55,8 +55,86 @@ export function serializeDbJsonNullable<T>(
 export const httpHeadersJsonSchema = z.record(z.string());
 export type HttpHeadersJson = z.infer<typeof httpHeadersJsonSchema>;
 
-export const expectedStatusJsonSchema = z.array(z.number().int().min(100).max(599)).min(1);
-export type ExpectedStatusJson = z.infer<typeof expectedStatusJsonSchema>;
+/** Single code (legacy) or inclusive range. Codes must be 100-599; ranges require from <= to. */
+export const statusCodeRuleSchema = z.union([
+  z.number().int().min(100).max(599),
+  z
+    .object({
+      from: z.number().int().min(100).max(599),
+      to: z.number().int().min(100).max(599),
+    })
+    .refine((rule) => rule.from <= rule.to, {
+      message: 'status code range from must be <= to',
+      path: ['to'],
+    }),
+]);
+export type StatusCodeRule = z.infer<typeof statusCodeRuleSchema>;
+
+/** Allow/deny list: non-empty array of exact codes and/or ranges. Empty → store null instead. */
+export const statusCodeRulesJsonSchema = z.array(statusCodeRuleSchema).min(1).max(50);
+export type StatusCodeRulesJson = z.infer<typeof statusCodeRulesJsonSchema>;
+
+/** @deprecated Prefer StatusCodeRulesJson — kept for existing imports. */
+export const expectedStatusJsonSchema = statusCodeRulesJsonSchema;
+export type ExpectedStatusJson = StatusCodeRulesJson;
+
+export const forbiddenStatusJsonSchema = statusCodeRulesJsonSchema;
+export type ForbiddenStatusJson = StatusCodeRulesJson;
+
+export function matchesStatusCodeRules(
+  status: number,
+  rules: readonly StatusCodeRule[] | null | undefined,
+): boolean {
+  if (!rules || rules.length === 0) return false;
+  for (const rule of rules) {
+    if (typeof rule === 'number') {
+      if (rule === status) return true;
+      continue;
+    }
+    if (status >= rule.from && status <= rule.to) return true;
+  }
+  return false;
+}
+
+/**
+ * Blacklist first → allowlist (if present) → default 2xx.
+ * - forbidden match → not accepted
+ * - expected present → must match expected
+ * - else → 2xx only
+ */
+export function isHttpStatusAccepted(
+  status: number,
+  opts: {
+    expected?: readonly StatusCodeRule[] | null;
+    forbidden?: readonly StatusCodeRule[] | null;
+  } = {},
+): boolean {
+  if (matchesStatusCodeRules(status, opts.forbidden)) return false;
+  if (opts.expected && opts.expected.length > 0) {
+    return matchesStatusCodeRules(status, opts.expected);
+  }
+  return status >= 200 && status < 300;
+}
+
+export type HttpStatusRejectReason = 'forbidden' | 'unexpected';
+
+export function evaluateHttpStatusCode(
+  status: number,
+  opts: {
+    expected?: readonly StatusCodeRule[] | null;
+    forbidden?: readonly StatusCodeRule[] | null;
+  } = {},
+): { ok: true } | { ok: false; reason: HttpStatusRejectReason } {
+  if (matchesStatusCodeRules(status, opts.forbidden)) {
+    return { ok: false, reason: 'forbidden' };
+  }
+  if (opts.expected && opts.expected.length > 0) {
+    return matchesStatusCodeRules(status, opts.expected)
+      ? { ok: true }
+      : { ok: false, reason: 'unexpected' };
+  }
+  return status >= 200 && status < 300 ? { ok: true } : { ok: false, reason: 'unexpected' };
+}
 
 export const webhookSigningSchema = z.object({
   enabled: z.boolean(),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -34,10 +34,13 @@ export const monitors = sqliteTable(
     httpBody: text('http_body'),
     followRedirects: integer('follow_redirects', { mode: 'boolean' }).notNull().default(true),
     expectedStatusJson: text('expected_status_json'),
+    forbiddenStatusJson: text('forbidden_status_json'),
     responseKeyword: text('response_keyword'),
     responseKeywordMode: text('response_keyword_mode').$type<HttpResponseMatchMode>(),
     responseForbiddenKeyword: text('response_forbidden_keyword'),
-    responseForbiddenKeywordMode: text('response_forbidden_keyword_mode').$type<HttpResponseMatchMode>(),
+    responseForbiddenKeywordMode: text(
+      'response_forbidden_keyword_mode',
+    ).$type<HttpResponseMatchMode>(),
 
     groupName: text('group_name'),
     groupSortOrder: integer('group_sort_order').notNull().default(0),


### PR DESCRIPTION
## Changes

实现HTTP监控的状态码校验新功能：
- 新增黑名单配置支持，黑名单优先于白名单判定
- 重构状态码校验逻辑，同时支持精确码和区间范围
- 新增数据库迁移脚本与`forbidden_status_json`存储字段
- 更新中英文文档、API类型与前端表单配置项
- 新增完整单元测试覆盖校验场景

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] Manually tested:

## Related Issues

Closes #97 
